### PR TITLE
test: deflake TestBuildPayload and TestForkResendTx

### DIFF
--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -213,11 +213,17 @@ func TestForkResendTx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create transaction: %v", err)
 	}
-	client.SendTransaction(ctx, tx)
+	if err := client.SendTransaction(ctx, tx); err != nil {
+		t.Fatalf("sending transaction: %v", err)
+	}
+	waitForTxPending(t, client, tx.Hash())
 	sim.Commit()
 
 	// 3.
-	receipt, _ := client.TransactionReceipt(ctx, tx.Hash())
+	receipt, err := client.TransactionReceipt(ctx, tx.Hash())
+	if err != nil {
+		t.Fatalf("retrieving receipt: %v", err)
+	}
 	if h := receipt.BlockNumber.Uint64(); h != 1 {
 		t.Errorf("TX included in wrong block: %d", h)
 	}
@@ -232,11 +238,29 @@ func TestForkResendTx(t *testing.T) {
 	if err := client.SendTransaction(ctx, tx); err != nil {
 		t.Fatalf("sending transaction: %v", err)
 	}
+	waitForTxPending(t, client, tx.Hash())
 	sim.Commit()
-	receipt, _ = client.TransactionReceipt(ctx, tx.Hash())
+	receipt, err = client.TransactionReceipt(ctx, tx.Hash())
+	if err != nil {
+		t.Fatalf("retrieving receipt after fork: %v", err)
+	}
 	if h := receipt.BlockNumber.Uint64(); h != 2 {
 		t.Errorf("TX included in wrong block: %d", h)
 	}
+}
+
+// waitForTxPending blocks until the transaction shows up in the node's pending
+// pool. Transaction injection is asynchronous, so committing a block right
+// after SendTransaction may produce an empty block on slow machines.
+func waitForTxPending(t *testing.T, client Client, hash common.Hash) {
+	t.Helper()
+	for i := 0; i < 500; i++ {
+		if _, isPending, err := client.TransactionByHash(context.Background(), hash); err == nil && isPending {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for tx %s to reach the pending pool", hash)
 }
 
 func TestCommitReturnValue(t *testing.T) {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -161,7 +161,10 @@ func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*worker, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
-	backend.txPool.Add(pendingTxs, true, false)
+	// Add the pending transactions synchronously: tests (e.g. TestBuildPayload)
+	// build blocks right after this call, and an async add may not have
+	// promoted the transactions into the pending pool yet on slow machines.
+	backend.txPool.Add(pendingTxs, true, true)
 	w := newWorker(testConfig, chainConfig, engine, backend, new(event.TypeMux), nil, false)
 	w.setEtherbase(testBankAddress)
 	return w, backend


### PR DESCRIPTION
## Summary

Two unit tests race against asynchronous transaction injection and fail intermittently on slow CI runners. Observed back-to-back on PR #50's CI (same ref, two runs):

- run 1: `TestBuildPayload` (miner) — `payload_building_test.go:67: Unexpected transaction set`
- run 2 (rerun): `TestForkResendTx` (ethclient/simulated)

Both pass consistently in faster environments, which is why they only bite on GitHub-hosted 2-core runners under full-suite load.

## Root causes & fixes

**miner/worker_test.go** — `newTestWorker` added the shared pending txs with `txPool.Add(..., sync=false)`. `Add` explicitly documents that it "may postpone fully integrating the tx", so a payload built right after can see an empty pending pool and produce 0 transactions. → add synchronously (`sync=true`).

**ethclient/simulated/backend_test.go** — `TestForkResendTx` called `sim.Commit()` immediately after `SendTransaction`; if the tx hadn't been promoted yet the block is empty and the test derefs a nil receipt. → wait for the tx to appear in the pending pool before committing, and surface previously ignored errors (`SendTransaction`, `TransactionReceipt`) as test failures with clear messages.

## Verification

- `go test -tags=ckzg -tags=integrationtests -p 1 -short ./miner/ ./ethclient/simulated/ -count 3` — PASS
- `GOMAXPROCS=1 go test -run 'TestBuildPayload|TestForkResendTx' -count 20` on both packages — PASS

Test-only changes; no production code touched.