### PR TITLE
fix to check sender's balance

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -756,7 +756,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		if pool.currentState.GetBalance(feePayer).Cmp(tx.FeePayerCost()) < 0 {
 			return ErrFeePayerInsufficientFunds
 		}
-		if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
+		if pool.currentState.GetBalance(from).Cmp(tx.Value()) < 0 {
 			return ErrSenderInsufficientFunds
 		}
 	} else {


### PR DESCRIPTION
When verifying the sender's balance in a Fee Delegation transaction, the method should be modified to compare tx.Value() with the sender's balance.