### PR TITLE
fix(consensus): serialize block-state commit against concurrent EVM reads

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1348,6 +1348,19 @@ func (bc *BlockChain) writeKnownBlock(block *types.Block) error {
 // writeBlockWithState writes block, metadata and corresponding state data to the
 // database.
 func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, state *state.StateDB) error {
+	// Serialize the entire commit against concurrent in-process EVM reads
+	// dispatched from the metadium admin module
+	// (accumulateRewards -> admin.calculateRewards -> metclient.CallContract).
+	// The read creates a fresh statedb backed by the same triedb; without
+	// serialization it can observe a transient missing-state for
+	// just-committed accounts (notably the governance ENV contract at
+	// testnet block 18) and return ErrNotInitialized, yielding a divergent
+	// stateRoot. Covers archive (TrieDirtyDisabled=true) and full (default)
+	// paths uniformly, and works for both leveldb and rocksdb backends
+	// (rocksdb's async batch ordering exposes a wider race window than
+	// leveldb's synchronous writes).
+	metaminer.TrieAccessMu.Lock()
+	defer metaminer.TrieAccessMu.Unlock()
 	// Calculate the total difficulty of the block
 	ptd := bc.GetTd(block.ParentHash(), block.NumberU64()-1)
 	if ptd == nil {

--- a/metadium/metclient/util.go
+++ b/metadium/metclient/util.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/console/prompt"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
 )
 
 type ContractData struct {
@@ -329,7 +330,14 @@ func CallContract(ctx context.Context, contract *RemoteContract,
 		To:   contract.To,
 		Data: in,
 	}
+	// Serialize against archive-mode triedb commits (see metaminer.TrieAccessMu).
+	// CallContract dispatches an EVM read on a fresh statedb that shares the
+	// same triedb backend as the main block-import goroutine; without this
+	// lock, the read can race with a concurrent triedb.Commit in archive
+	// mode and observe a transient missing-state.
+	metaminer.TrieAccessMu.RLock()
 	out, err = contract.Cli.CallContract(ctx, msg, block)
+	metaminer.TrieAccessMu.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/metadium/miner/miner.go
+++ b/metadium/miner/miner.go
@@ -5,10 +5,24 @@ package miner
 import (
 	"errors"
 	"math/big"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
+
+// TrieAccessMu serializes archive-mode triedb commits against concurrent
+// in-process RPC EVM reads issued by the metadium admin module. Without
+// this mutex, a triedb.Commit(root, false) performed by writeBlockWithState
+// in archive mode can race with an EVM call dispatched from
+// accumulateRewards -> admin.calculateRewards -> metclient.CallContract,
+// causing a transient "registry not initialized" miss on early historical
+// blocks (e.g. testnet block 18) and a divergent stateRoot.
+//
+// Writers (archive triedb.Commit) take the write lock; readers
+// (metclient.CallContract) take the read lock so concurrent contract reads
+// remain parallel.
+var TrieAccessMu sync.RWMutex
 
 var (
 	ErrNotInitialized = errors.New("not initialized")


### PR DESCRIPTION
## Summary

Fresh sync of a Metadium PoA chain (testnet, mainnet — both `LevelDB` and `RocksDB`, both `--gcmode full` and `--gcmode archive`) diverges from the BP-supplied chain at the first block that consumes governance state — **testnet block 18**, the `ENV.setRewardPool` tx.

```
BAD BLOCK #18 (0xd1b1009d…)
invalid merkle root
  remote: 0x599eaebad893d28adb480e1d1a015251ea24ca2b46e0eb52dac7f2dbba8cf861
  local:  0x0fa34156b91098674ac43643ade8fa83aa8ee4dd78ac1e62201f544b3e119c0d
```

This blocks any new archive/full node from joining the chain from scratch; the existing operating nodes only continue to function because their chaindata predates the regression.

## Root cause

`writeBlockWithState` commits the new account/storage trie and, in archive mode, immediately flushes the trie DB to disk.

While this commit is in progress, the metadium admin module — dispatched from `accumulateRewards` via the `metaminer.CalculateRewards` interface — invokes `metclient.CallContract` → `BlockChainAPI.Call`. That EVM call **runs on a separate RPC handler goroutine**, opens a fresh `statedb` against the same `triedb` backend, and races the still-running commit.

When the read observes a transient missing-state for a just-committed account (notably the governance registry), `CallContract` returns `not initialized`, `admin.calculateRewards` falls back to the all-fees-to-coinbase path, and the resulting balance write yields a different stateRoot than the BP — block 18's invalid merkle root.

`RocksDB`'s asynchronous batch ordering exposes a **wider race window** than `LevelDB`'s synchronous writes, so a narrower mutex targeted only at the archive `triedb.Commit` was not enough.

## Fix

Introduce `metaminer.TrieAccessMu` (`sync.RWMutex`):

- **Writer**: `writeBlockWithState` takes the write lock for its entire body.
- **Reader**: `metclient.CallContract` takes the read lock around `Cli.CallContract`.

This covers every storage-engine × gc-mode combination uniformly. Concurrent contract reads remain parallel (`RLock`); only the brief block-commit window serializes everything against them.

## Test plan

Verified by fresh sync on six independent configurations — each ran past testnet block 18 cleanly with **zero `invalid merkle root` events**:

| DB | Mode | Network | Result |
|---|---|---|---|
| LevelDB | full | testnet | ✅ block 51K+ |
| LevelDB | archive | testnet | ✅ block 10K+ |
| LevelDB | archive | mainnet | ✅ block 6.7K+ |
| LevelDB | archive | testnet (long-running) | ✅ block 591K+ |
| RocksDB | full | testnet | ✅ block 5K+ |
| RocksDB | archive | testnet | ✅ block 158K+ |

Without the fix, every one of these configurations stops on block 18 (or block 1 for RocksDB+full where the race window is widest).

## Files changed

- `metadium/miner/miner.go` — introduce `TrieAccessMu sync.RWMutex`
- `core/blockchain.go` — `Lock/defer Unlock` around `writeBlockWithState`
- `metadium/metclient/util.go` — `RLock/RUnlock` around `Cli.CallContract`

3 files, **+35 lines**.