### PR TITLE
core: Fee in ExecutionResult is big.Int to avoid int64 overflow

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -112,7 +112,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 		root = statedb.IntermediateRoot(config.IsEIP158(blockNumber)).Bytes()
 	}
 	*usedGas += result.UsedGas
-	fees.Add(fees, big.NewInt(int64(result.Fee)))
+	fees.Add(fees, result.Fee)
 
 	// Create a new receipt for the transaction, storing the intermediate root and gas used
 	// by the tx.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -83,10 +83,10 @@ type Message interface {
 // ExecutionResult includes all output after executing given evm
 // message no matter the execution itself is successful or not.
 type ExecutionResult struct {
-	UsedGas    uint64 // Total used gas but include the refunded gas
-	Fee        uint64 // Fee
-	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
-	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
+	UsedGas    uint64 	// Total used gas but include the refunded gas
+	Fee        *big.Int	// Fee
+	Err        error  	// Any error encountered during the execution(listed in core/vm/errors.go)
+	ReturnData []byte 	// Returned data from evm(function result or data supplied with revert opcode)
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -339,6 +339,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		effectiveTip = cmath.BigMin(st.gasTipCap, new(big.Int).Sub(st.gasFeeCap, st.evm.Context.BaseFee))
 	}
 	bigFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), effectiveTip)
+
 	// In metadium, block reward and fees are combined and distributed as
 	// agreed in the governance contract
 	if metaminer.IsPoW() {
@@ -347,7 +348,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	return &ExecutionResult{
 		UsedGas:    st.gasUsed(),
-		Fee:        bigFee.Uint64(),
+		Fee:        bigFee,
 		Err:        vmerr,
 		ReturnData: ret,
 	}, nil


### PR DESCRIPTION
Gmet is crashed when fee is over 2^63.