### PR TITLE
security: backport upstream DoS fix and harden block signature verification

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -315,8 +315,8 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 	if count == 0 {
 		return rlpHeaders
 	}
-	// read remaining from ancients
-	data, err := db.AncientRange(ChainFreezerHeaderTable, i+1-count, count, 0)
+	// read remaining from ancients, cap at 2M
+	data, err := db.AncientRange(ChainFreezerHeaderTable, i+1-count, count, 2*1024*1024)
 	if err != nil {
 		log.Error("Failed to read headers from freezer", "err", err)
 		return rlpHeaders

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -43,6 +43,9 @@ var (
 // The maximum number of topic criteria allowed, vm.LOG4 - vm.LOG0
 const maxTopics = 4
 
+// The maximum number of allowed topics within a topic criteria
+const maxSubTopics = 1000
+
 // filter is a helper struct that holds meta information over the filter type
 // and associated subscription in the event system.
 type filter struct {
@@ -546,6 +549,10 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	if len(raw.Topics) > maxTopics {
+		return errExceedMaxTopics
+	}
+
 	// topics is an array consisting of strings and/or arrays of strings.
 	// JSON null values are converted to common.Hash{} and ignored by the filter manager.
 	if len(raw.Topics) > 0 {
@@ -565,6 +572,9 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 
 			case []interface{}:
 				// or case e.g. [null, "topic0", "topic1"]
+				if len(topic) > maxSubTopics {
+					return errExceedMaxTopics
+				}
 				for _, rawTopic := range topic {
 					if rawTopic == nil {
 						// null component, match all

--- a/metadium/admin.go
+++ b/metadium/admin.go
@@ -1689,7 +1689,37 @@ func signBlock(height *big.Int, hash common.Hash, isPangyo bool) (coinbase commo
 	return
 }
 
+// acceptUnverifiableBlock decides whether a block whose governance data is
+// unavailable can be accepted without miner signature verification. Two
+// legitimate cases exist:
+//
+//	(a) genuinely pre-governance blocks: local state at height exists but the
+//	    registry/governance contracts are not deployed yet (early chain
+//	    segment during full sync from genesis)
+//	(b) snap-sync header gap: headers are verified ahead of state download,
+//	    so state at height is not available locally yet
+//
+// For (b), only heights at or beyond the locally executed head are accepted.
+// Below the executed head, state must be available; its absence means the
+// block cannot be tied to governance and is rejected, so a synced node never
+// accepts an unverified side-chain header.
+func (ma *metaAdmin) acceptUnverifiableBlock(ctx context.Context, height *big.Int) bool {
+	if _, err := ma.cli.BalanceAt(ctx, common.Address{}, height); err == nil {
+		// state is present, so the governance lookup failed because the
+		// contracts are genuinely not deployed at this height
+		return true
+	}
+	head, err := ma.cli.BlockNumber(ctx)
+	if err != nil {
+		return false
+	}
+	return height.Uint64() >= head
+}
+
 func verifyBlockSig(height *big.Int, coinbase common.Address, nodeId []byte, hash common.Hash, sig []byte, isPangyo bool) bool {
+	if admin == nil {
+		return false
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1697,11 +1727,13 @@ func verifyBlockSig(height *big.Int, coinbase common.Address, nodeId []byte, has
 	num := new(big.Int).Sub(height, common.Big1)
 	_, gov, _, _, _, err := admin.getRegGovEnvContracts(ctx, num)
 	if err != nil {
-		// Governance not yet initialized (early blocks before contract deployment).
-		// Allow these blocks — they are pre-governance and cannot be verified.
-		return true
+		// Governance data unavailable: either pre-governance blocks or a
+		// snap-sync gap. Accept only the cases that cannot be abused to
+		// bypass signature verification.
+		return admin.acceptUnverifiableBlock(ctx, num)
 	} else if count, err := admin.getInt(ctx, gov, num, "getMemberLength"); err != nil || count == 0 {
-		// No members registered yet — governance exists but is empty.
+		// Governance contracts exist in locally executed state but have no
+		// members yet (bootstrap phase); not remotely forgeable.
 		return true
 	}
 	// if minerNodeId is given, i.e. present in block header, use it,


### PR DESCRIPTION
Backports upstream go-ethereum v1.13.15 DoS fixes and hardens block signature verification. Closed; superseded.