### PR TITLE
core, params: drop underpriced transactions

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -672,6 +672,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if !local && tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
 	}
+	// Drop transactions if given fees are less than maxPriorityFeePerGas + baseFee
+	if params.DropUnderPriced && local && tx.EffectiveGasTipIntCmp(pool.gasPrice, pool.priced.urgent.baseFee) < 0 {
+		return ErrUnderpriced
+	}
 	// Ensure the transaction adheres to nonce ordering
 	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -55,6 +55,8 @@ func init() {
 	eip1559Config = &cpy
 	eip1559Config.BerlinBlock = common.Big0
 	eip1559Config.LondonBlock = common.Big0
+
+	params.DropUnderpriced = false
 }
 
 type testBlockChain struct {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -186,6 +186,7 @@ var (
 	FixedGasLimit        uint64 = 0x10000000   // 0 means no fixed gas limit
 	MaxIdleBlockInterval uint64 = 600          // in seconds
 	BlocksPerTurn        uint64 = 100
+	DropUnderPriced      bool = true // drop underpriced transactions
 
 	NonceLimit     uint64 = 0    // nonce limit for non-governing accounts
 	UseRocksDb     int    = 1    // LevelDB (0) or RocksDB (1)


### PR DESCRIPTION
Drop underpriced txs if it’s local & params.DropUnderpriced flag is set.