### PR TITLE
fix typo in genesis-template.json

### DIFF
--- a/metadium/scripts/genesis-template.json
+++ b/metadium/scripts/genesis-template.json
@@ -20,7 +20,7 @@
         "homesteadBlock": 0,
         "eip150Block": 0,
         "eip155Block": 0,
-        "eip158Block": 0
+        "eip158Block": 0,
         "byzantiumBlock": 0,
         "constantinopleBlock": 0,
         "istanbulBlock": 0,


### PR DESCRIPTION
missing comma in json format