### PR TITLE
add etcd compact

### DIFF
--- a/metadium/admin.go
+++ b/metadium/admin.go
@@ -1095,9 +1095,9 @@ func LogBlock(height int64, hash common.Hash) {
 		log.Info("Metadium - logged the latest block",
 			"height", height, "hash", hash, "took", time.Since(tstart))
 
-		if (rev%etcdCompactFrequency == 0) && (rev > etcdCompactWindow) {
+		if ((rev%etcdCompactFrequency == 0) && (rev > etcdCompactFrequency)) && (rev > etcdCompactWindow) {
 			go func() {
-				if err := admin.etcdCompact(rev); err != nil {
+				if err := admin.etcdCompact(rev - etcdCompactWindow + 1); err != nil {
 					log.Error("Metadium - failed to compact",
 						"rev", rev, "took", time.Since(tstart))
 				}

--- a/metadium/admin.go
+++ b/metadium/admin.go
@@ -102,6 +102,8 @@ var (
 	ErrNotRunning     = errors.New("not running")
 	ErrAlreadyRunning = errors.New("already running")
 	ErrInvalidEnode   = errors.New("invalid enode")
+
+	etcdCompactFrequency = int64(100)
 )
 
 func (n *metaNode) eq(m *metaNode) bool {
@@ -1084,12 +1086,22 @@ func LogBlock(height int64, hash common.Hash) {
 	}
 
 	tstart := time.Now()
-	if err := admin.etcdPut("metadium-work", string(work)); err != nil {
+	rev, err := admin.etcdPut("metadium-work", string(work))
+	if err != nil {
 		log.Error("Metadium - failed to log the latest block",
 			"height", height, "hash", hash, "took", time.Since(tstart))
 	} else {
 		log.Info("Metadium - logged the latest block",
 			"height", height, "hash", hash, "took", time.Since(tstart))
+
+		if (rev%etcdCompactFrequency == 0) && (rev > 100) {
+			go func() {
+				if err := admin.etcdCompact(rev); err != nil {
+					log.Error("Metadium - failed to compact",
+						"rev", rev, "took", time.Since(tstart))
+				}
+			}()
+		}
 	}
 
 	admin.blocksMined++

--- a/metadium/admin.go
+++ b/metadium/admin.go
@@ -104,6 +104,7 @@ var (
 	ErrInvalidEnode   = errors.New("invalid enode")
 
 	etcdCompactFrequency = int64(100)
+	etcdCompactWindow    = int64(100)
 )
 
 func (n *metaNode) eq(m *metaNode) bool {
@@ -1094,7 +1095,7 @@ func LogBlock(height int64, hash common.Hash) {
 		log.Info("Metadium - logged the latest block",
 			"height", height, "hash", hash, "took", time.Since(tstart))
 
-		if (rev%etcdCompactFrequency == 0) && (rev > 100) {
+		if (rev%etcdCompactFrequency == 0) && (rev > etcdCompactWindow) {
 			go func() {
 				if err := admin.etcdCompact(rev); err != nil {
 					log.Error("Metadium - failed to compact",

--- a/metadium/etcdutil.go
+++ b/metadium/etcdutil.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/embed"
 	"github.com/coreos/etcd/etcdserver/api/membership"
 	"github.com/coreos/etcd/etcdserver/api/v3client"
@@ -442,16 +443,16 @@ func (ma *metaAdmin) etcdLeader(locked bool) (uint64, *metaNode) {
 	return 0, nil
 }
 
-func (ma *metaAdmin) etcdPut(key, value string) error {
+func (ma *metaAdmin) etcdPut(key, value string) (int64, error) {
 	if !ma.etcdIsRunning() {
-		return ErrNotRunning
+		return 0, ErrNotRunning
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(),
 		ma.etcd.Server.Cfg.ReqTimeout())
 	defer cancel()
-	_, err := ma.etcdCli.Put(ctx, key, value)
-	return err
+	resp, err := ma.etcdCli.Put(ctx, key, value)
+	return resp.Header.Revision, err
 }
 
 func (ma *metaAdmin) etcdGet(key string) (string, error) {
@@ -484,6 +485,20 @@ func (ma *metaAdmin) etcdDelete(key string) error {
 		ma.etcd.Server.Cfg.ReqTimeout())
 	defer cancel()
 	_, err := ma.etcdCli.Delete(ctx, key)
+	return err
+}
+
+func (ma *metaAdmin) etcdCompact(rev int64) error {
+	if !ma.etcdIsRunning() {
+		return ErrNotRunning
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(),
+		ma.etcd.Server.Cfg.ReqTimeout())
+	defer cancel()
+	_, err := ma.etcdCli.Compact(ctx, rev, clientv3.WithCompactPhysical())
+	// WithCompactPhysical makes Compact wait until all compacted entries are
+	// removed from the etcd server's storage.
 	return err
 }
 


### PR DESCRIPTION
* Change `etcdPut` spec: now return revision info
* Process `etcdCompact` after `etcdPut` (at every `rev%100==0`)
* Keep last 100 revs
* Currently `etcdCompactFrequency` is 100 as default
* Run as goroutine