### PR TITLE
test: live-testnet Camellia verification (Layer 10) and e2e live-network support

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -477,9 +477,3 @@ func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	}
 	return gas, nil
 }
-
-func debugGasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	size, _ := stack.Back(2).Uint64WithOverflow()
-	println("DEBUG gasCreate2Eip3860: size=", size, "MaxInitCodeSize=", params.MaxInitCodeSize)
-	return gasCreate2Eip3860(evm, contract, stack, mem, memorySize)
-}

--- a/docs/camellia-verification-checklist.md
+++ b/docs/camellia-verification-checklist.md
@@ -3,7 +3,7 @@
 > Camellia = Shanghai + Cancun (EIP-1153, 3651, 3855, 3860, 4844, 5656, 6780)
 > 기존 Metadium 기능 (Fee Delegation Type 22, SPoA, VRF, 거버넌스, TRS) 호환성 포함
 
-> Last updated: 2026-04-07. Layer 1 (T-01~T-16): ALL PASS. Layer 2: PASS=10, N/A=1. Layer 3: 배포 완료, CamelliaBlock 대기. Layer 4: PASS. Layer 5 SPoA: 22/22 PASS. Layer 6 (sync): 4개 노드 전체 PASS. Layer 7 (blob tx E2E): PASS. Layer 8 (mixed tx): PASS — normal+fee delegation+blob 혼합 블록 검증. Layer 9 (txpool Camellia blob tx): PASS — v1.13.14 merge txpool regression tests added. make test / make test-short: 전체 PASS (TestEmptyBlocks Engine API PoS 테스트 제외, Metadium PoA 구조적 비해당).
+> Last updated: 2026-06-04. Layer 1 (T-01~T-16): ALL PASS. Layer 2: PASS=10, N/A=1. Layer 3: 완료 (Layer 10에서 흡수). Layer 4: PASS. Layer 5 SPoA: 22/22 PASS. Layer 6 (sync): 4개 노드 전체 PASS. Layer 7 (blob tx E2E): PASS. Layer 8 (mixed tx): PASS — normal+fee delegation+blob 혼합 블록 검증. Layer 9 (txpool Camellia blob tx): PASS — v1.13.14 merge txpool regression tests added. **Layer 10 (live testnet HF 활성화 후 검증): ALL PASS — 운영 testnet에서 pre→post 전이 + 실 tx e2e 실증.** make test / make test-short: 전체 PASS (TestEmptyBlocks Engine API PoS 테스트 제외, Metadium PoA 구조적 비해당).
 
 ---
 
@@ -87,15 +87,16 @@ RPC=http://localhost:8545 ./camellia-test.sh
     → 완료 (2026-04-04): commit 0b59d7b, 63MB, Go 1.22.2
 [x] gmet-testnet.service 재시작 후 동기화 확인
     → 완료: block 84M+ syncing, 5 peers, ~30 blocks/min
-[ ] CamelliaBlock 번호 설정 후 포크 전환 모니터링 (1시간)
-    → 대기 중: CamelliaBlock 번호 미결정
-[ ] testnet에서 Type 22 tx 수동 전송 확인
-    → CamelliaBlock 활성화 후 진행 예정
-[ ] CamelliaBlock 전후 노드 재시작 테스트 (재시작 후 체인 이어받기)
-    → CamelliaBlock 활성화 후 진행 예정
+[x] CamelliaBlock 번호 설정 후 포크 전환 모니터링 (1시간)
+    → 완료: CamelliaBlock=86,449,000 (2026-05-20 활성화). archive race 회귀는
+      m1.0.0.testnet.hotfix2 (TrieAccessMu)로 해결, 이후 전 노드 invalid merkle 0건
+[x] testnet에서 Type 22 tx 수동 전송 확인
+    → 완료 (2026-06-04): Layer 10 참고
+[x] CamelliaBlock 전후 노드 재시작 테스트 (재시작 후 체인 이어받기)
+    → 완료: hotfix1/hotfix2 배포 과정에서 전 노드 stop→start 후 체인 이어받기 확인
 ```
 
-> Status (2026-04-05): 바이너리 배포 및 동기화 완료. CamelliaBlock 번호 결정 후 나머지 3개 항목 진행.
+> Status (2026-06-04): 전체 완료. live testnet 동작 검증은 Layer 10 참고.
 
 ---
 
@@ -174,19 +175,20 @@ Camellia 바이너리로 실제 chaindata를 이어받아 최신 블록까지 �
 
 ## 완료 기준
 
-### 현재 상태 (2026-04-06)
+### 현재 상태 (2026-06-04)
 
 | Layer | 항목 수 | 상태 |
 |-------|---------|------|
 | Layer 1 (Go 단위 테스트) | T-01~T-16 | ✅ 전체 PASS |
 | Layer 2 (bash 통합) | I-01~I-11 | ✅ 10/11 PASS (I-10 N/A) |
-| Layer 3 (testnet 배포) | 5개 항목 | ✅ 2/5 완료, 3개 CamelliaBlock 설정 후 |
+| Layer 3 (testnet 배포) | 5개 항목 | ✅ 전체 완료 (Layer 10에서 흡수) |
 | Layer 4 (롤링 업그레이드) | 3개 항목 | ✅ 전체 PASS |
 | Layer 5 (SPoA 통합) | 22개 항목 | ✅ 22/22 PASS |
 | Layer 6 (실서버 동기화) | 4개 노드 | ✅ 전체 PASS (testnet/mainnet × LevelDB/RocksDB) |
-| Layer 7 (blob tx E2E) | 4단계 | ✅ PASS (submit→pool sidecar→mined→sidecar pruned) |
+| Layer 7 (blob tx E2E) | 4단계 | ✅ PASS (submit→pool sidecar→mined→sidecar retained) |
 | Layer 8 (mixed tx) | 3 tx 타입 | ✅ PASS (Type 2 + Type 22 + Type 3 혼합 블록) |
 | Layer 9 (txpool Camellia blob tx) | 2개 regression test | ✅ PASS (v1.13.14 merge fixes) |
+| Layer 10 (live testnet HF 검증) | L10-01~L10-15 | ✅ 14 PASS, 1 N/A — 운영 testnet 실증 |
 
 ### Layer 9: txpool Camellia blob tx 회귀 테스트 (v1.13.14 merge, 2026-04-07)
 
@@ -202,10 +204,62 @@ go test ./core/txpool/ -run TestValidateTransactionCamelliaOnly -v
 go test ./core/txpool/blobpool/ -run TestBlobPoolLimboFinalizeCamellia -v
 ```
 
-**남은 작업:** testnet `CamelliaBlock` 번호 결정 → 포크 전환 모니터링 → mainnet 설정
+---
+
+## Layer 10: Live testnet HF 활성화 후 검증 (2026-06-04)
+
+testnet `CamelliaBlock=86,449,000` (2026-05-20 활성화) 이후 **실제 운영 testnet**에서 수행.
+
+- **바이너리:** `m1.0.0.testnet.hotfix2` (`d8471dd68`)
+- **검증 노드:** 개인 sync 노드 46 (LevelDB full, tx 전송·eth_call) + Explorer#2 (LevelDB archive, pre-fork state 조회)
+- **tx 경로:** 46 sync 노드 `eth_sendRawTransaction` → P2P 전파 → AWS BP 채굴 (실제 운영 경로)
+
+### L10-A: pre→post 포크 전이 (archive 노드 eth_call, read-only)
+
+pre-fork = block 86,448,999 시점 state, post-fork = latest.
+
+| ID | EIP | pre-fork | post-fork | 상태 |
+|----|-----|----------|-----------|------|
+| L10-01 | EIP-3855 PUSH0 | `invalid opcode: PUSH0` | 0x00 반환 | [x] |
+| L10-02 | EIP-1153 TSTORE/TLOAD | `invalid opcode: TSTORE` | slot 왕복 0x42 | [x] |
+| L10-03 | EIP-5656 MCOPY | `invalid opcode: MCOPY` | 0xab 복사 | [x] |
+| L10-04 | EIP-4844 BLOBBASEFEE | `invalid opcode: BLOBBASEFEE` | 1 wei | [x] |
+| L10-05 | EIP-3651 Warm COINBASE | 2606 gas (cold) | 106 gas (warm) | [x] |
+
+### L10-B: post-fork 상태 검증 (read-only)
+
+| ID | 항목 | 결과 | 상태 |
+|----|------|------|------|
+| L10-06 | EIP-3860 CREATE 경계 (eth_call) | size 507904 성공 / 507905 abort — Metadium `MaxInitCodeSize` 실증 | [x] |
+| L10-07 | eth_blobBaseFee API | 0x1 | [x] |
+| L10-08 | 블록 헤더 Cancun/Shanghai 필드 | `blobGasUsed`/`excessBlobGas`=0x0, `withdrawalsRoot`=empty trie, `parentBeaconBlockRoot` 없음 (EIP-4788 의도적 제외) | [x] |
+| L10-09 | eth_feeHistory blob 필드 | 미반환 — upstream go-ethereum v1.13.14 동작 (blob 필드는 v1.14.x 추가). `eth_blobBaseFee`로 대체 가능, 버그 아님 | N/A |
+
+### L10-C: 실 tx e2e (state-changing)
+
+| ID | 항목 | 결과 | 상태 |
+|----|------|------|------|
+| L10-10 | EIP-6780 SELFDESTRUCT | deploy (block 87,095,856) 후 별도 tx selfdestruct → 코드 보존 (`0x33ff`) | [x] |
+| L10-11 | Blob tx (Type 3) — **testnet 사상 최초** | 제출→in-pool sidecar→채굴 status 0x1 type 0x3 | [x] |
+| L10-12 | Mixed block (Type 2 + Type 22 동일 블록) | block 87,095,879에 혼재 채굴 | [x] |
+| L10-13 | Fee Delegation (Type 22) | feePayer 가스 차감 확인 (sender 잔액과 분리) | [x] |
+| L10-14 | Blob sidecar retention | mined 후에도 `eth_getBlobSidecar` 조회 가능 (`BlobRetentionBlocks`=1572480, ~18일 보관) | [x] |
+| L10-15 | 노드 안정성 | 검증 중 ERROR/CRIT/invalid merkle 0건 | [x] |
+
+**실행 방법** (live 네트워크용 env 키):
+
+```bash
+export E2E_SENDER_KEY=<hex>     # funded testnet 계정
+export E2E_FEEPAYER_KEY=<hex>   # fee delegation용 별도 funded 계정
+go run ./tests/private-net-poa/eip6780-e2e/  http://127.0.0.1:8588
+go run ./tests/private-net-poa/blob-tx-e2e/  http://127.0.0.1:8588
+go run ./tests/private-net-poa/mixed-tx-e2e/ http://127.0.0.1:8588
+```
+
+**남은 작업:** mainnet `CamelliaBlock` 번호 결정 → mainnet 노드 hotfix2 바이너리 교체 → 활성화 후 Layer 10 재실행
 
 ```go
-// params/config.go — CamelliaBlock 번호 결정 후 설정
+// params/config.go — mainnet CamelliaBlock 번호 결정 후 설정
 CamelliaBlock: big.NewInt(<block_number>),
 ```
 

--- a/tests/private-net-poa/blob-tx-e2e/main.go
+++ b/tests/private-net-poa/blob-tx-e2e/main.go
@@ -31,7 +31,15 @@ import (
 )
 
 // Hardhat account 0 — pre-funded in genesis.json with 1e24 wei.
-const senderKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+// Override with E2E_SENDER_KEY to run against a live network.
+const defaultSenderKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+func senderKeyHex() string {
+	if k := os.Getenv("E2E_SENDER_KEY"); k != "" {
+		return strings.TrimPrefix(k, "0x")
+	}
+	return defaultSenderKey
+}
 
 func main() {
 	rpc := "http://192.168.0.151:8545"
@@ -42,7 +50,7 @@ func main() {
 	fmt.Printf("=== EIP-4844 Blob Tx E2E Test ===\n")
 	fmt.Printf("RPC: %s\n\n", rpc)
 
-	key, err := crypto.HexToECDSA(senderKey)
+	key, err := crypto.HexToECDSA(senderKeyHex())
 	must(err, "parse key")
 	sender := crypto.PubkeyToAddress(key.PublicKey)
 	fmt.Printf("Sender: %s\n", sender.Hex())
@@ -175,13 +183,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// 10. eth_getBlobSidecar after mining — sidecar is not persisted post-mine
+	// 10. eth_getBlobSidecar after mining — mined sidecars are persisted in the
+	// chain DB and kept for params.BlobRetentionBlocks (~18 days), so the
+	// sidecar must still be retrievable right after mining.
 	fmt.Println("\nChecking eth_getBlobSidecar post-mining...")
 	sidecarPost := rpcCallRaw(rpc, "eth_getBlobSidecar", []any{txHash})
-	if strings.Contains(sidecarPost, `"result":null`) {
-		fmt.Println("✅ PASS: sidecar correctly pruned after mining")
+	if strings.Contains(sidecarPost, `"blobs"`) {
+		fmt.Println("✅ PASS: sidecar retrievable post-mine (retained in chain DB)")
 	} else {
-		fmt.Printf("ℹ️  INFO: post-mine sidecar response: %s\n", sidecarPost)
+		fmt.Printf("❌ FAIL: post-mine sidecar response: %s\n", sidecarPost)
+		os.Exit(1)
 	}
 
 	fmt.Printf("\n=== ALL PASS ===\n")

--- a/tests/private-net-poa/eip6780-e2e/main.go
+++ b/tests/private-net-poa/eip6780-e2e/main.go
@@ -1,0 +1,223 @@
+// eip6780-e2e: End-to-end test for EIP-6780 SELFDESTRUCT semantics on a live
+// (or private) Camellia-enabled network.
+//
+//  1. Deploy a contract whose runtime code is CALLER; SELFDESTRUCT (0x33ff).
+//  2. Call SELFDESTRUCT from a separate transaction.
+//  3. Verify via eth_getCode that the code is preserved (EIP-6780: only
+//     contracts created in the same tx are actually destroyed).
+//
+// Usage:
+//
+//	E2E_SENDER_KEY=<hex> go run ./tests/private-net-poa/eip6780-e2e/ [rpc-url]
+//
+// Default rpc-url: http://localhost:8545
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Hardhat account 0 — pre-funded in genesis.json with 1e24 wei.
+// Override with E2E_SENDER_KEY to run against a live network.
+const defaultSenderKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+// init (12 bytes): PUSH1 2, PUSH1 0x0c, PUSH1 0, CODECOPY, PUSH1 2, PUSH1 0, RETURN
+// runtime (2 bytes): CALLER (0x33), SELFDESTRUCT (0xff)
+var sdDeployCode = common.FromHex("0x6002600c60003960026000f333ff")
+
+func main() {
+	rpc := "http://localhost:8545"
+	if len(os.Args) > 1 {
+		rpc = os.Args[1]
+	}
+
+	fmt.Printf("=== EIP-6780 SELFDESTRUCT E2E Test ===\n")
+	fmt.Printf("RPC: %s\n\n", rpc)
+
+	keyHex := defaultSenderKey
+	if k := os.Getenv("E2E_SENDER_KEY"); k != "" {
+		keyHex = strings.TrimPrefix(k, "0x")
+	}
+	key, err := crypto.HexToECDSA(keyHex)
+	must(err, "parse key")
+	sender := crypto.PubkeyToAddress(key.PublicKey)
+	fmt.Printf("Sender: %s\n", sender.Hex())
+
+	chainIDBig := hexToBigInt(rpcCall(rpc, "eth_chainId", nil))
+	gasPrice := hexToBigInt(rpcCall(rpc, "eth_gasPrice", nil))
+	nonce := hexToUint64(rpcCall(rpc, "eth_getTransactionCount", []any{sender.Hex(), "pending"}))
+	fmt.Printf("ChainID: %s  GasPrice: %s  Nonce: %d\n\n", chainIDBig, gasPrice, nonce)
+
+	signer := types.NewLondonSigner(chainIDBig)
+	feeCap := new(big.Int).Mul(gasPrice, big.NewInt(2))
+
+	// === TX 1: deploy the self-destructing contract ===
+	fmt.Println("--- TX 1: deploy contract (runtime = CALLER; SELFDESTRUCT) ---")
+	deployTx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainIDBig,
+		Nonce:     nonce,
+		GasTipCap: gasPrice,
+		GasFeeCap: feeCap,
+		Gas:       100000,
+		To:        nil,
+		Data:      sdDeployCode,
+	}), signer, key)
+	must(err, "sign deploy tx")
+
+	deployRaw, err := deployTx.MarshalBinary()
+	must(err, "marshal deploy tx")
+	hash1 := submitRawTx(rpc, deployRaw)
+	fmt.Printf("Submitted deploy tx: %s\n", hash1)
+
+	r1 := waitForReceipt(rpc, hash1, 15)
+	if r1 == nil {
+		fail("deploy tx not mined within 30s")
+	}
+	if fmt.Sprintf("%v", r1["status"]) != "0x1" {
+		fail(fmt.Sprintf("deploy tx failed: status=%v", r1["status"]))
+	}
+	contractAddr := fmt.Sprintf("%v", r1["contractAddress"])
+	fmt.Printf("✅ deployed at %s (block %v)\n\n", contractAddr, r1["blockNumber"])
+
+	code := strings.Trim(rpcCall(rpc, "eth_getCode", []any{contractAddr, "latest"}), `"`)
+	if code != "0x33ff" {
+		fail(fmt.Sprintf("unexpected runtime code: %s (want 0x33ff)", code))
+	}
+	fmt.Printf("Runtime code: %s ✓\n\n", code)
+
+	// === TX 2: trigger SELFDESTRUCT from a separate tx ===
+	fmt.Println("--- TX 2: call contract → SELFDESTRUCT executes ---")
+	to := common.HexToAddress(contractAddr)
+	callTx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainIDBig,
+		Nonce:     nonce + 1,
+		GasTipCap: gasPrice,
+		GasFeeCap: feeCap,
+		Gas:       100000,
+		To:        &to,
+	}), signer, key)
+	must(err, "sign call tx")
+
+	callRaw, err := callTx.MarshalBinary()
+	must(err, "marshal call tx")
+	hash2 := submitRawTx(rpc, callRaw)
+	fmt.Printf("Submitted selfdestruct tx: %s\n", hash2)
+
+	r2 := waitForReceipt(rpc, hash2, 15)
+	if r2 == nil {
+		fail("selfdestruct tx not mined within 30s")
+	}
+	if fmt.Sprintf("%v", r2["status"]) != "0x1" {
+		fail(fmt.Sprintf("selfdestruct tx failed: status=%v", r2["status"]))
+	}
+	fmt.Printf("✅ selfdestruct tx mined (block %v)\n\n", r2["blockNumber"])
+
+	// === Verify: code must be preserved (EIP-6780) ===
+	codeAfter := strings.Trim(rpcCall(rpc, "eth_getCode", []any{contractAddr, "latest"}), `"`)
+	fmt.Printf("Code after SELFDESTRUCT: %s\n", codeAfter)
+	if codeAfter == "0x33ff" {
+		fmt.Println("\n=== ALL PASS ===")
+		fmt.Println("EIP-6780: code preserved after SELFDESTRUCT in a separate tx.")
+	} else {
+		fail(fmt.Sprintf("EIP-6780 NOT applied — code after selfdestruct: %s", codeAfter))
+	}
+}
+
+func fail(msg string) {
+	fmt.Printf("❌ FAIL: %s\n", msg)
+	os.Exit(1)
+}
+
+func submitRawTx(rpc string, raw []byte) string {
+	txHashResult := rpcCall(rpc, "eth_sendRawTransaction", []any{"0x" + common.Bytes2Hex(raw)})
+	txHash := strings.Trim(txHashResult, `"`)
+	if strings.HasPrefix(txHash, "0x") && len(txHash) == 66 {
+		return txHash
+	}
+	fmt.Fprintf(os.Stderr, "FATAL: eth_sendRawTransaction returned: %s\n", txHashResult)
+	os.Exit(1)
+	return ""
+}
+
+func waitForReceipt(rpc, hash string, maxAttempts int) map[string]any {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		time.Sleep(2 * time.Second)
+		raw := rpcCall(rpc, "eth_getTransactionReceipt", []any{hash})
+		if raw == "null" || raw == "" {
+			continue
+		}
+		var r map[string]any
+		if err := json.Unmarshal([]byte(raw), &r); err == nil {
+			return r
+		}
+	}
+	return nil
+}
+
+// RPC helpers
+
+type rpcReq struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+	ID      int    `json:"id"`
+}
+
+func rpcCallRaw(url, method string, params []any) string {
+	if params == nil {
+		params = []any{}
+	}
+	body, _ := json.Marshal(rpcReq{JSONRPC: "2.0", Method: method, Params: params, ID: 1})
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Sprintf(`{"error":"%v"}`, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}
+
+func rpcCall(url, method string, params []any) string {
+	raw := rpcCallRaw(url, method, params)
+	var r struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		return raw
+	}
+	if r.Error != nil {
+		return fmt.Sprintf(`"error: %s"`, r.Error.Message)
+	}
+	return string(r.Result)
+}
+
+func hexToBigInt(s string) *big.Int {
+	s = strings.Trim(strings.TrimPrefix(strings.Trim(s, `"`), "0x"), `"`)
+	n := new(big.Int)
+	n.SetString(s, 16)
+	return n
+}
+
+func hexToUint64(s string) uint64 { return hexToBigInt(s).Uint64() }
+
+func must(err error, ctx string) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL [%s]: %v\n", ctx, err)
+		os.Exit(1)
+	}
+}

--- a/tests/private-net-poa/mixed-tx-e2e/main.go
+++ b/tests/private-net-poa/mixed-tx-e2e/main.go
@@ -32,10 +32,18 @@ import (
 )
 
 // Hardhat accounts pre-funded in genesis.json with 1e24 wei.
+// Override with E2E_SENDER_KEY / E2E_FEEPAYER_KEY to run against a live network.
 const (
-	senderKey   = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-	feePayerKey = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+	defaultSenderKey   = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+	defaultFeePayerKey = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 )
+
+func keyFromEnv(envName, fallback string) string {
+	if k := os.Getenv(envName); k != "" {
+		return strings.TrimPrefix(k, "0x")
+	}
+	return fallback
+}
 
 func main() {
 	rpc := "http://localhost:8545"
@@ -46,9 +54,9 @@ func main() {
 	fmt.Printf("=== Mixed Tx E2E Test (Normal + FeeDelegation + Blob) ===\n")
 	fmt.Printf("RPC: %s\n\n", rpc)
 
-	senderPriv, err := crypto.HexToECDSA(senderKey)
+	senderPriv, err := crypto.HexToECDSA(keyFromEnv("E2E_SENDER_KEY", defaultSenderKey))
 	must(err, "parse sender key")
-	feePayerPriv, err := crypto.HexToECDSA(feePayerKey)
+	feePayerPriv, err := crypto.HexToECDSA(keyFromEnv("E2E_FEEPAYER_KEY", defaultFeePayerKey))
 	must(err, "parse feePayer key")
 
 	sender := crypto.PubkeyToAddress(senderPriv.PublicKey)
@@ -66,6 +74,7 @@ func main() {
 	blobBaseFee := hexToBigInt(rpcCall(rpc, "eth_blobBaseFee", nil))
 	blockNum := hexToBigInt(rpcCall(rpc, "eth_blockNumber", nil))
 	senderNonce := hexToUint64(rpcCall(rpc, "eth_getTransactionCount", []any{sender.Hex(), "pending"}))
+	fpBalancePre := hexToBigInt(rpcCall(rpc, "eth_getBalance", []any{feePayer.Hex(), "latest"}))
 
 	fmt.Printf("\nChainID:     %s\n", chainIDBig)
 	fmt.Printf("BlockNumber: %s\n", blockNum)
@@ -243,12 +252,11 @@ func main() {
 	if receipts[1] != nil {
 		fpBalance := hexToBigInt(rpcCall(rpc, "eth_getBalance", []any{feePayer.Hex(), "latest"}))
 		senderBalance := hexToBigInt(rpcCall(rpc, "eth_getBalance", []any{sender.Hex(), "latest"}))
-		fmt.Printf("\nFeePayer balance post-tx: %s wei\n", fpBalance)
+		fmt.Printf("\nFeePayer balance pre-tx:  %s wei\n", fpBalancePre)
+		fmt.Printf("FeePayer balance post-tx: %s wei\n", fpBalance)
 		fmt.Printf("Sender balance post-tx:   %s wei\n", senderBalance)
-		// feePayer should have less than 1e24 (paid gas)
-		initial := new(big.Int)
-		initial.SetString("1000000000000000000000000", 10) // 1e24
-		if fpBalance.Cmp(initial) < 0 {
+		// feePayer should have paid gas for the fee delegation tx
+		if fpBalance.Cmp(fpBalancePre) < 0 {
 			fmt.Println("✅ FeePayer paid gas (balance decreased)")
 		} else {
 			fmt.Println("❌ FAIL: FeePayer balance did not decrease")


### PR DESCRIPTION
## Summary

Camellia HF activated on testnet at block **86,449,000** (2026-05-20). This PR records the post-activation verification performed on the **live testnet** with `m1.0.0.testnet.hotfix2`, and makes the e2e tools reusable against live networks.

No node behavior changes — test tooling, docs, and dead-code removal only. No redeploy needed.

## Verification results (Layer 10 — 14 PASS, 1 N/A)

**Pre→post fork transition** (archive node `eth_call` at block 86,448,999 vs latest):
- PUSH0 / TSTORE·TLOAD / MCOPY / BLOBBASEFEE: `invalid opcode` before → working after
- EIP-3651 warm COINBASE: 2606 gas (cold) → 106 gas (warm)

**Post-fork state** (read-only):
- EIP-3860 CREATE boundary at Metadium `MaxInitCodeSize`: size 507904 succeeds / 507905 aborts
- Block headers carry `blobGasUsed`/`excessBlobGas`/`withdrawalsRoot`; no `parentBeaconBlockRoot` (EIP-4788 intentionally excluded)
- `eth_feeHistory` blob fields absent — upstream v1.13.14 behavior (added in v1.14.x), `eth_blobBaseFee` covers it (N/A, not a bug)

**Real tx e2e** (sync node → P2P → BP mining):
- EIP-6780: code preserved after SELFDESTRUCT from a separate tx
- First-ever blob tx (Type 3) on testnet: submitted → in-pool sidecar → mined, status 0x1
- Type 2 + Type 22 mixed in the same block; feePayer gas deduction verified
- Blob sidecar retained post-mine per `BlobRetentionBlocks` (~18 days)
- Zero ERROR/CRIT/invalid-merkle across all nodes during verification

## Changes

- `tests/private-net-poa/{blob,mixed}-tx-e2e`: `E2E_SENDER_KEY` / `E2E_FEEPAYER_KEY` env overrides for live networks; feePayer balance check now uses a pre-tx snapshot; post-mine sidecar expectation updated for retention
- `tests/private-net-poa/eip6780-e2e`: new e2e — deploy `CALLER;SELFDESTRUCT`, trigger from a separate tx, verify code preservation
- `core/vm/gas_table.go`: drop unused `debugGasCreate2Eip3860` (dead code with a stray `println`)
- `docs/camellia-verification-checklist.md`: Layer 10 results; Layer 3 pending items closed out

## Remaining (not in this PR)

Mainnet `CamelliaBlock` decision → mainnet nodes to hotfix2 binary → re-run Layer 10 after activation.