### PR TITLE
Pre-mainnet security hardening, meta/69 blob serving & replay protection, and upstream backports

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1731,6 +1731,26 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	} else if ctx.IsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *flags.GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
 	}
+	// go-metadium runs full sync only. The snap state-healing path (gentrie
+	// redesign, PRs #29313/#30258/#33428) is not backported to this base and is
+	// known to risk state corruption, so reject snap/fast on the Metadium
+	// networks. For fast new-node bring-up, bootstrap from a chain snapshot
+	// (see docs/sync-policy-and-snapshot-bootstrap.md). Upstream test networks
+	// and --dev are exempt.
+	if cfg.SyncMode != downloader.FullSync {
+		nonMetaNet := ctx.Bool(GoerliFlag.Name) || ctx.Bool(SepoliaFlag.Name) ||
+			ctx.Bool(HoleskyFlag.Name) || ctx.Bool(DeveloperFlag.Name)
+		if !nonMetaNet {
+			network := "mainnet"
+			if ctx.Bool(MetaTestnetFlag.Name) {
+				network = "testnet"
+			}
+			Fatalf("--%s=%v is not supported on the Metadium %s: go-metadium runs full sync only "+
+				"(snap state-healing is not backported). Use --%s=full, or bootstrap from a chain "+
+				"snapshot for fast bring-up (see docs/sync-policy-and-snapshot-bootstrap.md).",
+				SyncModeFlag.Name, cfg.SyncMode, network, SyncModeFlag.Name)
+		}
+	}
 	if ctx.IsSet(NetworkIdFlag.Name) {
 		cfg.NetworkId = ctx.Uint64(NetworkIdFlag.Name)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -224,6 +224,13 @@ type BlockChain struct {
 	// Set externally after construction to enable sidecar storage on block import.
 	BlobSidecarFn func(txHash common.Hash) *types.BlobTxSidecar
 
+	// MissingBlobSidecarFn is invoked after a block is imported whose blob txs
+	// could not all be sourced locally (sidecars missing from the pool). A higher
+	// layer (the eth handler, meta/69 M5) uses it to fetch the missing sidecars
+	// from peers and persist them, closing the data-availability gap. It must not
+	// block. Set externally after construction; nil disables wire fetching.
+	MissingBlobSidecarFn func(block *types.Block)
+
 	hc            *HeaderChain
 	rmLogsFeed    event.Feed
 	chainFeed     event.Feed
@@ -1853,11 +1860,17 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		blockValidationTimer.Update(vtime - (triehash + trieUpdate))    // The time spent on block validation
 
 		// Collect blob sidecars from the pool BEFORE writing the block
-		// (the pool evicts included txs on chain head update).
-		var blobSidecars []*types.BlobTxSidecar
-		if bc.BlobSidecarFn != nil {
-			for _, tx := range block.Transactions() {
-				if tx.Type() == types.BlobTxType {
+		// (the pool evicts included txs on chain head update). Count blob txs
+		// independently so we can detect sidecars that could not be sourced
+		// locally and trigger a wire fetch below (meta/69 M5).
+		var (
+			blobSidecars []*types.BlobTxSidecar
+			blobTxCount  int
+		)
+		for _, tx := range block.Transactions() {
+			if tx.Type() == types.BlobTxType {
+				blobTxCount++
+				if bc.BlobSidecarFn != nil {
 					if sc := bc.BlobSidecarFn(tx.Hash()); sc != nil {
 						blobSidecars = append(blobSidecars, sc)
 					}
@@ -1883,6 +1896,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		// Persist collected blob sidecars.
 		if len(blobSidecars) > 0 {
 			rawdb.WriteBlobSidecars(bc.db, block.Hash(), block.NumberU64(), blobSidecars)
+		}
+		// If the block carries blob txs whose sidecars could not be sourced
+		// locally, ask a higher layer to fetch the missing data over the wire
+		// (meta/69 M5). The callback must not block.
+		if blobTxCount > 0 && len(blobSidecars) < blobTxCount && bc.MissingBlobSidecarFn != nil {
+			bc.MissingBlobSidecarFn(block)
 		}
 		// Update the metrics touched during block commit
 		accountCommitTimer.Update(statedb.AccountCommits)   // Account commits are complete, we can mark them

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -258,6 +258,17 @@ func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	return receipts
 }
 
+// GetBlobSidecars retrieves the blob tx sidecars stored for a block by hash, or
+// nil if the block is unknown or has no stored sidecars. Used to serve meta/69
+// GetBlobSidecars requests (M5).
+func (bc *BlockChain) GetBlobSidecars(hash common.Hash) []*types.BlobTxSidecar {
+	number := rawdb.ReadHeaderNumber(bc.db, hash)
+	if number == nil {
+		return nil
+	}
+	return rawdb.ReadBlobSidecars(bc.db, hash, *number)
+}
+
 // GetUnclesInChain retrieves all the uncles from a given block backwards until
 // a specific distance is reached.
 func (bc *BlockChain) GetUnclesInChain(block *types.Block, length int) []*types.Header {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -315,8 +315,8 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 	if count == 0 {
 		return rlpHeaders
 	}
-	// read remaining from ancients
-	data, err := db.AncientRange(ChainFreezerHeaderTable, i+1-count, count, 0)
+	// read remaining from ancients, cap at 2M
+	data, err := db.AncientRange(ChainFreezerHeaderTable, i+1-count, count, 2*1024*1024)
 	if err != nil {
 		log.Error("Failed to read headers from freezer", "err", err)
 		return rlpHeaders

--- a/core/txpool/errors.go
+++ b/core/txpool/errors.go
@@ -51,6 +51,12 @@ var (
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
 
+	// ErrInvalidBlob is returned when a blob transaction's sidecar fails
+	// validation (blob/commitment/proof counts or KZG proof verification). It
+	// marks a cryptographic protocol violation by the sending peer, which should
+	// be dropped rather than merely rejected. (CVE-2026-22862/22868 hardening)
+	ErrInvalidBlob = errors.New("invalid blob sidecar")
+
 	// ErrFutureReplacePending is returned if a future transaction replaces a pending
 	// one. Future transactions should only be able to replace other future transactions.
 	ErrFutureReplacePending = errors.New("future transaction tries to replace pending")

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -141,13 +141,13 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 
 func validateBlobSidecar(hashes []common.Hash, sidecar *types.BlobTxSidecar) error {
 	if len(sidecar.Blobs) != len(hashes) {
-		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(sidecar.Blobs), len(hashes))
+		return fmt.Errorf("%w: invalid number of %d blobs compared to %d blob hashes", ErrInvalidBlob, len(sidecar.Blobs), len(hashes))
 	}
 	if len(sidecar.Commitments) != len(hashes) {
-		return fmt.Errorf("invalid number of %d blob commitments compared to %d blob hashes", len(sidecar.Commitments), len(hashes))
+		return fmt.Errorf("%w: invalid number of %d blob commitments compared to %d blob hashes", ErrInvalidBlob, len(sidecar.Commitments), len(hashes))
 	}
 	if len(sidecar.Proofs) != len(hashes) {
-		return fmt.Errorf("invalid number of %d blob proofs compared to %d blob hashes", len(sidecar.Proofs), len(hashes))
+		return fmt.Errorf("%w: invalid number of %d blob proofs compared to %d blob hashes", ErrInvalidBlob, len(sidecar.Proofs), len(hashes))
 	}
 	// Blob quantities match up, validate that the provers match with the
 	// transaction hash before getting to the cryptography
@@ -156,7 +156,7 @@ func validateBlobSidecar(hashes []common.Hash, sidecar *types.BlobTxSidecar) err
 		commit := (*kzg4844.Commitment)(sidecar.Commitments[i])
 		computed := kzg4844.CalcBlobHashV1(hasher, commit)
 		if vhash != computed {
-			return fmt.Errorf("blob %d: computed hash %#x mismatches transaction one %#x", i, computed, vhash)
+			return fmt.Errorf("%w: blob %d computed hash %#x mismatches transaction one %#x", ErrInvalidBlob, i, computed, vhash)
 		}
 	}
 	// Blob commitments match with the hashes in the transaction, verify the
@@ -166,7 +166,7 @@ func validateBlobSidecar(hashes []common.Hash, sidecar *types.BlobTxSidecar) err
 		commit := (*kzg4844.Commitment)(sidecar.Commitments[i])
 		proof := (*kzg4844.Proof)(sidecar.Proofs[i])
 		if err := kzg4844.VerifyBlobProof(*blob, *commit, *proof); err != nil {
-			return fmt.Errorf("invalid blob %d: %v", i, err)
+			return fmt.Errorf("%w: blob %d failed KZG proof: %v", ErrInvalidBlob, i, err)
 		}
 	}
 	return nil

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -139,6 +139,15 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	return nil
 }
 
+// ValidateBlobSidecar verifies a blob sidecar received over the wire against the
+// expected versioned hashes: blob/commitment/proof counts, commitment-to-hash
+// derivation, and the KZG proofs. It wraps ErrInvalidBlob on any failure so
+// callers (e.g. the meta/69 blob-sidecar fetcher, M5/#31219) can drop the
+// offending peer. It is the exported entry point for validateBlobSidecar.
+func ValidateBlobSidecar(hashes []common.Hash, sidecar *types.BlobTxSidecar) error {
+	return validateBlobSidecar(hashes, sidecar)
+}
+
 func validateBlobSidecar(hashes []common.Hash, sidecar *types.BlobTxSidecar) error {
 	if len(sidecar.Blobs) != len(hashes) {
 		return fmt.Errorf("%w: invalid number of %d blobs compared to %d blob hashes", ErrInvalidBlob, len(sidecar.Blobs), len(hashes))

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -217,6 +217,13 @@ func symDecrypt(params *ECIESParams, key, ct []byte) (m []byte, err error) {
 		return
 	}
 
+	// Reject a ciphertext shorter than the IV/block size; otherwise the slices
+	// below go out of bounds and panic, which a remote peer can trigger during
+	// the RLPx handshake. (CVE-2026-22862/22868)
+	if len(ct) < params.BlockSize {
+		return nil, ErrInvalidMessage
+	}
+
 	ctr := cipher.NewCTR(c, ct[:params.BlockSize])
 
 	m = make([]byte, len(ct)-params.BlockSize)

--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -92,6 +92,15 @@ func (BitCurve *BitCurve) Params() *elliptic.CurveParams {
 
 // IsOnCurve returns true if the given (x,y) lies on the BitCurve.
 func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
+	// Reject coordinates that are negative or not fully reduced modulo P.
+	// Without this bound, a malformed point supplied by a remote peer during
+	// the RLPx handshake can satisfy the curve equation modulo P yet feed an
+	// out-of-range value into the scalar-multiplication path. This is the
+	// chokepoint elliptic.Unmarshal uses to validate decoded points, so it
+	// guards both the Go and CGo ScalarMult paths. (CVE-2026-26313/26314/26315)
+	if x.Sign() < 0 || y.Sign() < 0 || x.Cmp(BitCurve.P) >= 0 || y.Cmp(BitCurve.P) >= 0 {
+		return false
+	}
 	// y² = x³ + b
 	y2 := new(big.Int).Mul(y, y) //y²
 	y2.Mod(y2, BitCurve.P)       //y²%P

--- a/crypto/secp256k1/scalar_mult_cgo.go
+++ b/crypto/secp256k1/scalar_mult_cgo.go
@@ -22,6 +22,16 @@ extern int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, const unsigned
 import "C"
 
 func (BitCurve *BitCurve) ScalarMult(Bx, By *big.Int, scalar []byte) (*big.Int, *big.Int) {
+	// Reject base points that are not on the curve, including coordinates that
+	// are >= P. secp256k1_ext_scalar_mul ignores the return of
+	// secp256k1_fe_set_b32 and does not validate the input point, so without
+	// this guard a malformed remote point (e.g. from the RLPx/ECIES handshake)
+	// would be fed into the scalar-multiplication path. Callers treat a nil
+	// result as point-at-infinity / shared-key failure.
+	// (CVE-2026-26313/26314/26315 defense-in-depth)
+	if Bx == nil || By == nil || !BitCurve.IsOnCurve(Bx, By) {
+		return nil, nil
+	}
 	// Ensure scalar is exactly 32 bytes. We pad always, even if
 	// scalar is 32 bytes long, to avoid a timing side channel.
 	if len(scalar) > 32 {

--- a/docs/block18-reward-race-known-issue.md
+++ b/docs/block18-reward-race-known-issue.md
@@ -1,0 +1,132 @@
+# Block 18 Reward Distribution Race — Resolved
+
+**Branch:** `fix/block18-testnet-reward-pin`
+**Base:** `fix/pre-mainnet-security` (`c15827520`)
+**Date:** 2026-06-16
+**Author:** Jeffrey Song
+**Status:** Resolved — testnet block 18 pinned (commit `766c918eb`); see Resolution
+
+---
+
+## Summary
+
+On a **fresh-genesis full clean-sync**, the testnet chain intermittently failed
+to import **block 18** with an `invalid merkle root` error. The failure was
+**non-deterministic**: roughly 40% of clean-sync attempts failed, the rest
+passed. A 10x clean-sync run reproduced approximately **6 PASS / 4 FAIL**,
+confirming a race rather than a deterministic divergence.
+
+This was **not a regression**. The reward-related code on `develop` and on
+`c15827520` is byte-identical; the same race existed on both.
+
+The root cause is a race in consensus-level reward calculation. Because the two
+networks' canonical block 18 differ on the exact decision involved (see below),
+the fix is network-gated rather than a global rule.
+
+---
+
+## Symptom
+
+- Phase: fresh-genesis **full** clean-sync (no snapshot, no pre-existing DB).
+- Block: **18**, always the same block.
+- Error: `invalid merkle root (remote 599eae… / local 0fa341…)`.
+- Blocks 1–17 imported and matched canonical state roots. Block 18's transaction
+  executed identically to canonical (`gasUsed` matched); only the
+  **consensus-level reward / fee distribution** diverged.
+- More reproducible on **RocksDB** than LevelDB, because RocksDB's asynchronous
+  batch commit widens the race window.
+
+---
+
+## Root cause
+
+Reward calculation for block N reads the **parent (block N-1) governance state**
+to decide how fees are distributed. In the legacy path
+(`metadium/legacy.go calculateRewardsLegacy`) this read is
+`getRewardAccountsLegacy(num-1)`, performed via an **in-process `eth_call` on a
+fresh statedb** that races with block 17's asynchronous trie commit/flush:
+
+- Canonical (correct) read: `{rewardPool=nil, maintenance=nil, members=0}` →
+  `ErrNotInitialized` → fees go to the **coinbase** → state root `599eae`.
+- Racy read: `{rewardPool=nil, maintenance=0x6d4685…, members=0}` — the
+  maintenance account registered by a block 17 transaction is observed → fees
+  are **distributed** to it → state root `0fa341` ≠ canonical.
+
+The racy read returns **success with a stale value**, so an error-based retry
+cannot catch it. The existing `metaminer.TrieAccessMu` mutex does not close the
+gap: `InsertChain` is sequential, so block 17's `writeBlockWithState` has already
+released the writer lock by the time block 18's reward read runs, and RocksDB's
+async flush/visibility lag happens outside the lock.
+
+---
+
+## Why the fix is network-gated, not a global rule
+
+The two chains' canonical histories are split on this exact decision:
+
+- **testnet** canonical block 18: fees go to **coinbase** (`header.Rewards = "0x"`,
+  state root `599eae`, miner = genesis coinbase `0x378360d4…`).
+- **mainnet** canonical block 18: fees are **distributed** (maintenance path).
+
+The governance code is the same on both networks. At original mining time the
+race landed on opposite outcomes on each chain, and each is now frozen into that
+chain's canonical history. **No single deterministic rule reproduces both.**
+
+> A general rule such as *"if `rewardPool == nil` treat as `ErrNotInitialized`"*
+> makes testnet deterministic but **breaks mainnet block 18**, where
+> distribution is canonical. This was attempted and reverted — do not reintroduce
+> it.
+
+---
+
+## Resolution
+
+Pin testnet block 18 to its canonical coinbase outcome, mirroring the existing
+`handleBlock94Rewards` special case (commit `766c918eb`):
+
+- `metaAdmin` caches the **genesis hash** (`getGenesisInfo`).
+- At the top of `calculateRewardsLegacy`, before the racy governance read:
+
+  ```go
+  if num.Int64() == 18 && ma.genesisHash == params.MetadiumTestnetGenesisHash {
+      return nil, nil, metaminer.ErrNotInitialized
+  }
+  ```
+
+Properties:
+- **Race-immune** — the pin does not depend on the governance read, so block 18's
+  outcome is deterministic regardless of trie-commit timing.
+- **Mainnet-safe** — gated on `params.MetadiumTestnetGenesisHash`, so it can never
+  trigger on mainnet (different genesis), where block 18 distribution is
+  canonical and continues to compute normally.
+- **Minimal** — one block, one network; all other blocks and the new (non-legacy)
+  path are untouched.
+
+### Validation
+
+On server 47 (RocksDB), fresh-genesis full clean-sync repeated **5×** with the
+fix: **5 PASS / 0 FAIL**, block 18 state root = canonical
+`0x599eaebad893d28adb480e1d1a015251ea24ca2b46e0eb52dac7f2dbba8cf861` every time
+(vs ~40–60% failure before). Sync continues past block 18 normally.
+
+---
+
+## Impact (pre-fix)
+
+Low. Affected only a **fresh-genesis full clean-sync**, at exactly **block 18**.
+Not affected: normal operation, block production, nodes bootstrapped from a
+snapshot or existing DB, or any block other than 18. Mainnet nodes are not stood
+up via fresh-genesis full clean-sync, so there was no meaningful operational
+exposure; the fix removes the residual testnet flakiness.
+
+---
+
+## Notes for mainnet
+
+The same race can in principle affect a mainnet fresh-genesis full clean-sync at
+block 18 (computing coinbase when distribution is canonical). Mainnet is not
+bootstrapped that way in practice, and this fix deliberately does **not** pin
+mainnet block 18 (its canonical value depends on governance params, not a fixed
+coinbase). A general deterministic-committed-parent-read change remains a
+possible future hardening, but is out of scope here and was intentionally not
+bundled into a pre-launch consensus change.

--- a/docs/meta69-blob-replay-design.md
+++ b/docs/meta69-blob-replay-design.md
@@ -1,0 +1,166 @@
+# meta/69 Design — Blob Sidecar Serving (M5) + Meta-Message Replay Protection (M12)
+
+**Date:** 2026-06-17
+**Author:** Jeffrey Song
+**Status:** Design (pre-implementation) — to be reviewed before coding
+**Targets:** phase-2 items #3 (M5) and #4 (M12), bundled into a new protocol
+version and rolled out **with the Camellia mainnet hard fork (2026-08~09)**
+
+---
+
+## 1. Why one bundle, one new version
+
+Both M5 and M12 change the `meta` wire protocol:
+- **M12** adds replay-protection fields to existing meta messages → a wire-format
+  change (old/new nodes cannot decode each other's frames).
+- **M5** adds two new message codes for blob-sidecar request/response.
+
+There is no per-message capability negotiation, so the only safe discriminator is
+the **negotiated protocol version** (`handshake.go:101` enforces
+`status.ProtocolVersion == p.version`; dispatch is version-keyed in
+`handler.go:226`). Doing these piecemeal would force two separate lockstep
+upgrades of all governance/partner nodes. Bundling them into **one new version,
+`meta/69`**, rolled out with the Camellia fork (which already mandates a
+coordinated upgrade), amortizes a single coordinated event.
+
+---
+
+## 2. Current state (baseline)
+
+- `ProtocolName = "meta"`; `ProtocolVersions = {ETH68, ETH66}` (`protocol.go`).
+  `ETH66=66`, `ETH68=68`. `protocolLengths = {68:23, 66:23}`.
+- Meta message codes: `GetPendingTxsMsg 0x11`, `GetStatusExMsg 0x12`,
+  `StatusExMsg 0x13`, `EtcdAddMemberMsg 0x14`, `EtcdClusterMsg 0x15`,
+  `TransactionsExMsg 0x16` (highest = 0x16).
+- Handler maps `eth68` / `eth66` (`handler.go:165/189`); dispatch:
+  `if peer.Version() >= ETH68 { eth68 } else { eth66 }`.
+- Meta packets (`metadium_protocol.go`) carry **no nonce/timestamp**:
+  `GetStatusExPacket int`, `StatusExPacket = metaapi.MetadiumMinerStatus`,
+  `EtcdAddMemberPacket int`, `EtcdClusterPacket string`.
+- **No blob-sidecar P2P serving**: a node that learns a block via propagation but
+  never mempool-fetched its blob txs has permanently missing sidecar DA
+  (`core/blockchain.go:1855` `BlobSidecarFn` returns nil → not stored). Blob txs
+  are not broadcast (`handler_eth.go:76`).
+- **Interop constraint:** the live mainnet is public and the official sealers run
+  **Gmet/v0.10.2** (speaking meta/66 or meta/68). Our nodes MUST keep meta/66+68
+  for interop with them. meta/69 is negotiated **only between Camellia-upgraded
+  nodes**; legacy links stay on meta/66/68.
+
+---
+
+## 3. meta/69 introduction (scaffolding)
+
+- Add `ETH69 = 69`. `ProtocolVersions = {ETH69, ETH68, ETH66}` (69 primary).
+- `protocolLengths[ETH69] = 25` (covers new `0x17`, `0x18`); keep 68/66 at 23.
+- New handler map `eth69` = `eth68` + the two blob handlers + replay-aware meta
+  handlers (see §4, §5). Dispatch becomes:
+  `if v >= ETH69 { eth69 } else if v >= ETH68 { eth68 } else { eth66 }`.
+- devp2p already negotiates the highest common version; no handshake change beyond
+  registering 69. A node only uses meta/69 features with peers that also
+  negotiated 69.
+
+---
+
+## 4. M12 — replay protection (meta/69 only)
+
+**Threat:** meta messages (StatusEx/EtcdCluster/EtcdAddMember/GetStatusEx) carry
+no freshness token (`metadium_handlers.go`); a captured partner frame can be
+replayed. Most damaging: a stale `EtcdCluster`/`EtcdAddMember` replayed into etcd
+self-healing. Today only `IsPartner` + the M11 semaphores gate these.
+
+**Design:**
+- Define meta/69 packet variants with `Nonce uint64` + `Timestamp uint64`
+  (unix seconds). The bare-`int` request packets (`GetStatusExPacket`,
+  `EtcdAddMemberPacket`, currently sent as `common.Big1`) become structs.
+- **Version-aware encode/decode**: meta/69 peers exchange the struct-with-fields
+  form; meta/66/68 peers keep the legacy form. Selection is by `peer.Version()`
+  at send time and by the handler map at receive time (legacy handlers decode the
+  legacy shape, eth69 handlers decode the new shape).
+- **Receiver state** (new per-`Peer` fields): track the last accepted
+  `(nonce, timestamp)` per message kind per peer. Reject if `nonce <= lastNonce`
+  or `|now - timestamp| > skew` (bounded clock skew, e.g. 30s). Drop or ignore on
+  violation (do not feed etcd).
+- **Authentication note:** nonce/timestamp prevents *replay* but not forgery by a
+  party that can produce valid frames. These messages are already `IsPartner`-
+  gated; binding the token into the existing block-signature scheme (sign the
+  `(payload, nonce, timestamp)`) would also prevent forgery — evaluate as a
+  follow-up; replay protection is the in-scope minimum.
+- **Rollout reality:** replay protection is effective only on meta/69 links. Until
+  all partner nodes are on meta/69 (post-fork), legacy links remain unprotected —
+  acceptable for the transition window; full coverage once meta/66/68 are retired.
+
+---
+
+## 5. M5 — blob sidecar serving (meta/69 only)
+
+**Goal:** any node that imports a block with blob txs can obtain and persist the
+sidecars even if it never had the blob tx in its local pool.
+
+**New messages** (meta/69):
+- `GetBlobSidecarsMsg = 0x17` — request: a block hash (or a small list of block
+  hashes / blob versioned hashes).
+- `BlobSidecarsMsg = 0x18` — response: the `[]*types.BlobTxSidecar` for the
+  requested block(s).
+
+**Serve side:** handler reads from `rawdb.ReadBlobSidecars` (already exists) and
+replies; bound the response size (reuse `maxMessageSize` and a per-request cap;
+enforce the EIP-7594 max-blob limit, **#32246**).
+
+**Request side:** after importing a block where `BlobSidecarFn` returned nil for
+some blob txs (`core/blockchain.go:1855`), enqueue a sidecar fetch from a meta/69
+peer; on response, validate (below) and persist via `rawdb.WriteBlobSidecars`.
+
+**Validation on receipt (#31219):** verify received sidecar commitments against
+the block's blob versioned hashes; reuse `validateBlobSidecar`
+(`core/txpool/validation.go`) — which already wraps `txpool.ErrInvalidBlob` after
+batch 2 — and **drop the peer on mismatch** (batch 2 already drops on the fetcher
+path; mirror it here).
+
+**Primary path hardening (#30125):** backport the fetcher ordering fix so blob
+txs reliably land in the pool before the block arrives; the new message is the
+fallback when they don't.
+
+**Activation:** gated on Camellia blob support. Mainnet `params CamelliaBlock` is
+currently `nil` (no blob txs on mainnet yet), so there is **no mainnet exposure
+until Camellia is activated**; testnet already runs Camellia. M5 is a **release
+blocker for flipping mainnet `CamelliaBlock`**, not for the current chain.
+
+---
+
+## 6. Rollout & fork sequencing
+
+1. Implement meta/69 (scaffolding + M12 + M5) behind the new version; keep
+   meta/66/68 fully functional for interop with official v0.10.2 nodes.
+2. Verify on SPoA (all nodes meta/69) + a mixed meta/68↔meta/69 interop test +
+   blob-tx-e2e + replay unit tests.
+3. Ship the binary ahead of the Camellia mainnet fork; partner nodes upgrade in
+   the same coordinated window as the fork.
+4. Order: land #30125 fetcher fix + M5 serve/fetch + #31219/#32246 validation
+   **before** flipping mainnet `CamelliaBlock`. M12 rides the same version.
+5. After all partner nodes are on meta/69, retire meta/66/68 (drop from
+   `ProtocolVersions`) in a later release to make replay protection universal.
+
+---
+
+## 7. Implementation phases (proposed)
+
+- **P1 — meta/69 scaffolding**: `ETH69` const, `ProtocolVersions`,
+  `protocolLengths`, `eth69` handler map (= eth68 initially), dispatch. No
+  behavior change. Build + SPoA smoke.
+- **P2 — M12 replay**: version-aware meta packets with nonce/timestamp, per-peer
+  tracking, reject stale. Unit tests for accept/reject; SPoA (meta/69) + mixed
+  interop.
+- **P3 — M5 serving**: `0x17/0x18` messages + handlers + fetch-trigger + persist +
+  #31219/#32246 validation + #30125 ordering. blob-tx-e2e (valid) + an
+  invalid-sidecar peer-drop test.
+- Each phase: own commits on a phase-2/fork branch, CGO unit tests + SPoA, no node
+  deploy until the coordinated fork window.
+
+## 8. Risks
+
+- Protocol-version change is lockstep: a bug in version gating can partition the
+  partner set. Mitigate with the mixed meta/68↔69 interop test.
+- Replay-protection clock-skew window must tolerate real node clock drift; too
+  tight → false rejects of honest partners.
+- M5 fetch/serve adds p2p surface; bound response size + apply the same
+  ErrInvalidBlob peer-drop as the txpool path.

--- a/docs/meta69-blob-replay-design.md
+++ b/docs/meta69-blob-replay-design.md
@@ -156,6 +156,17 @@ blocker for flipping mainnet `CamelliaBlock`**, not for the current chain.
 - Each phase: own commits on a phase-2/fork branch, CGO unit tests + SPoA, no node
   deploy until the coordinated fork window.
 
+**Implementation status (secfix/mainnet-phase2):** P1 done (e35de7f39),
+P2 done (16f953018), **P3 done (5f8eed04b)** — `GetBlobSidecars`/`BlobSidecars`
+packets, serve via `BlockChain.GetBlobSidecars`, `MissingBlobSidecarFn` import
+trigger + serial fetch loop in `eth/metadium_blobsync.go`, `txpool.ValidateBlobSidecar`
++ versioned-hash/KZG check with peer-drop (#31219), per-block cap inherent (#32246).
+Verified: CGO=0/CGO=1 build, unit tests, SPoA meta/69 PASS=19/0/2, blob-tx-e2e ALL
+PASS, and a cross-node M5 e2e (node2/3 — which never pooled the blob tx — obtain and
+persist the sidecar after importing node1's block). **Remaining:** the #30125 fetcher
+ordering backport is primary-path hardening (the M5 message is the fallback when blob
+txs don't pre-land in the pool), tracked as a separate lower-priority follow-up.
+
 ## 8. Risks
 
 - Protocol-version change is lockstep: a bug in version gating can partition the

--- a/docs/meta69-blob-replay-design.md
+++ b/docs/meta69-blob-replay-design.md
@@ -163,9 +163,11 @@ trigger + serial fetch loop in `eth/metadium_blobsync.go`, `txpool.ValidateBlobS
 + versioned-hash/KZG check with peer-drop (#31219), per-block cap inherent (#32246).
 Verified: CGO=0/CGO=1 build, unit tests, SPoA meta/69 PASS=19/0/2, blob-tx-e2e ALL
 PASS, and a cross-node M5 e2e (node2/3 — which never pooled the blob tx — obtain and
-persist the sidecar after importing node1's block). **Remaining:** the #30125 fetcher
-ordering backport is primary-path hardening (the M5 message is the fallback when blob
-txs don't pre-land in the pool), tracked as a separate lower-priority follow-up.
+persist the sidecar after importing node1's block). The #30125 fetcher-ordering
+backport (commit c152a6e4a) is also landed: arrival-order tx scheduling + blob
+skip-waitlist harden the primary path so blob txs land in the pool before the block
+arrives (the M5 message remains the fallback); the full eth/fetcher suite passes and
+SPoA + blob-tx-e2e + cross-node M5 re-verified with no regression.
 
 ## 8. Risks
 

--- a/docs/sync-policy-and-snapshot-bootstrap.md
+++ b/docs/sync-policy-and-snapshot-bootstrap.md
@@ -1,0 +1,149 @@
+# go-metadium Sync Policy & Snapshot Bootstrap
+
+**Date:** 2026-06-17
+**Author:** Jeffrey Song
+**Applies to:** `fix/pre-mainnet-security` / `secfix/mainnet-phase2` and later
+
+---
+
+## 1. Sync policy: full sync only
+
+go-metadium runs **full sync only**. Snap sync is **not supported** — the upstream
+snap state-healing path (gentrie redesign, PRs #29313/#30258/#33428) is not
+backported to this v1.13.14 base, so the snap path carries known state-integrity
+bugs. The default sync mode is therefore `full` (changed in
+`eth/ethconfig/config.go`).
+
+For fast new-node bring-up, **do not enable snap** — use the snapshot bootstrap
+in §3 instead. It is faster than a full genesis sync and carries no integrity
+risk.
+
+### 1.1 How the policy is surfaced to node operators (defense in depth)
+
+1. **Default value** — `ethconfig.Defaults.SyncMode = downloader.FullSync`. A node
+   started with no `--syncmode` flag runs full. Operators get the safe behavior
+   with zero action. *(done)*
+2. **Launcher / unit files** — every shipped config pins `--syncmode full`:
+   `metadium/scripts/gmet.sh` (default branch), all `tests/**/docker-compose.yml`,
+   and the production systemd units. Keep this explicit so the policy survives a
+   default change. *(already true)*
+3. **Startup guard (recommended, optional)** — reject or loudly warn when an
+   operator passes `--syncmode snap|fast` on the Metadium mainnet/testnet, in
+   `cmd/utils/flags.go` near `SetEthConfig`. Hard-reject is strongest; a WARN that
+   coerces to full is the minimum. *(not yet implemented — see open item)*
+4. **Documentation / release notes** — state the policy in the node-operator
+   README and CHANGELOG: "go-metadium supports full sync only; `--syncmode full`
+   is the default; for fast bring-up use snapshot bootstrap (this document)."
+
+The combination of (1)+(2)+(4) means a normal operator never has to think about
+it; (3) stops a determined operator from silently re-enabling the vulnerable path.
+
+---
+
+## 2. Hard prerequisites for snapshot bootstrap
+
+A snapshot is a file-level copy of one node's chain database into another node.
+It only works when **all** of these match between source and target:
+
+- **DB backend** — LevelDB ↔ LevelDB, or RocksDB ↔ RocksDB. Selected at runtime
+  by `--userocksdb 0` (LevelDB) / `--userocksdb 1` (RocksDB). A LevelDB snapshot
+  **cannot** be loaded by a RocksDB node or vice versa — that needs a full
+  re-sync or a DB-conversion tool, not a copy.
+  - Source map in this fleet: **46 / mykeepin = LevelDB**, **47 = RocksDB**.
+- **Network** — mainnet ↔ mainnet, testnet ↔ testnet (different genesis).
+- **Binary** — same/compatible gmet version (fork rules live in the binary, not
+  the DB). Use the deployed build.
+
+This procedure is for **sync (follower) nodes**. A governance/sealing node also
+needs its own identity and an etcd cluster join — see §4.
+
+---
+
+## 3. Snapshot bootstrap procedure
+
+Layout reference (per node): `<datadir>/geth/chaindata` holds the state DB **and**
+the freezer at `<datadir>/geth/chaindata/ancient` (the bulk of the data — it must
+be copied). Node identity is `<datadir>/geth/nodekey`; accounts are in
+`<datadir>/keystore`. Example datadirs: `/data/gmet-mainnet`, `/data/gmet-testnet`.
+
+### Step 1 — snapshot the SOURCE (consistent copy)
+
+Pick a healthy source with the **same backend + network** as the target.
+
+```bash
+# Graceful stop ONLY — never kill -9 (RocksDB flush can take minutes; an
+# ungraceful stop leaves the DB needing "Head state missing, repairing").
+sudo systemctl stop gmet-<net>        # e.g. gmet-testnet
+#   wait until fully stopped:
+until [ "$(systemctl is-active gmet-<net>)" = inactive ]; do sleep 3; done
+
+# Archive chaindata (includes the ancient/ freezer subdir).
+sudo tar -C /data/gmet-<net>/geth -cf /tmp/chaindata-<net>.tar chaindata
+
+# Bring the source back up immediately.
+sudo systemctl start gmet-<net>
+```
+
+Notes:
+- Downtime = copy time. Pick the least-critical node (e.g. a spare/secondary, or
+  47 which is a test node) so production stays up on the others.
+- Online copy without stopping is possible (`rsync` twice, second pass after a
+  brief stop) but a single live copy of LevelDB/RocksDB files can be inconsistent.
+  Stopping the source is the safe default.
+
+### Step 2 — transfer to the TARGET
+
+```bash
+scp /tmp/chaindata-<net>.tar <target>:/tmp/      # or rsync
+```
+
+### Step 3 — load on the TARGET
+
+```bash
+sudo systemctl stop gmet-<net>          # if running; graceful
+
+# Remove any partial chain DB, then extract the snapshot.
+sudo rm -rf /data/gmet-<net>/geth/chaindata
+sudo tar -C /data/gmet-<net>/geth -xf /tmp/chaindata-<net>.tar
+
+# IMPORTANT: keep the target's OWN nodekey and keystore. We only copied
+# chaindata, so nodekey/keystore are untouched — verify they still exist and are
+# the target's own (two nodes sharing a nodekey = enode collision).
+ls -la /data/gmet-<net>/geth/nodekey
+
+sudo systemctl start gmet-<net>         # --syncmode full, --userocksdb matching backend
+```
+
+### Step 4 — verify
+
+```bash
+# Head should be ~snapshot height, then climb to tip with no BAD BLOCK.
+curl -s -X POST http://127.0.0.1:<rpc> -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}'
+```
+
+- Head starts near the snapshot height and syncs only the gap → fast.
+- Confirm peers > 0 and the block number advances; check the log has no
+  `invalid merkle root` / `BAD BLOCK` for newly imported blocks.
+
+---
+
+## 4. Governance / sealing nodes
+
+Snapshot bootstrap gives a node the **chain data** only. A governance (sealing)
+node additionally needs:
+
+- its **own** governance-member key / enode registered in the governance node set
+  (do **not** reuse another node's nodekey);
+- to **join the etcd cluster** (it auto-joins via `etcdAutoJoin` once it is a
+  recognized governance member; etcd data is per-node, do **not** copy it).
+
+So: bootstrap chain data with §3, then complete governance membership + etcd join
+separately. For pure follower/RPC nodes, §3 alone is sufficient.
+
+---
+
+## Open item
+
+- Startup guard (§1.1.3): add the `--syncmode snap|fast` warn/reject for
+  Metadium networks in `cmd/utils/flags.go`. Tracked as an optional phase-2 task.

--- a/docs/sync-policy-and-snapshot-bootstrap.md
+++ b/docs/sync-policy-and-snapshot-bootstrap.md
@@ -27,10 +27,10 @@ risk.
    `metadium/scripts/gmet.sh` (default branch), all `tests/**/docker-compose.yml`,
    and the production systemd units. Keep this explicit so the policy survives a
    default change. *(already true)*
-3. **Startup guard (recommended, optional)** — reject or loudly warn when an
-   operator passes `--syncmode snap|fast` on the Metadium mainnet/testnet, in
-   `cmd/utils/flags.go` near `SetEthConfig`. Hard-reject is strongest; a WARN that
-   coerces to full is the minimum. *(not yet implemented — see open item)*
+3. **Startup guard (hard-reject)** — a node started with `--syncmode snap|fast`
+   on the Metadium mainnet/testnet exits immediately with a fatal error pointing
+   to this document (`cmd/utils/flags.go`, in `SetEthConfig`). Upstream test
+   networks and `--dev` are exempt. *(implemented)*
 4. **Documentation / release notes** — state the policy in the node-operator
    README and CHANGELOG: "go-metadium supports full sync only; `--syncmode full`
    is the default; for fast bring-up use snapshot bootstrap (this document)."
@@ -140,10 +140,3 @@ node additionally needs:
 
 So: bootstrap chain data with §3, then complete governance membership + etcd join
 separately. For pure follower/RPC nodes, §3 alone is sufficient.
-
----
-
-## Open item
-
-- Startup guard (§1.1.3): add the `--syncmode snap|fast` warn/reject for
-  Metadium networks in `cmd/utils/flags.go`. Tracked as an optional phase-2 task.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -49,7 +49,11 @@ var FullNodeGPO = gasprice.Config{
 
 // Defaults contains default settings for use on the Ethereum main net.
 var Defaults = Config{
-	SyncMode:           downloader.SnapSync,
+	// go-metadium runs full sync only. The snap-sync state-healing path carries
+	// known upstream integrity bugs (gentrie redesign, PRs #29313/#30258/#33428)
+	// that are not backported to this v1.13.14 base, so default new nodes to
+	// full sync rather than leaving them on the vulnerable snap path.
+	SyncMode:           downloader.FullSync,
 	NetworkId:          0, // enable auto configuration of networkID == chainID
 	TxLookupLimit:      2350000,
 	TransactionHistory: 2350000,

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -314,8 +314,9 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 	// Push all the transactions into the pool, tracking underpriced ones to avoid
 	// re-requesting them and dropping the peer in case of malicious transfers.
 	var (
-		added = make([]common.Hash, 0, len(txs))
-		metas = make([]txMetadata, 0, len(txs))
+		added         = make([]common.Hash, 0, len(txs))
+		metas         = make([]txMetadata, 0, len(txs))
+		maliciousBlob bool
 	)
 	// proceed in batches
 	for i := 0; i < len(txs); i += 128 {
@@ -347,6 +348,13 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 			case errors.Is(err, txpool.ErrUnderpriced) || errors.Is(err, txpool.ErrReplaceUnderpriced):
 				underpriced++
 
+			case errors.Is(err, txpool.ErrInvalidBlob):
+				// Cryptographically invalid blob sidecar (KZG proof / commitment /
+				// count). An honest peer never sends this, so flag the peer to be
+				// dropped after the batch. (CVE-2026-22862/22868 hardening)
+				otherreject++
+				maliciousBlob = true
+
 			default:
 				otherreject++
 			}
@@ -365,6 +373,10 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 			time.Sleep(200 * time.Millisecond)
 			log.Debug("Peer delivering stale transactions", "peer", peer, "rejected", otherreject)
 		}
+	}
+	if maliciousBlob {
+		log.Debug("Dropping peer for invalid blob sidecar", "peer", peer)
+		f.dropPeer(peer)
 	}
 	select {
 	case f.cleanup <- &txDelivery{origin: peer, hashes: added, metas: metas, direct: direct}:

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -17,7 +17,6 @@
 package fetcher
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -122,6 +121,15 @@ type txMetadata struct {
 	size uint32 // Transaction size in bytes
 }
 
+// txMetadataWithSeq wraps txMetadata with the announcement's arrival sequence
+// number, so fetches can be scheduled in arrival order to minimize nonce gaps
+// that would otherwise get transactions rejected by the pool (upstream #30125).
+// meta may be nil for pre-eth/68 (meta/66) announcements that carry no type/size.
+type txMetadataWithSeq struct {
+	meta *txMetadata
+	seq  uint64
+}
+
 // txRequest represents an in-flight transaction retrieval request destined to
 // a specific peers.
 type txRequest struct {
@@ -167,18 +175,20 @@ type TxFetcher struct {
 	drop    chan *txDrop
 	quit    chan struct{}
 
+	txSeq uint64 // Monotonic arrival-sequence counter for announcements (fetch ordering, #30125)
+
 	underpriced *lru.Cache[common.Hash, time.Time] // Transactions discarded as too cheap (don't re-fetch)
 
 	// Stage 1: Waiting lists for newly discovered transactions that might be
 	// broadcast without needing explicit request/reply round trips.
-	waitlist  map[common.Hash]map[string]struct{}    // Transactions waiting for an potential broadcast
-	waittime  map[common.Hash]mclock.AbsTime         // Timestamps when transactions were added to the waitlist
-	waitslots map[string]map[common.Hash]*txMetadata // Waiting announcements grouped by peer (DoS protection)
+	waitlist  map[common.Hash]map[string]struct{}           // Transactions waiting for an potential broadcast
+	waittime  map[common.Hash]mclock.AbsTime                // Timestamps when transactions were added to the waitlist
+	waitslots map[string]map[common.Hash]*txMetadataWithSeq // Waiting announcements grouped by peer (DoS protection)
 
 	// Stage 2: Queue of transactions that waiting to be allocated to some peer
 	// to be retrieved directly.
-	announces map[string]map[common.Hash]*txMetadata // Set of announced transactions, grouped by origin peer
-	announced map[common.Hash]map[string]struct{}    // Set of download locations, grouped by transaction hash
+	announces map[string]map[common.Hash]*txMetadataWithSeq // Set of announced transactions, grouped by origin peer
+	announced map[common.Hash]map[string]struct{}           // Set of download locations, grouped by transaction hash
 
 	// Stage 3: Set of transactions currently being retrieved, some which may be
 	// fulfilled and some rescheduled. Note, this step shares 'announces' from the
@@ -216,8 +226,8 @@ func NewTxFetcherForTests(
 		quit:        make(chan struct{}),
 		waitlist:    make(map[common.Hash]map[string]struct{}),
 		waittime:    make(map[common.Hash]mclock.AbsTime),
-		waitslots:   make(map[string]map[common.Hash]*txMetadata),
-		announces:   make(map[string]map[common.Hash]*txMetadata),
+		waitslots:   make(map[string]map[common.Hash]*txMetadataWithSeq),
+		announces:   make(map[string]map[common.Hash]*txMetadataWithSeq),
 		announced:   make(map[common.Hash]map[string]struct{}),
 		fetching:    make(map[common.Hash]string),
 		requests:    make(map[string]*txRequest),
@@ -444,7 +454,20 @@ func (f *TxFetcher) loop() {
 			idleWait := len(f.waittime) == 0
 			_, oldPeer := f.announces[ann.origin]
 
+			// hasBlob tracks whether a blob-tx announcement was added this round so
+			// the wait timer is rescheduled to fetch it immediately (#30125).
+			hasBlob := false
+
+			// nextSeq hands out a monotonically increasing sequence number used to
+			// preserve announcement arrival order when scheduling fetches (#30125).
+			nextSeq := func() uint64 {
+				seq := f.txSeq
+				f.txSeq++
+				return seq
+			}
+
 			for i, hash := range ann.hashes {
+				meta := ann.metas[i]
 				// If the transaction is already downloading, add it to the list
 				// of possible alternates (in case the current retrieval fails) and
 				// also account it for the peer.
@@ -453,9 +476,11 @@ func (f *TxFetcher) loop() {
 
 					// Stage 2 and 3 share the set of origins per tx
 					if announces := f.announces[ann.origin]; announces != nil {
-						announces[hash] = ann.metas[i]
+						announces[hash] = &txMetadataWithSeq{meta: meta, seq: nextSeq()}
 					} else {
-						f.announces[ann.origin] = map[common.Hash]*txMetadata{hash: ann.metas[i]}
+						f.announces[ann.origin] = map[common.Hash]*txMetadataWithSeq{
+							hash: {meta: meta, seq: nextSeq()},
+						}
 					}
 					continue
 				}
@@ -466,9 +491,11 @@ func (f *TxFetcher) loop() {
 
 					// Stage 2 and 3 share the set of origins per tx
 					if announces := f.announces[ann.origin]; announces != nil {
-						announces[hash] = ann.metas[i]
+						announces[hash] = &txMetadataWithSeq{meta: meta, seq: nextSeq()}
 					} else {
-						f.announces[ann.origin] = map[common.Hash]*txMetadata{hash: ann.metas[i]}
+						f.announces[ann.origin] = map[common.Hash]*txMetadataWithSeq{
+							hash: {meta: meta, seq: nextSeq()},
+						}
 					}
 					continue
 				}
@@ -485,24 +512,40 @@ func (f *TxFetcher) loop() {
 					f.waitlist[hash][ann.origin] = struct{}{}
 
 					if waitslots := f.waitslots[ann.origin]; waitslots != nil {
-						waitslots[hash] = ann.metas[i]
+						waitslots[hash] = &txMetadataWithSeq{meta: meta, seq: nextSeq()}
 					} else {
-						f.waitslots[ann.origin] = map[common.Hash]*txMetadata{hash: ann.metas[i]}
+						f.waitslots[ann.origin] = map[common.Hash]*txMetadataWithSeq{
+							hash: {meta: meta, seq: nextSeq()},
+						}
 					}
 					continue
 				}
 				// Transaction unknown to the fetcher, insert it into the waiting list
 				f.waitlist[hash] = map[string]struct{}{ann.origin: {}}
-				f.waittime[hash] = f.clock.Now()
+
+				// Assign the current timestamp as the wait time, but for blob
+				// transactions skip the wait (set the timestamp into the past) so
+				// they are fetched promptly: blob txs are only announced, never
+				// broadcast, so waiting cannot satisfy them (#30125).
+				if meta == nil || meta.kind != types.BlobTxType {
+					f.waittime[hash] = f.clock.Now()
+				} else {
+					hasBlob = true
+					f.waittime[hash] = f.clock.Now() - mclock.AbsTime(txArriveTimeout)
+				}
 
 				if waitslots := f.waitslots[ann.origin]; waitslots != nil {
-					waitslots[hash] = ann.metas[i]
+					waitslots[hash] = &txMetadataWithSeq{meta: meta, seq: nextSeq()}
 				} else {
-					f.waitslots[ann.origin] = map[common.Hash]*txMetadata{hash: ann.metas[i]}
+					f.waitslots[ann.origin] = map[common.Hash]*txMetadataWithSeq{
+						hash: {meta: meta, seq: nextSeq()},
+					}
 				}
 			}
-			// If a new item was added to the waitlist, schedule it into the fetcher
-			if idleWait && len(f.waittime) > 0 {
+			// If a new item was added to the waitlist, schedule it into the fetcher.
+			// A blob announcement forces a reschedule even if the wait set was not
+			// previously idle, so its zero wait time fires right away (#30125).
+			if hasBlob || (idleWait && len(f.waittime) > 0) {
 				f.rescheduleWait(waitTimer, waitTrigger)
 			}
 			// If this peer is new and announced something already queued, maybe
@@ -526,7 +569,7 @@ func (f *TxFetcher) loop() {
 						if announces := f.announces[peer]; announces != nil {
 							announces[hash] = f.waitslots[peer][hash]
 						} else {
-							f.announces[peer] = map[common.Hash]*txMetadata{hash: f.waitslots[peer][hash]}
+							f.announces[peer] = map[common.Hash]*txMetadataWithSeq{hash: f.waitslots[peer][hash]}
 						}
 						delete(f.waitslots[peer], hash)
 						if len(f.waitslots[peer]) == 0 {
@@ -600,7 +643,8 @@ func (f *TxFetcher) loop() {
 			for i, hash := range delivery.hashes {
 				if _, ok := f.waitlist[hash]; ok {
 					for peer, txset := range f.waitslots {
-						if meta := txset[hash]; meta != nil {
+						if entry := txset[hash]; entry != nil && entry.meta != nil {
+							meta := entry.meta
 							if delivery.metas[i].kind != meta.kind {
 								log.Warn("Announced transaction type mismatch", "peer", peer, "tx", hash, "type", delivery.metas[i].kind, "ann", meta.kind)
 								f.dropPeer(peer)
@@ -626,7 +670,8 @@ func (f *TxFetcher) loop() {
 					delete(f.waittime, hash)
 				} else {
 					for peer, txset := range f.announces {
-						if meta := txset[hash]; meta != nil {
+						if entry := txset[hash]; entry != nil && entry.meta != nil {
+							meta := entry.meta
 							if delivery.metas[i].kind != meta.kind {
 								log.Warn("Announced transaction type mismatch", "peer", peer, "tx", hash, "type", delivery.metas[i].kind, "ann", meta.kind)
 								f.dropPeer(peer)
@@ -953,28 +998,27 @@ func (f *TxFetcher) forEachPeer(peers map[string]struct{}, do func(peer string))
 	}
 }
 
-// forEachAnnounce does a range loop over a map of announcements in production,
-// but during testing it does a deterministic sorted random to allow reproducing
-// issues.
-func (f *TxFetcher) forEachAnnounce(announces map[common.Hash]*txMetadata, do func(hash common.Hash, meta *txMetadata) bool) {
-	// If we're running production, use whatever Go's map gives us
-	if f.rand == nil {
-		for hash, meta := range announces {
-			if !do(hash, meta) {
-				return
-			}
-		}
-		return
+// forEachAnnounce loops over the given announcements in arrival (sequence) order,
+// invoking do for each until it returns false. Enforcing arrival ordering
+// minimizes transaction nonce-gaps, which would otherwise cause transactions to
+// be rejected by the txpool (#30125). The meta passed to do may be nil for
+// pre-eth/68 (meta/66) announcements that carry no type/size.
+func (f *TxFetcher) forEachAnnounce(announces map[common.Hash]*txMetadataWithSeq, do func(hash common.Hash, meta *txMetadata) bool) {
+	type announcement struct {
+		hash common.Hash
+		meta *txMetadata
+		seq  uint64
 	}
-	// We're running the test suite, make iteration deterministic
-	list := make([]common.Hash, 0, len(announces))
-	for hash := range announces {
-		list = append(list, hash)
+	// Process announcements by their arrival order
+	list := make([]announcement, 0, len(announces))
+	for hash, entry := range announces {
+		list = append(list, announcement{hash: hash, meta: entry.meta, seq: entry.seq})
 	}
-	sortHashes(list)
-	rotateHashes(list, f.rand.Intn(len(list)))
-	for _, hash := range list {
-		if !do(hash, announces[hash]) {
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].seq < list[j].seq
+	})
+	for i := range list {
+		if !do(list[i].hash, list[i].meta) {
 			return
 		}
 	}
@@ -984,29 +1028,6 @@ func (f *TxFetcher) forEachAnnounce(announces map[common.Hash]*txMetadata, do fu
 // used in tests to simulate random map iteration but keep it deterministic.
 func rotateStrings(slice []string, n int) {
 	orig := make([]string, len(slice))
-	copy(orig, slice)
-
-	for i := 0; i < len(orig); i++ {
-		slice[i] = orig[(i+n)%len(orig)]
-	}
-}
-
-// sortHashes sorts a slice of hashes. This method is only used in tests in order
-// to simulate random map iteration but keep it deterministic.
-func sortHashes(slice []common.Hash) {
-	for i := 0; i < len(slice); i++ {
-		for j := i + 1; j < len(slice); j++ {
-			if bytes.Compare(slice[i][:], slice[j][:]) > 0 {
-				slice[i], slice[j] = slice[j], slice[i]
-			}
-		}
-	}
-}
-
-// rotateHashes rotates the contents of a slice by n steps. This method is only
-// used in tests to simulate random map iteration but keep it deterministic.
-func rotateHashes(slice []common.Hash, n int) {
-	orig := make([]common.Hash, len(slice))
 	copy(orig, slice)
 
 	for i := 0; i < len(orig); i++ {

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -713,7 +713,9 @@ func TestTransactionFetcherMissingRescheduling(t *testing.T) {
 			},
 			// Deliver the middle transaction requested, the one before which
 			// should be dropped and the one after re-requested.
-			doTxEnqueue{peer: "A", txs: []*types.Transaction{testTxs[0]}, direct: true}, // This depends on the deterministic random
+			// #30125: with arrival-order fetching the request is [0,1,2]; deliver
+			// the middle one so the prior is dropped and the next re-requested.
+			doTxEnqueue{peer: "A", txs: []*types.Transaction{testTxs[1]}, direct: true},
 			isScheduled{
 				tracking: map[string][]common.Hash{
 					"A": {testTxsHashes[2]},
@@ -1022,7 +1024,9 @@ func TestTransactionFetcherRateLimiting(t *testing.T) {
 					"A": hashes,
 				},
 				fetching: map[string][]common.Hash{
-					"A": hashes[30315 : 30315+maxTxRetrievals],
+					// #30125: fetches now follow announcement arrival order, so the
+					// first maxTxRetrievals announced hashes are requested.
+					"A": hashes[:maxTxRetrievals],
 				},
 			},
 		},
@@ -1082,9 +1086,11 @@ func TestTransactionFetcherBandwidthLimiting(t *testing.T) {
 					},
 				},
 				fetching: map[string][]common.Hash{
-					"A": {{0x02}, {0x03}, {0x04}},
-					"B": {{0x06}},
-					"C": {{0x08}},
+					// #30125: fetches follow announcement arrival order, so the
+					// lowest-seq hashes within each peer's size budget are taken.
+					"A": {{0x01}, {0x02}, {0x03}},
+					"B": {{0x05}},
+					"C": {{0x07}},
 				},
 			},
 		},
@@ -1139,8 +1145,9 @@ func TestTransactionFetcherDoSProtection(t *testing.T) {
 					"B": hashesB[:maxTxAnnounces/2-1],
 				},
 				fetching: map[string][]common.Hash{
-					"A": hashesA[30315 : 30315+maxTxRetrievals],
-					"B": hashesB[14969 : 14969+maxTxRetrievals],
+					// #30125: fetches now follow announcement arrival order.
+					"A": hashesA[:maxTxRetrievals],
+					"B": hashesB[:maxTxRetrievals],
 				},
 			},
 			// Ensure that adding even one more hash results in dropping the hash
@@ -1157,8 +1164,9 @@ func TestTransactionFetcherDoSProtection(t *testing.T) {
 					"B": hashesB[:maxTxAnnounces/2-1],
 				},
 				fetching: map[string][]common.Hash{
-					"A": hashesA[30315 : 30315+maxTxRetrievals],
-					"B": hashesB[14969 : 14969+maxTxRetrievals],
+					// #30125: fetches now follow announcement arrival order.
+					"A": hashesA[:maxTxRetrievals],
+					"B": hashesB[:maxTxRetrievals],
 				},
 			},
 		},
@@ -1726,9 +1734,10 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 					continue
 				}
 				for _, ann := range announces {
-					if meta, ok := waiting[ann.hash]; !ok {
+					if entry, ok := waiting[ann.hash]; !ok {
 						t.Errorf("step %d, peer %s: hash %x missing from waitslots", i, peer, ann.hash)
 					} else {
+						meta := entry.meta
 						if (meta == nil && (ann.kind != nil || ann.size != nil)) ||
 							(meta != nil && (ann.kind == nil || ann.size == nil)) ||
 							(meta != nil && (meta.kind != *ann.kind || meta.size != *ann.size)) {
@@ -1736,10 +1745,10 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 						}
 					}
 				}
-				for hash, meta := range waiting {
+				for hash, entry := range waiting {
 					ann := announce{hash: hash}
-					if meta != nil {
-						ann.kind, ann.size = &meta.kind, &meta.size
+					if entry.meta != nil {
+						ann.kind, ann.size = &entry.meta.kind, &entry.meta.size
 					}
 					if !containsAnnounce(announces, ann) {
 						t.Errorf("step %d, peer %s: announce %v extra in waitslots", i, peer, ann)
@@ -1795,9 +1804,10 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 					continue
 				}
 				for _, ann := range announces {
-					if meta, ok := scheduled[ann.hash]; !ok {
+					if entry, ok := scheduled[ann.hash]; !ok {
 						t.Errorf("step %d, peer %s: hash %x missing from announces", i, peer, ann.hash)
 					} else {
+						meta := entry.meta
 						if (meta == nil && (ann.kind != nil || ann.size != nil)) ||
 							(meta != nil && (ann.kind == nil || ann.size == nil)) ||
 							(meta != nil && (meta.kind != *ann.kind || meta.size != *ann.size)) {
@@ -1805,10 +1815,10 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 						}
 					}
 				}
-				for hash, meta := range scheduled {
+				for hash, entry := range scheduled {
 					ann := announce{hash: hash}
-					if meta != nil {
-						ann.kind, ann.size = &meta.kind, &meta.size
+					if entry.meta != nil {
+						ann.kind, ann.size = &entry.meta.kind, &entry.meta.size
 					}
 					if !containsAnnounce(announces, ann) {
 						t.Errorf("step %d, peer %s: announce %x extra in announces", i, peer, hash)

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -43,6 +43,9 @@ var (
 // The maximum number of topic criteria allowed, vm.LOG4 - vm.LOG0
 const maxTopics = 4
 
+// The maximum number of allowed topics within a topic criteria
+const maxSubTopics = 1000
+
 // filter is a helper struct that holds meta information over the filter type
 // and associated subscription in the event system.
 type filter struct {
@@ -546,6 +549,10 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	if len(raw.Topics) > maxTopics {
+		return errExceedMaxTopics
+	}
+
 	// topics is an array consisting of strings and/or arrays of strings.
 	// JSON null values are converted to common.Hash{} and ignored by the filter manager.
 	if len(raw.Topics) > 0 {
@@ -565,6 +572,9 @@ func (args *FilterCriteria) UnmarshalJSON(data []byte) error {
 
 			case []interface{}:
 				// or case e.g. [null, "topic0", "topic1"]
+				if len(topic) > maxSubTopics {
+					return errExceedMaxTopics
+				}
 				for _, rawTopic := range topic {
 					if rawTopic == nil {
 						// null component, match all

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -123,6 +123,14 @@ type handler struct {
 
 	requiredBlocks map[uint64]common.Hash
 
+	// meta/69 blob-sidecar fetching (M5). blobFetchCh queues blocks whose blob
+	// sidecars were missing locally on import; blobPending correlates in-flight
+	// GetBlobSidecars requests with their replies by request id.
+	blobFetchCh  chan *types.Block
+	blobReqLock  sync.Mutex
+	blobPending  map[uint64]*blobSidecarRequest
+	blobReqIDGen atomic.Uint64
+
 	// channels for fetcher, syncer, txsyncLoop
 	quitSync chan struct{}
 
@@ -277,6 +285,15 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		return h.txpool.Add(txs, false, false)
 	}
 	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, addTxs, fetchTx, h.removePeer)
+
+	// meta/69 blob-sidecar fetching (M5): wire the import-time miss callback and
+	// the request-correlation map. Blob txs only appear once Camellia is active,
+	// and the fetch loop no-ops without meta/69 peers, so this is inert on
+	// pre-Camellia / legacy-only networks.
+	h.blobFetchCh = make(chan *types.Block, blobSidecarMaxQueue)
+	h.blobPending = make(map[uint64]*blobSidecarRequest)
+	h.chain.MissingBlobSidecarFn = h.enqueueBlobSidecarFetch
+
 	h.chainSync = newChainSyncer(h)
 	return h, nil
 }
@@ -527,6 +544,10 @@ func (h *handler) Start(maxPeers int) {
 	// start peer handler tracker
 	h.wg.Add(1)
 	go h.protoTracker()
+
+	// fetch blob sidecars missing after block import (meta/69 M5)
+	h.wg.Add(1)
+	go h.blobSidecarLoop()
 }
 
 func (h *handler) Stop() {

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -81,6 +81,11 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 	case *eth.PooledTransactionsResponse:
 		return h.txFetcher.Enqueue(peer.ID(), *packet, true)
 
+	case *eth.BlobSidecarsPacket:
+		// meta/69 blob-sidecar reply (M5): correlate with the in-flight request.
+		(*handler)(h).deliverBlobSidecars(packet.RequestId, packet.Sidecars)
+		return nil
+
 	default:
 		return fmt.Errorf("unexpected eth packet type: %T", packet)
 	}

--- a/eth/metadium_blobsync.go
+++ b/eth/metadium_blobsync.go
@@ -1,0 +1,236 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+// meta/69 blob-sidecar fetching (M5).
+//
+// A node that learns a block via propagation but never mempool-fetched its blob
+// txs ends up with permanently missing sidecar data availability
+// (core/blockchain.go: BlobSidecarFn returns nil → not stored). This file backs
+// the data-availability gap: when block import reports missing sidecars
+// (MissingBlobSidecarFn), it fetches them from a meta/69 peer, validates them
+// against the block's blob txs, and persists them. It is the fallback for the
+// primary in-pool path; it engages only with meta/69 peers and only for blocks
+// that actually carry blob txs (i.e. post-Camellia).
+
+import (
+	"errors"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	// blobSidecarFetchTimeout bounds how long a single GetBlobSidecars request
+	// waits for its reply before trying another peer.
+	blobSidecarFetchTimeout = 10 * time.Second
+
+	// blobSidecarMaxQueue bounds the import-time fetch queue. Overflow is dropped
+	// (logged) rather than blocking the block-import path.
+	blobSidecarMaxQueue = 256
+
+	// blobSidecarMaxAttempts bounds the number of distinct peers tried per block.
+	blobSidecarMaxAttempts = 4
+)
+
+var (
+	errBlobFetchTimeout = errors.New("blob sidecar request timed out")
+	errBlobFetchQuit    = errors.New("shutting down")
+)
+
+// blobSidecarRequest is an in-flight GetBlobSidecars request awaiting its reply.
+type blobSidecarRequest struct {
+	deliver chan []*types.BlobTxSidecar
+}
+
+// enqueueBlobSidecarFetch is the core.BlockChain.MissingBlobSidecarFn callback,
+// invoked from the block-import path. It must not block, so it enqueues without
+// waiting and drops on a full queue (the data can be re-fetched later).
+func (h *handler) enqueueBlobSidecarFetch(block *types.Block) {
+	select {
+	case h.blobFetchCh <- block:
+	default:
+		log.Warn("Blob sidecar fetch queue full, dropping", "number", block.NumberU64(), "hash", block.Hash())
+	}
+}
+
+// blobSidecarLoop services queued blob-sidecar fetches serially. Blob blocks are
+// rare on Metadium (<=2 blobs/block) so serial fetching keeps the resource
+// footprint bounded; per-block stalls are capped by blobSidecarFetchTimeout.
+func (h *handler) blobSidecarLoop() {
+	defer h.wg.Done()
+	for {
+		select {
+		case <-h.quitSync:
+			return
+		case block := <-h.blobFetchCh:
+			h.fetchBlobSidecars(block)
+		}
+	}
+}
+
+// fetchBlobSidecars obtains and persists the blob sidecars for a block from a
+// meta/69 peer, validating the reply and dropping peers that return bad data.
+func (h *handler) fetchBlobSidecars(block *types.Block) {
+	// Collect the block's blob txs in order; the reply must line up with them.
+	var blobTxs []*types.Transaction
+	for _, tx := range block.Transactions() {
+		if tx.Type() == types.BlobTxType {
+			blobTxs = append(blobTxs, tx)
+		}
+	}
+	if len(blobTxs) == 0 {
+		return
+	}
+	// Skip if a complete set was persisted in the meantime (e.g. via the pool).
+	if existing := h.chain.GetBlobSidecars(block.Hash()); len(existing) >= len(blobTxs) {
+		return
+	}
+	tried := make(map[string]struct{})
+	for attempt := 0; attempt < blobSidecarMaxAttempts; attempt++ {
+		select {
+		case <-h.quitSync:
+			return
+		default:
+		}
+		peer := h.randomBlobSidecarPeer(tried)
+		if peer == nil {
+			log.Debug("No meta/69 peer to fetch blob sidecars from", "number", block.NumberU64(), "hash", block.Hash())
+			return
+		}
+		tried[peer.ID()] = struct{}{}
+
+		sidecars, err := h.requestBlobSidecars(peer, block.Hash())
+		if err != nil {
+			if errors.Is(err, errBlobFetchQuit) {
+				return
+			}
+			peer.Log().Debug("Blob sidecar request failed", "number", block.NumberU64(), "err", err)
+			continue
+		}
+		if err := validateBlobSidecarsForBlock(blobTxs, sidecars); err != nil {
+			// Structurally or cryptographically invalid reply: drop the peer (#31219).
+			peer.Log().Warn("Dropping peer for invalid blob sidecars", "number", block.NumberU64(), "err", err)
+			h.removePeer(peer.ID())
+			continue
+		}
+		rawdb.WriteBlobSidecars(h.database, block.Hash(), block.NumberU64(), sidecars)
+		log.Debug("Fetched missing blob sidecars", "number", block.NumberU64(), "hash", block.Hash(), "blobs", len(sidecars))
+		return
+	}
+	log.Debug("Gave up fetching blob sidecars", "number", block.NumberU64(), "hash", block.Hash())
+}
+
+// requestBlobSidecars sends a single-block GetBlobSidecars request and waits for
+// the correlated reply, bounded by blobSidecarFetchTimeout.
+func (h *handler) requestBlobSidecars(peer *ethPeer, hash common.Hash) ([]*types.BlobTxSidecar, error) {
+	id := h.blobReqIDGen.Add(1)
+	req := &blobSidecarRequest{deliver: make(chan []*types.BlobTxSidecar, 1)}
+
+	h.blobReqLock.Lock()
+	h.blobPending[id] = req
+	h.blobReqLock.Unlock()
+	defer func() {
+		h.blobReqLock.Lock()
+		delete(h.blobPending, id)
+		h.blobReqLock.Unlock()
+	}()
+
+	if err := peer.RequestBlobSidecars(id, []common.Hash{hash}); err != nil {
+		return nil, err
+	}
+	timer := time.NewTimer(blobSidecarFetchTimeout)
+	defer timer.Stop()
+	select {
+	case sidecars := <-req.deliver:
+		return sidecars, nil
+	case <-timer.C:
+		return nil, errBlobFetchTimeout
+	case <-h.quitSync:
+		return nil, errBlobFetchQuit
+	}
+}
+
+// deliverBlobSidecars correlates a BlobSidecars reply with its pending request.
+// It is called from the peer message-handling path (ethHandler.Handle). Each
+// request asks for a single block hash, so only the first sidecar slice is used.
+func (h *handler) deliverBlobSidecars(id uint64, sidecars [][]*types.BlobTxSidecar) {
+	h.blobReqLock.Lock()
+	req := h.blobPending[id]
+	h.blobReqLock.Unlock()
+	if req == nil {
+		return
+	}
+	var sc []*types.BlobTxSidecar
+	if len(sidecars) > 0 {
+		sc = sidecars[0]
+	}
+	select {
+	case req.deliver <- sc:
+	default:
+	}
+}
+
+// randomBlobSidecarPeer returns a connected meta/69 peer not already tried for
+// this block, or nil if none are available.
+func (h *handler) randomBlobSidecarPeer(tried map[string]struct{}) *ethPeer {
+	for _, p := range h.peers.peerList() {
+		if p.Version() < eth.ETH69 {
+			continue
+		}
+		if _, ok := tried[p.ID()]; ok {
+			continue
+		}
+		return p
+	}
+	return nil
+}
+
+// validateBlobSidecarsForBlock checks a received sidecar set against the block's
+// ordered blob txs: the counts must match, each sidecar's versioned hashes must
+// equal the corresponding tx's, and each sidecar must pass KZG/commitment
+// verification. The block's blob txs were already consensus-validated, so the
+// per-block blob count is inherently bounded (#32246) by what the block carries.
+func validateBlobSidecarsForBlock(blobTxs []*types.Transaction, sidecars []*types.BlobTxSidecar) error {
+	if len(sidecars) != len(blobTxs) {
+		return errors.New("blob sidecar count mismatch")
+	}
+	for i, tx := range blobTxs {
+		sc := sidecars[i]
+		if sc == nil {
+			return errors.New("nil blob sidecar")
+		}
+		hashes := tx.BlobHashes()
+		if len(sc.BlobHashes) != len(hashes) {
+			return errors.New("blob sidecar versioned-hash count mismatch")
+		}
+		for j, want := range hashes {
+			if sc.BlobHashes[j] != want {
+				return errors.New("blob sidecar versioned-hash mismatch")
+			}
+		}
+		if err := txpool.ValidateBlobSidecar(hashes, sc); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/eth/metadium_blobsync_test.go
+++ b/eth/metadium_blobsync_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/holiman/uint256"
+)
+
+var (
+	testBlob          = kzg4844.Blob{}
+	testBlobCommit, _ = kzg4844.BlobToCommitment(testBlob)
+	testBlobProof, _  = kzg4844.ComputeBlobProof(testBlob, testBlobCommit)
+	testBlobVHash     = kzg4844.CalcBlobHashV1(sha256.New(), &testBlobCommit)
+)
+
+// newTestBlobTx builds a blob transaction carrying the given versioned hashes.
+func newTestBlobTx(hashes []common.Hash) *types.Transaction {
+	return types.NewTx(&types.BlobTx{
+		ChainID:    uint256.NewInt(1),
+		BlobHashes: hashes,
+	})
+}
+
+// newValidSidecar builds a sidecar that matches a single empty blob.
+func newValidSidecar() *types.BlobTxSidecar {
+	return &types.BlobTxSidecar{
+		Blobs:       [][]byte{testBlob[:]},
+		Commitments: [][]byte{testBlobCommit[:]},
+		Proofs:      [][]byte{testBlobProof[:]},
+		BlobHashes:  []common.Hash{testBlobVHash},
+	}
+}
+
+func TestValidateBlobSidecarsForBlock(t *testing.T) {
+	blobTx := newTestBlobTx([]common.Hash{testBlobVHash})
+
+	// Happy path: one blob tx, one matching valid sidecar.
+	if err := validateBlobSidecarsForBlock([]*types.Transaction{blobTx}, []*types.BlobTxSidecar{newValidSidecar()}); err != nil {
+		t.Fatalf("valid sidecar rejected: %v", err)
+	}
+
+	// Count mismatch: more txs than sidecars.
+	if err := validateBlobSidecarsForBlock([]*types.Transaction{blobTx, blobTx}, []*types.BlobTxSidecar{newValidSidecar()}); err == nil {
+		t.Fatal("expected error on sidecar count mismatch")
+	}
+
+	// Nil sidecar entry.
+	if err := validateBlobSidecarsForBlock([]*types.Transaction{blobTx}, []*types.BlobTxSidecar{nil}); err == nil {
+		t.Fatal("expected error on nil sidecar")
+	}
+
+	// Versioned-hash mismatch: sidecar advertises a different hash than the tx.
+	badHash := newValidSidecar()
+	badHash.BlobHashes = []common.Hash{{0xde, 0xad}}
+	if err := validateBlobSidecarsForBlock([]*types.Transaction{blobTx}, []*types.BlobTxSidecar{badHash}); err == nil {
+		t.Fatal("expected error on versioned-hash mismatch")
+	}
+
+	// Tampered proof: KZG verification must fail (ValidateBlobSidecar).
+	badProof := newValidSidecar()
+	tampered := make([]byte, len(badProof.Proofs[0]))
+	copy(tampered, badProof.Proofs[0])
+	tampered[0] ^= 0xff
+	badProof.Proofs[0] = tampered
+	if err := validateBlobSidecarsForBlock([]*types.Transaction{blobTx}, []*types.BlobTxSidecar{badProof}); err == nil {
+		t.Fatal("expected error on tampered KZG proof")
+	}
+}

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -184,6 +184,33 @@ var eth68 = map[uint64]msgHandler{
 	TransactionsExMsg: handleTransactionsEx,
 }
 
+// eth69 ("meta/69") bundles blob-sidecar serving (M5) and meta-message replay
+// protection (M12). For P1 (scaffolding) it mirrors eth68; P2 replaces the meta
+// handlers with replay-aware variants and P3 adds the blob-sidecar handlers
+// (GetBlobSidecarsMsg / BlobSidecarsMsg). Kept as a distinct map so those phases
+// can diverge from eth68 without affecting meta/68 peers.
+var eth69 = map[uint64]msgHandler{
+	NewBlockHashesMsg:             handleNewBlockhashes,
+	NewBlockMsg:                   handleNewBlock,
+	TransactionsMsg:               handleTransactions,
+	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes,
+	GetBlockHeadersMsg:            handleGetBlockHeaders,
+	BlockHeadersMsg:               handleBlockHeaders,
+	GetBlockBodiesMsg:             handleGetBlockBodies,
+	BlockBodiesMsg:                handleBlockBodies,
+	GetReceiptsMsg:                handleGetReceipts,
+	ReceiptsMsg:                   handleReceipts,
+	GetPooledTransactionsMsg:      handleGetPooledTransactions,
+	PooledTransactionsMsg:         handlePooledTransactions,
+	// Metadium extensions
+	GetPendingTxsMsg:  handleGetPendingTxs,
+	GetStatusExMsg:    handleGetStatusEx,
+	StatusExMsg:       handleStatusEx,
+	EtcdAddMemberMsg:  handleEtcdAddMember,
+	EtcdClusterMsg:    handleEtcdCluster,
+	TransactionsExMsg: handleTransactionsEx,
+}
+
 // eth66 is like eth68 but uses the old NewPooledTransactionHashes format (hashes only,
 // no type/size) and accepts GetNodeData/NodeData from peers that may still send them.
 var eth66 = map[uint64]msgHandler{
@@ -224,7 +251,9 @@ func handleMessage(backend Backend, peer *Peer) error {
 	defer msg.Discard()
 
 	var handlers map[uint64]msgHandler
-	if peer.Version() >= ETH68 {
+	if peer.Version() >= ETH69 {
+		handlers = eth69
+	} else if peer.Version() >= ETH68 {
 		handlers = eth68
 	} else {
 		handlers = eth66

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -209,6 +209,9 @@ var eth69 = map[uint64]msgHandler{
 	EtcdAddMemberMsg:  handleEtcdAddMember69,
 	EtcdClusterMsg:    handleEtcdCluster69,
 	TransactionsExMsg: handleTransactionsEx,
+	// Blob-sidecar serving (M5, meta/69 only)
+	GetBlobSidecarsMsg: handleGetBlobSidecars69,
+	BlobSidecarsMsg:    handleBlobSidecars69,
 }
 
 // eth66 is like eth68 but uses the old NewPooledTransactionHashes format (hashes only,

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -202,12 +202,12 @@ var eth69 = map[uint64]msgHandler{
 	ReceiptsMsg:                   handleReceipts,
 	GetPooledTransactionsMsg:      handleGetPooledTransactions,
 	PooledTransactionsMsg:         handlePooledTransactions,
-	// Metadium extensions
+	// Metadium extensions (meta/69: replay-protected meta handlers, M12)
 	GetPendingTxsMsg:  handleGetPendingTxs,
-	GetStatusExMsg:    handleGetStatusEx,
-	StatusExMsg:       handleStatusEx,
-	EtcdAddMemberMsg:  handleEtcdAddMember,
-	EtcdClusterMsg:    handleEtcdCluster,
+	GetStatusExMsg:    handleGetStatusEx69,
+	StatusExMsg:       handleStatusEx69,
+	EtcdAddMemberMsg:  handleEtcdAddMember69,
+	EtcdClusterMsg:    handleEtcdCluster69,
 	TransactionsExMsg: handleTransactionsEx,
 }
 

--- a/eth/protocols/eth/metadium_blob_test.go
+++ b/eth/protocols/eth/metadium_blob_test.go
@@ -1,0 +1,75 @@
+package eth
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// TestBlobSidecarsPacketRoundtrip checks that the meta/69 blob-sidecar request
+// and reply packets (M5) survive an RLP encode/decode roundtrip, including the
+// positional, possibly-nil per-block sidecar slices.
+func TestBlobSidecarsPacketRoundtrip(t *testing.T) {
+	req := &GetBlobSidecarsPacket{
+		RequestId: 42,
+		Hashes:    []common.Hash{{0x01}, {0x02}},
+	}
+	enc, err := rlp.EncodeToBytes(req)
+	if err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+	var gotReq GetBlobSidecarsPacket
+	if err := rlp.DecodeBytes(enc, &gotReq); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if gotReq.RequestId != req.RequestId || len(gotReq.Hashes) != 2 || gotReq.Hashes[1] != (common.Hash{0x02}) {
+		t.Fatalf("request roundtrip mismatch: %+v", gotReq)
+	}
+
+	res := &BlobSidecarsPacket{
+		RequestId: 42,
+		Sidecars: [][]*types.BlobTxSidecar{
+			{
+				{
+					Blobs:       [][]byte{{0xaa}},
+					Commitments: [][]byte{{0xbb}},
+					Proofs:      [][]byte{{0xcc}},
+					BlobHashes:  []common.Hash{{0xdd}},
+				},
+			},
+			nil, // server did not have the second block
+		},
+	}
+	enc, err = rlp.EncodeToBytes(res)
+	if err != nil {
+		t.Fatalf("encode reply: %v", err)
+	}
+	var gotRes BlobSidecarsPacket
+	if err := rlp.DecodeBytes(enc, &gotRes); err != nil {
+		t.Fatalf("decode reply: %v", err)
+	}
+	if gotRes.RequestId != res.RequestId {
+		t.Fatalf("reply request id mismatch: %d", gotRes.RequestId)
+	}
+	if len(gotRes.Sidecars) != 2 {
+		t.Fatalf("reply block count mismatch: %d", len(gotRes.Sidecars))
+	}
+	if len(gotRes.Sidecars[0]) != 1 || gotRes.Sidecars[0][0].BlobHashes[0] != (common.Hash{0xdd}) {
+		t.Fatalf("reply first block sidecar mismatch: %+v", gotRes.Sidecars[0])
+	}
+	if len(gotRes.Sidecars[1]) != 0 {
+		t.Fatalf("reply second block should be empty, got: %+v", gotRes.Sidecars[1])
+	}
+}
+
+// TestBlobSidecarPacketKind verifies the message codes are wired correctly.
+func TestBlobSidecarPacketKind(t *testing.T) {
+	if (&GetBlobSidecarsPacket{}).Kind() != GetBlobSidecarsMsg {
+		t.Fatal("GetBlobSidecarsPacket kind mismatch")
+	}
+	if (&BlobSidecarsPacket{}).Kind() != BlobSidecarsMsg {
+		t.Fatal("BlobSidecarsPacket kind mismatch")
+	}
+}

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -8,6 +8,19 @@ import (
 	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
 )
 
+// Concurrency caps for the asynchronous Metadium message handlers below. Each
+// handler spawns a goroutine per inbound message; without a bound, a compromised
+// partner (these messages are IsPartner-gated) could flood StatusEx/EtcdCluster
+// and exhaust memory through unbounded goroutine creation (audit finding M11).
+// When the cap is reached the message is dropped instead of queued: status
+// gossip is periodic and etcd-cluster/join messages are retried, so dropping
+// under flood is safe and self-healing. Caps are sized well above the expected
+// governance member count so normal operation never drops.
+var (
+	statusExSem = make(chan struct{}, 128)
+	etcdSem     = make(chan struct{}, 16)
+)
+
 func handleGetPendingTxs(backend Backend, msg Decoder, peer *Peer) error {
 	// not supported, just ignore it.
 	return nil
@@ -18,7 +31,13 @@ func handleGetStatusEx(backend Backend, msg Decoder, peer *Peer) error {
 		return nil
 	}
 
+	select {
+	case statusExSem <- struct{}{}:
+	default:
+		return nil // concurrency cap reached, drop under flood
+	}
 	go func() {
+		defer func() { <-statusExSem }()
 		statusEx := metaapi.GetMinerStatus()
 		if statusEx == nil {
 			// ignore the error, most likely server is shutting down
@@ -43,7 +62,13 @@ func handleStatusEx(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 
+	select {
+	case statusExSem <- struct{}{}:
+	default:
+		return nil // concurrency cap reached, drop under flood
+	}
 	go func() {
+		defer func() { <-statusExSem }()
 		if _, td := peer.Head(); status.LatestBlockTd.Cmp(td) > 0 {
 			peer.SetHead(status.LatestBlockHash, status.LatestBlockTd)
 		}
@@ -58,7 +83,13 @@ func handleEtcdAddMember(backend Backend, msg Decoder, peer *Peer) error {
 		return nil
 	}
 
+	select {
+	case etcdSem <- struct{}{}:
+	default:
+		return nil // concurrency cap reached, drop under flood
+	}
 	go func() {
+		defer func() { <-etcdSem }()
 		cluster, _ := metaapi.EtcdAddMember(peer.ID())
 		if err := peer.SendEtcdCluster(cluster); err != nil {
 			// ignore the error
@@ -77,7 +108,15 @@ func handleEtcdCluster(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 
-	go metaapi.GotEtcdCluster(cluster)
+	select {
+	case etcdSem <- struct{}{}:
+	default:
+		return nil // concurrency cap reached, drop under flood
+	}
+	go func() {
+		defer func() { <-etcdSem }()
+		metaapi.GotEtcdCluster(cluster)
+	}()
 
 	return nil
 }

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -30,11 +30,11 @@ func handleGetPendingTxs(backend Backend, msg Decoder, peer *Peer) error {
 	return nil
 }
 
-func handleGetStatusEx(backend Backend, msg Decoder, peer *Peer) error {
-	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
-		return nil
-	}
+// --- shared processing cores (used by both legacy and meta/69 handlers) ---
 
+// serveStatusEx sends this node's miner status back to the peer (response to a
+// GetStatusEx request), bounded by the status concurrency cap.
+func serveStatusEx(backend Backend, peer *Peer) error {
 	select {
 	case statusExSem <- struct{}{}:
 	default:
@@ -53,19 +53,11 @@ func handleGetStatusEx(backend Backend, msg Decoder, peer *Peer) error {
 			// ignore the error
 		}
 	}()
-
 	return nil
 }
 
-func handleStatusEx(backend Backend, msg Decoder, peer *Peer) error {
-	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
-		return nil
-	}
-	var status metaapi.MetadiumMinerStatus
-	if err := msg.Decode(&status); err != nil {
-		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
-	}
-
+// applyStatusEx applies a received miner status (head update + delivery).
+func applyStatusEx(backend Backend, peer *Peer, status *metaapi.MetadiumMinerStatus) error {
 	select {
 	case statusExSem <- struct{}{}:
 	default:
@@ -76,17 +68,14 @@ func handleStatusEx(backend Backend, msg Decoder, peer *Peer) error {
 		if _, td := peer.Head(); status.LatestBlockTd.Cmp(td) > 0 {
 			peer.SetHead(status.LatestBlockHash, status.LatestBlockTd)
 		}
-		metaapi.GotStatusEx(&status)
+		metaapi.GotStatusEx(status)
 	}()
-
 	return nil
 }
 
-func handleEtcdAddMember(backend Backend, msg Decoder, peer *Peer) error {
-	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
-		return nil
-	}
-
+// serveEtcdAddMember adds the peer to the etcd cluster and replies with the
+// resulting cluster, bounded by the add-member concurrency cap.
+func serveEtcdAddMember(peer *Peer) error {
 	select {
 	case etcdAddSem <- struct{}{}:
 	default:
@@ -99,8 +88,48 @@ func handleEtcdAddMember(backend Backend, msg Decoder, peer *Peer) error {
 			// ignore the error
 		}
 	}()
-
 	return nil
+}
+
+// applyEtcdCluster feeds a received etcd cluster string into self-healing.
+func applyEtcdCluster(cluster string) error {
+	select {
+	case etcdClusterSem <- struct{}{}:
+	default:
+		return nil // concurrency cap reached, drop under flood
+	}
+	go func() {
+		defer func() { <-etcdClusterSem }()
+		metaapi.GotEtcdCluster(cluster)
+	}()
+	return nil
+}
+
+// --- legacy (meta/66, meta/68) handlers ---
+
+func handleGetStatusEx(backend Backend, msg Decoder, peer *Peer) error {
+	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
+		return nil
+	}
+	return serveStatusEx(backend, peer)
+}
+
+func handleStatusEx(backend Backend, msg Decoder, peer *Peer) error {
+	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
+		return nil
+	}
+	var status metaapi.MetadiumMinerStatus
+	if err := msg.Decode(&status); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	return applyStatusEx(backend, peer, &status)
+}
+
+func handleEtcdAddMember(backend Backend, msg Decoder, peer *Peer) error {
+	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
+		return nil
+	}
+	return serveEtcdAddMember(peer)
 }
 
 func handleEtcdCluster(backend Backend, msg Decoder, peer *Peer) error {
@@ -111,18 +140,73 @@ func handleEtcdCluster(backend Backend, msg Decoder, peer *Peer) error {
 	if err := msg.Decode(&cluster); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
+	return applyEtcdCluster(cluster)
+}
 
-	select {
-	case etcdClusterSem <- struct{}{}:
-	default:
-		return nil // concurrency cap reached, drop under flood
+// --- meta/69 handlers (M12 replay protection) ---
+//
+// Each decodes the replay-protected packet, rejects stale/replayed frames
+// (silently dropping rather than disconnecting, to avoid false positives from
+// clock skew or reordering), then runs the shared processing core.
+
+func handleGetStatusEx69(backend Backend, msg Decoder, peer *Peer) error {
+	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
+		return nil
 	}
-	go func() {
-		defer func() { <-etcdClusterSem }()
-		metaapi.GotEtcdCluster(cluster)
-	}()
+	var pkt GetStatusEx69Packet
+	if err := msg.Decode(&pkt); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.acceptMetaReplay(pkt.Nonce, pkt.Timestamp) {
+		peer.Log().Debug("Dropping replayed meta GetStatusEx", "nonce", pkt.Nonce)
+		return nil
+	}
+	return serveStatusEx(backend, peer)
+}
 
-	return nil
+func handleStatusEx69(backend Backend, msg Decoder, peer *Peer) error {
+	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
+		return nil
+	}
+	var pkt StatusEx69Packet
+	if err := msg.Decode(&pkt); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.acceptMetaReplay(pkt.Nonce, pkt.Timestamp) {
+		peer.Log().Debug("Dropping replayed meta StatusEx", "nonce", pkt.Nonce)
+		return nil
+	}
+	return applyStatusEx(backend, peer, &pkt.Status)
+}
+
+func handleEtcdAddMember69(backend Backend, msg Decoder, peer *Peer) error {
+	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
+		return nil
+	}
+	var pkt EtcdAddMember69Packet
+	if err := msg.Decode(&pkt); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.acceptMetaReplay(pkt.Nonce, pkt.Timestamp) {
+		peer.Log().Debug("Dropping replayed meta EtcdAddMember", "nonce", pkt.Nonce)
+		return nil
+	}
+	return serveEtcdAddMember(peer)
+}
+
+func handleEtcdCluster69(backend Backend, msg Decoder, peer *Peer) error {
+	if !metaminer.AmPartner() || !metaminer.IsPartner(peer.ID()) {
+		return nil
+	}
+	var pkt EtcdCluster69Packet
+	if err := msg.Decode(&pkt); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.acceptMetaReplay(pkt.Nonce, pkt.Timestamp) {
+		peer.Log().Debug("Dropping replayed meta EtcdCluster", "nonce", pkt.Nonce)
+		return nil
+	}
+	return applyEtcdCluster(pkt.Cluster)
 }
 
 // handleTransactionsEx handles the Metadium extended transactions message.

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -25,9 +25,45 @@ var (
 	etcdClusterSem = make(chan struct{}, 64)
 )
 
+// maxBlobSidecarBlocksServe bounds how many blocks a single GetBlobSidecars
+// request may ask for (M5). Each Metadium block carries at most
+// MaxBlobGasPerBlock/BlobTxBlobGasPerBlob blobs (~128KB each), so this keeps the
+// reply well under maxMessageSize while limiting disk lookups.
+const maxBlobSidecarBlocksServe = 16
+
 func handleGetPendingTxs(backend Backend, msg Decoder, peer *Peer) error {
 	// not supported, just ignore it.
 	return nil
+}
+
+// --- meta/69 blob-sidecar serving (M5) ---
+
+// handleGetBlobSidecars69 serves blob sidecars for the requested block hashes
+// from local storage (rawdb), bounding the number of blocks per request.
+func handleGetBlobSidecars69(backend Backend, msg Decoder, peer *Peer) error {
+	var req GetBlobSidecarsPacket
+	if err := msg.Decode(&req); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	hashes := req.Hashes
+	if len(hashes) > maxBlobSidecarBlocksServe {
+		hashes = hashes[:maxBlobSidecarBlocksServe]
+	}
+	response := make([][]*types.BlobTxSidecar, len(hashes))
+	for i, hash := range hashes {
+		response[i] = backend.Chain().GetBlobSidecars(hash)
+	}
+	return peer.ReplyBlobSidecars(req.RequestId, response)
+}
+
+// handleBlobSidecars69 forwards a received blob-sidecar reply to the backend,
+// which correlates it with the in-flight request and validates/persists it.
+func handleBlobSidecars69(backend Backend, msg Decoder, peer *Peer) error {
+	var res BlobSidecarsPacket
+	if err := msg.Decode(&res); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	return backend.Handle(peer, &res)
 }
 
 // --- shared processing cores (used by both legacy and meta/69 handlers) ---

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -18,7 +18,11 @@ import (
 // governance member count so normal operation never drops.
 var (
 	statusExSem = make(chan struct{}, 128)
-	etcdSem     = make(chan struct{}, 16)
+	// etcd add-member (slow raft write) and cluster gossip (fast feed send) use
+	// separate caps so a slow/stuck AddMember cannot starve cluster-gossip
+	// handling and block etcd membership self-healing.
+	etcdAddSem     = make(chan struct{}, 16)
+	etcdClusterSem = make(chan struct{}, 64)
 )
 
 func handleGetPendingTxs(backend Backend, msg Decoder, peer *Peer) error {
@@ -84,12 +88,12 @@ func handleEtcdAddMember(backend Backend, msg Decoder, peer *Peer) error {
 	}
 
 	select {
-	case etcdSem <- struct{}{}:
+	case etcdAddSem <- struct{}{}:
 	default:
 		return nil // concurrency cap reached, drop under flood
 	}
 	go func() {
-		defer func() { <-etcdSem }()
+		defer func() { <-etcdAddSem }()
 		cluster, _ := metaapi.EtcdAddMember(peer.ID())
 		if err := peer.SendEtcdCluster(cluster); err != nil {
 			// ignore the error
@@ -109,12 +113,12 @@ func handleEtcdCluster(backend Backend, msg Decoder, peer *Peer) error {
 	}
 
 	select {
-	case etcdSem <- struct{}{}:
+	case etcdClusterSem <- struct{}{}:
 	default:
 		return nil // concurrency cap reached, drop under flood
 	}
 	go func() {
-		defer func() { <-etcdSem }()
+		defer func() { <-etcdClusterSem }()
 		metaapi.GotEtcdCluster(cluster)
 	}()
 

--- a/eth/protocols/eth/metadium_peer.go
+++ b/eth/protocols/eth/metadium_peer.go
@@ -2,27 +2,48 @@ package eth
 
 import (
 	"math/rand"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	metaapi "github.com/ethereum/go-ethereum/metadium/api"
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
-// SendStatusEx sends this node's miner status
+// SendStatusEx sends this node's miner status. On meta/69 it is wrapped with a
+// replay-protection nonce/timestamp; on meta/66/68 the legacy packet is sent.
 func (p *Peer) SendStatusEx(status *metaapi.MetadiumMinerStatus) error {
+	if p.version >= ETH69 {
+		return p2p.Send(p.rw, StatusExMsg, &StatusEx69Packet{
+			Nonce:     p.nextMetaNonce(),
+			Timestamp: uint64(time.Now().Unix()),
+			Status:    *status,
+		})
+	}
 	return p2p.Send(p.rw, StatusExMsg, status)
 }
 
-// SendEtcdCluster sends this node's etcd cluster
+// SendEtcdCluster sends this node's etcd cluster.
 func (p *Peer) SendEtcdCluster(cluster string) error {
+	if p.version >= ETH69 {
+		return p2p.Send(p.rw, EtcdClusterMsg, &EtcdCluster69Packet{
+			Nonce:     p.nextMetaNonce(),
+			Timestamp: uint64(time.Now().Unix()),
+			Cluster:   cluster,
+		})
+	}
 	return p2p.Send(p.rw, EtcdClusterMsg, cluster)
 }
 
 // RequestStatusEx sends a GetStatusEx request to the peer
 func (p *Peer) RequestStatusEx() error {
 	p.Log().Debug("Fetching extended status")
-	_ = rand.Uint64()
 	requestTracker.Track(p.id, p.version, GetStatusExMsg, StatusExMsg, rand.Uint64())
+	if p.version >= ETH69 {
+		return p2p.Send(p.rw, GetStatusExMsg, &GetStatusEx69Packet{
+			Nonce:     p.nextMetaNonce(),
+			Timestamp: uint64(time.Now().Unix()),
+		})
+	}
 	return p2p.Send(p.rw, GetStatusExMsg, common.Big1)
 }
 
@@ -30,6 +51,12 @@ func (p *Peer) RequestStatusEx() error {
 func (p *Peer) RequestEtcdAddMember() error {
 	p.Log().Debug("Trying to join etcd network")
 	requestTracker.Track(p.id, p.version, EtcdAddMemberMsg, EtcdClusterMsg, rand.Uint64())
+	if p.version >= ETH69 {
+		return p2p.Send(p.rw, EtcdAddMemberMsg, &EtcdAddMember69Packet{
+			Nonce:     p.nextMetaNonce(),
+			Timestamp: uint64(time.Now().Unix()),
+		})
+	}
 	return p2p.Send(p.rw, EtcdAddMemberMsg, common.Big1)
 }
 

--- a/eth/protocols/eth/metadium_peer.go
+++ b/eth/protocols/eth/metadium_peer.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	metaapi "github.com/ethereum/go-ethereum/metadium/api"
 	"github.com/ethereum/go-ethereum/p2p"
 )
@@ -63,6 +64,26 @@ func (p *Peer) RequestEtcdAddMember() error {
 // SendNodeData sends a batch of state trie node data (response to GetNodeData, eth/66).
 func (p *Peer) SendNodeData(data [][]byte) error {
 	return p2p.Send(p.rw, NodeDataMsg, NodeDataPacket(data))
+}
+
+// RequestBlobSidecars fetches the blob sidecars for the given block hashes from
+// a meta/69 peer (M5). The id correlates the BlobSidecars reply.
+func (p *Peer) RequestBlobSidecars(id uint64, hashes []common.Hash) error {
+	p.Log().Debug("Fetching blob sidecars", "count", len(hashes))
+	requestTracker.Track(p.id, p.version, GetBlobSidecarsMsg, BlobSidecarsMsg, id)
+	return p2p.Send(p.rw, GetBlobSidecarsMsg, &GetBlobSidecarsPacket{
+		RequestId: id,
+		Hashes:    hashes,
+	})
+}
+
+// ReplyBlobSidecars sends blob sidecars in response to a GetBlobSidecars request
+// (M5). sidecars is positional with the request's hashes.
+func (p *Peer) ReplyBlobSidecars(id uint64, sidecars [][]*types.BlobTxSidecar) error {
+	return p2p.Send(p.rw, BlobSidecarsMsg, &BlobSidecarsPacket{
+		RequestId: id,
+		Sidecars:  sidecars,
+	})
 }
 
 // sendPooledTransactionHashesVersioned sends transaction hashes using the appropriate

--- a/eth/protocols/eth/metadium_protocol.go
+++ b/eth/protocols/eth/metadium_protocol.go
@@ -27,3 +27,37 @@ func (*EtcdAddMemberPacket) Kind() byte   { return EtcdAddMemberMsg }
 
 func (*EtcdClusterPacket) Name() string { return "EtcdCluster" }
 func (*EtcdClusterPacket) Kind() byte   { return EtcdClusterMsg }
+
+// --- meta/69 replay-protected packets (M12) ---
+//
+// These carry a per-connection monotonic Nonce and a unix-seconds Timestamp,
+// checked on receipt to reject replayed/stale frames. They are used only on
+// meta/69 links; meta/66 and meta/68 keep the unprotected packets above. The
+// message codes are unchanged — the wire shape is disambiguated by the
+// negotiated protocol version (version-keyed handler maps + send paths).
+
+// GetStatusEx69Packet is the meta/69 GetStatusEx request.
+type GetStatusEx69Packet struct {
+	Nonce     uint64
+	Timestamp uint64
+}
+
+// StatusEx69Packet is the meta/69 StatusEx response.
+type StatusEx69Packet struct {
+	Nonce     uint64
+	Timestamp uint64
+	Status    metaapi.MetadiumMinerStatus
+}
+
+// EtcdAddMember69Packet is the meta/69 EtcdAddMember request.
+type EtcdAddMember69Packet struct {
+	Nonce     uint64
+	Timestamp uint64
+}
+
+// EtcdCluster69Packet is the meta/69 EtcdCluster message.
+type EtcdCluster69Packet struct {
+	Nonce     uint64
+	Timestamp uint64
+	Cluster   string
+}

--- a/eth/protocols/eth/metadium_protocol.go
+++ b/eth/protocols/eth/metadium_protocol.go
@@ -1,6 +1,8 @@
 package eth
 
 import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	metaapi "github.com/ethereum/go-ethereum/metadium/api"
 )
 
@@ -61,3 +63,32 @@ type EtcdCluster69Packet struct {
 	Timestamp uint64
 	Cluster   string
 }
+
+// --- meta/69 blob-sidecar serving packets (M5) ---
+//
+// These let a node that imported a block via propagation (and so never
+// mempool-fetched its blob txs) obtain and persist the sidecars from a meta/69
+// peer, closing the data-availability gap at core/blockchain.go (BlobSidecarFn
+// returns nil → not stored). Used only on meta/69 links; meta/66 and meta/68 do
+// not carry blob-sidecar messages.
+
+// GetBlobSidecarsPacket is the meta/69 request for the blob sidecars of one or
+// more blocks, identified by block hash. RequestId correlates the reply.
+type GetBlobSidecarsPacket struct {
+	RequestId uint64
+	Hashes    []common.Hash
+}
+
+// BlobSidecarsPacket is the meta/69 reply carrying the blob sidecars for the
+// requested blocks. Sidecars is positional with the request's Hashes: entry i
+// holds the sidecars for Hashes[i] (nil if the server does not have them).
+type BlobSidecarsPacket struct {
+	RequestId uint64
+	Sidecars  [][]*types.BlobTxSidecar
+}
+
+func (*GetBlobSidecarsPacket) Name() string { return "GetBlobSidecars" }
+func (*GetBlobSidecarsPacket) Kind() byte   { return GetBlobSidecarsMsg }
+
+func (*BlobSidecarsPacket) Name() string { return "BlobSidecars" }
+func (*BlobSidecarsPacket) Kind() byte   { return BlobSidecarsMsg }

--- a/eth/protocols/eth/metadium_replay.go
+++ b/eth/protocols/eth/metadium_replay.go
@@ -1,0 +1,38 @@
+package eth
+
+import "time"
+
+// metaReplaySkewSeconds bounds how far a meta/69 message Timestamp may deviate
+// from local time. Generous enough to tolerate real node clock drift, tight
+// enough to keep the replay window small. (M12)
+const metaReplaySkewSeconds = 60
+
+// nextMetaNonce returns the next outbound meta/69 nonce for this peer. Nonces
+// start at 1 and increase monotonically for the lifetime of the connection.
+func (p *Peer) nextMetaNonce() uint64 {
+	return p.metaSendNonce.Add(1)
+}
+
+// acceptMetaReplay reports whether an inbound meta/69 message carrying the given
+// nonce/timestamp is fresh, and records it. It rejects:
+//   - timestamps outside +/- metaReplaySkewSeconds of local time (stale or future), and
+//   - nonces that do not strictly increase versus the highest already accepted
+//     from this peer (verbatim replays / out-of-order duplicates).
+//
+// It is safe for concurrent use; in practice it is called from the serial
+// per-peer message-read path before the message is acted upon.
+func (p *Peer) acceptMetaReplay(nonce, timestamp uint64) bool {
+	now := uint64(time.Now().Unix())
+	if timestamp+metaReplaySkewSeconds < now || timestamp > now+metaReplaySkewSeconds {
+		return false
+	}
+	for {
+		last := p.metaRecvNonce.Load()
+		if nonce <= last {
+			return false
+		}
+		if p.metaRecvNonce.CompareAndSwap(last, nonce) {
+			return true
+		}
+	}
+}

--- a/eth/protocols/eth/metadium_replay_test.go
+++ b/eth/protocols/eth/metadium_replay_test.go
@@ -1,0 +1,51 @@
+package eth
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAcceptMetaReplay covers the meta/69 replay-protection accept/reject rules
+// (M12): monotonic nonce and bounded timestamp skew.
+func TestAcceptMetaReplay(t *testing.T) {
+	p := &Peer{}
+	now := uint64(time.Now().Unix())
+
+	if !p.acceptMetaReplay(1, now) {
+		t.Fatal("fresh nonce 1 should be accepted")
+	}
+	if p.acceptMetaReplay(1, now) {
+		t.Fatal("replayed nonce 1 should be rejected")
+	}
+	if p.acceptMetaReplay(0, now) {
+		t.Fatal("lower nonce 0 should be rejected")
+	}
+	if !p.acceptMetaReplay(2, now) {
+		t.Fatal("increasing nonce 2 should be accepted")
+	}
+	if p.acceptMetaReplay(3, now-metaReplaySkewSeconds-10) {
+		t.Fatal("stale timestamp should be rejected")
+	}
+	if p.acceptMetaReplay(4, now+metaReplaySkewSeconds+10) {
+		t.Fatal("future timestamp should be rejected")
+	}
+	// rejected-on-timestamp frames must not advance the accepted nonce
+	if !p.acceptMetaReplay(3, now) {
+		t.Fatal("nonce 3 with fresh timestamp should be accepted after stale/future rejects")
+	}
+	// within-skew timestamp is fine
+	if !p.acceptMetaReplay(4, now-metaReplaySkewSeconds+5) {
+		t.Fatal("in-skew nonce 4 should be accepted")
+	}
+}
+
+// TestNextMetaNonce verifies outbound nonces are monotonic and start at 1.
+func TestNextMetaNonce(t *testing.T) {
+	p := &Peer{}
+	if n := p.nextMetaNonce(); n != 1 {
+		t.Fatalf("first nonce = %d, want 1", n)
+	}
+	if n := p.nextMetaNonce(); n != 2 {
+		t.Fatalf("second nonce = %d, want 2", n)
+	}
+}

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
@@ -90,6 +91,13 @@ type Peer struct {
 
 	term chan struct{} // Termination channel to stop the broadcasters
 	lock sync.RWMutex  // Mutex protecting the internal fields
+
+	// meta/69 replay protection (M12). metaSendNonce is a per-connection
+	// monotonic counter stamped on outbound meta messages; metaRecvNonce is the
+	// highest nonce accepted from this peer. Both are meaningful only on meta/69
+	// links; on meta/66/68 the legacy unprotected packets are used.
+	metaSendNonce atomic.Uint64
+	metaRecvNonce atomic.Uint64
 }
 
 // NewPeer creates a wrapper for a network connection and negotiated  protocol

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -32,6 +32,11 @@ import (
 const (
 	ETH66 = 66
 	ETH68 = 68
+	// ETH69 is the Metadium "meta/69" version that bundles blob-sidecar serving
+	// (M5) and meta-message replay protection (M12). It is negotiated only
+	// between Camellia-upgraded nodes; meta/66 and meta/68 remain supported for
+	// interop with the official v0.10.2 mainnet nodes during rollout.
+	ETH69 = 69
 )
 
 // ProtocolName is the official short name of the `eth` protocol used during
@@ -42,12 +47,14 @@ const ProtocolName = "meta"
 // ProtocolVersions are the supported versions of the `eth` protocol (first
 // is primary). ETH68 is primary; ETH66 is supported for backward compatibility
 // with existing Metadium mainnet nodes.
-var ProtocolVersions = []uint{ETH68, ETH66}
+var ProtocolVersions = []uint{ETH69, ETH68, ETH66}
 
 // protocolLengths are the number of message codes used by each protocol version.
 // Must cover the highest Metadium message code (TransactionsExMsg = 0x16 = 22),
 // so length is 23 for both versions.
-var protocolLengths = map[uint]uint64{ETH68: 23, ETH66: 23}
+// meta/69 reserves two extra codes (0x17, 0x18) for blob-sidecar request/reply
+// (M5, wired in P3), so its length is 25; meta/66 and meta/68 stay at 23.
+var protocolLengths = map[uint]uint64{ETH69: 25, ETH68: 23, ETH66: 23}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
@@ -77,6 +84,10 @@ const (
 	EtcdAddMemberMsg  = 0x14
 	EtcdClusterMsg    = 0x15
 	TransactionsExMsg = 0x16
+
+	// meta/69 only (reserved here, handlers wired in P3 — M5 blob serving)
+	GetBlobSidecarsMsg = 0x17
+	BlobSidecarsMsg    = 0x18
 )
 
 var (

--- a/metadium/admin.go
+++ b/metadium/admin.go
@@ -62,6 +62,7 @@ type metaAdmin struct {
 
 	bootNodeId  string // allowed to generate block without admin contract
 	bootAccount common.Address
+	genesisHash common.Hash // identifies the network (set in getGenesisInfo)
 	nodeInfo    *p2p.NodeInfo
 	registry    *metclient.RemoteContract
 	gov         *metclient.RemoteContract
@@ -223,6 +224,7 @@ func (ma *metaAdmin) getGenesisInfo() (string, common.Address, error) {
 	if err != nil {
 		return "", common.Address{}, err
 	}
+	ma.genesisHash = block.Hash()
 
 	var nodeId string
 	if len(block.Extra) < 64 {

--- a/metadium/admin.go
+++ b/metadium/admin.go
@@ -1689,7 +1689,37 @@ func signBlock(height *big.Int, hash common.Hash, isPangyo bool) (coinbase commo
 	return
 }
 
+// acceptUnverifiableBlock decides whether a block whose governance data is
+// unavailable can be accepted without miner signature verification. Two
+// legitimate cases exist:
+//
+//	(a) genuinely pre-governance blocks: local state at height exists but the
+//	    registry/governance contracts are not deployed yet (early chain
+//	    segment during full sync from genesis)
+//	(b) snap-sync header gap: headers are verified ahead of state download,
+//	    so state at height is not available locally yet
+//
+// For (b), only heights at or beyond the locally executed head are accepted.
+// Below the executed head, state must be available; its absence means the
+// block cannot be tied to governance and is rejected, so a synced node never
+// accepts an unverified side-chain header.
+func (ma *metaAdmin) acceptUnverifiableBlock(ctx context.Context, height *big.Int) bool {
+	if _, err := ma.cli.BalanceAt(ctx, common.Address{}, height); err == nil {
+		// state is present, so the governance lookup failed because the
+		// contracts are genuinely not deployed at this height
+		return true
+	}
+	head, err := ma.cli.BlockNumber(ctx)
+	if err != nil {
+		return false
+	}
+	return height.Uint64() >= head
+}
+
 func verifyBlockSig(height *big.Int, coinbase common.Address, nodeId []byte, hash common.Hash, sig []byte, isPangyo bool) bool {
+	if admin == nil {
+		return false
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1697,11 +1727,13 @@ func verifyBlockSig(height *big.Int, coinbase common.Address, nodeId []byte, has
 	num := new(big.Int).Sub(height, common.Big1)
 	_, gov, _, _, _, err := admin.getRegGovEnvContracts(ctx, num)
 	if err != nil {
-		// Governance not yet initialized (early blocks before contract deployment).
-		// Allow these blocks — they are pre-governance and cannot be verified.
-		return true
+		// Governance data unavailable: either pre-governance blocks or a
+		// snap-sync gap. Accept only the cases that cannot be abused to
+		// bypass signature verification.
+		return admin.acceptUnverifiableBlock(ctx, num)
 	} else if count, err := admin.getInt(ctx, gov, num, "getMemberLength"); err != nil || count == 0 {
-		// No members registered yet — governance exists but is empty.
+		// Governance contracts exist in locally executed state but have no
+		// members yet (bootstrap phase); not remotely forgeable.
 		return true
 	}
 	// if minerNodeId is given, i.e. present in block header, use it,

--- a/metadium/etcdutil.go
+++ b/metadium/etcdutil.go
@@ -222,7 +222,11 @@ func (ma *metaAdmin) etcdAddMember(name string) (string, error) {
 	now := time.Now()
 	u, _ := url.Parse(fmt.Sprintf("https://%s:%d", node.Ip, node.Port+1))
 	m := membership.NewMember(node.Name, []url.URL{*u}, etcdClusterName, &now)
-	ms, err := ma.etcd.Server.AddMember(context.Background(), *m)
+	// Bound the call: AddMember blocks indefinitely if the raft quorum is lost,
+	// which would pin a handler goroutine (and its etcd concurrency slot) forever.
+	ctx, cancel := context.WithTimeout(context.Background(), ma.etcd.Server.Cfg.ReqTimeout())
+	defer cancel()
+	ms, err := ma.etcd.Server.AddMember(ctx, *m)
 	bb := &bytes.Buffer{}
 	for _, i := range ms {
 		if bb.Len() > 0 {
@@ -262,7 +266,9 @@ func (ma *metaAdmin) etcdRemoveMember(name string) (string, error) {
 		}
 	}
 
-	_, err := ma.etcdCli.MemberRemove(context.Background(), id)
+	ctx, cancel := context.WithTimeout(context.Background(), ma.etcdTimeout)
+	defer cancel()
+	_, err := ma.etcdCli.MemberRemove(ctx, id)
 	if err != nil {
 		return "", err
 	}

--- a/metadium/etcdutil.go
+++ b/metadium/etcdutil.go
@@ -78,6 +78,18 @@ func (ma *metaAdmin) etcdFixCluster(cluster string) (string, error) {
 
 	host := fmt.Sprintf("%s:%d", ma.self.Ip, ma.self.Port+1)
 
+	// Build the set of trusted etcd peer endpoints from governance-registered
+	// nodes (etcd peer port = p2p port + 1). The cluster string arrives from a
+	// peer over the wire; without this check a compromised partner could inject
+	// an arbitrary endpoint into InitialCluster and hijack the etcd membership.
+	// Every member must resolve to a known governance node (or self).
+	allowed := map[string]bool{host: true}
+	ma.lock.Lock()
+	for _, n := range ma.nodes {
+		allowed[fmt.Sprintf("%s:%d", n.Ip, n.Port+1)] = true
+	}
+	ma.lock.Unlock()
+
 	var ss []string
 	if ss = strings.Split(cluster, ","); len(ss) <= 0 {
 		return "", ethereum.NotFound
@@ -87,6 +99,17 @@ func (ma *metaAdmin) etcdFixCluster(cluster string) (string, error) {
 	var bb bytes.Buffer
 	for _, i := range ss {
 		if j := strings.Split(i, "="); len(j) == 2 {
+			// Validate the advertised endpoint against the known node set
+			// regardless of the supplied name, so a forged name cannot smuggle
+			// in an untrusted endpoint.
+			u, err := url.Parse(j[1])
+			if err != nil {
+				return "", err
+			}
+			if !allowed[u.Host] {
+				return "", fmt.Errorf("etcd cluster member %q is not a known governance node", i)
+			}
+
 			if bb.Len() > 0 {
 				bb.WriteString(",")
 			}
@@ -96,16 +119,11 @@ func (ma *metaAdmin) etcdFixCluster(cluster string) (string, error) {
 					found = true
 				}
 				bb.WriteString(i)
+			} else if u.Host != host {
+				bb.WriteString(i)
 			} else {
-				u, err := url.Parse(j[1])
-				if err != nil {
-					return "", err
-				} else if u.Host != host {
-					bb.WriteString(i)
-				} else {
-					found = true
-					bb.WriteString(fmt.Sprintf("%s=%s", ma.self.Name, j[1]))
-				}
+				found = true
+				bb.WriteString(fmt.Sprintf("%s=%s", ma.self.Name, j[1]))
 			}
 		}
 	}

--- a/metadium/etcdutil_test.go
+++ b/metadium/etcdutil_test.go
@@ -1,0 +1,47 @@
+package metadium
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestEtcdFixClusterValidation verifies that etcdFixCluster only accepts
+// cluster members whose advertised etcd peer endpoint (ip:port+1) belongs to a
+// governance-registered node, preventing a compromised partner from injecting
+// arbitrary endpoints into InitialCluster (audit finding H4/H5).
+func TestEtcdFixClusterValidation(t *testing.T) {
+	ma := &metaAdmin{
+		lock: &sync.Mutex{},
+		self: &metaNode{Name: "node1", Ip: "10.0.0.1", Port: 8589},
+		nodes: map[string]*metaNode{
+			"node1": {Name: "node1", Ip: "10.0.0.1", Port: 8589},
+			"node2": {Name: "node2", Ip: "10.0.0.2", Port: 8589},
+			"node3": {Name: "node3", Ip: "10.0.0.3", Port: 8589},
+		},
+	}
+
+	// All members map to governance nodes -> accepted.
+	good := "node1=https://10.0.0.1:8590,node2=https://10.0.0.2:8590,node3=https://10.0.0.3:8590"
+	if _, err := ma.etcdFixCluster(good); err != nil {
+		t.Fatalf("valid cluster rejected: %v", err)
+	}
+
+	// Forged endpoint that is not a known node -> rejected.
+	bad := "node1=https://10.0.0.1:8590,evil=https://6.6.6.6:8590"
+	if _, err := ma.etcdFixCluster(bad); err == nil {
+		t.Fatal("forged endpoint accepted")
+	}
+
+	// Forged endpoint placed first (before self) -> still rejected.
+	badFirst := "evil=https://6.6.6.6:8590,node1=https://10.0.0.1:8590"
+	if _, err := ma.etcdFixCluster(badFirst); err == nil {
+		t.Fatal("forged endpoint (leading) accepted")
+	}
+
+	// A trusted endpoint with an arbitrary name is harmless (connection still
+	// only targets the known node address) -> accepted.
+	nameSwap := "node1=https://10.0.0.1:8590,whatever=https://10.0.0.2:8590"
+	if _, err := ma.etcdFixCluster(nameSwap); err != nil {
+		t.Fatalf("trusted endpoint with arbitrary name rejected: %v", err)
+	}
+}

--- a/metadium/legacy.go
+++ b/metadium/legacy.go
@@ -279,6 +279,19 @@ func (ma *metaAdmin) calculateRewardsLegacy(num, blockReward, fees *big.Int, add
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Testnet block 18 pin. The maintenance governance account is registered by a
+	// transaction in block 17, but the canonical testnet chain computed block 18's
+	// reward before that registration became visible, so the fees went to the
+	// coinbase. Reading the parent governance state for block 18 races with block
+	// 17's trie commit, so a clean sync intermittently observes the maintenance
+	// account and distributes the fees instead, diverging from canonical (invalid
+	// merkle root). Pin block 18 to the canonical coinbase outcome. Gated on the
+	// genesis hash so it can never affect mainnet, where block 18 distribution is
+	// canonical.
+	if num.Int64() == 18 && ma.genesisHash == params.MetadiumTestnetGenesisHash {
+		return nil, nil, metaminer.ErrNotInitialized
+	}
+
 	rewardPoolAccount, maintenanceAccount, members, err := ma.getRewardAccountsLegacy(ctx, big.NewInt(num.Int64()-1))
 	if err != nil {
 		// all goes to the coinbase

--- a/tests/private-net-poa/spoa-test.sh
+++ b/tests/private-net-poa/spoa-test.sh
@@ -402,21 +402,28 @@ echo ""
 
 # ── I-07: EIP-3860 initcode limit ────────────────────────────
 log "--- I-07: EIP-3860: initcode size limit ---"
-INITCODE_HEX=$(python3 -c "print('0x' + '00' * 49153)" 2>/dev/null || true)
+# Metadium extends MaxCodeSize to 253952 (params/protocol_params.go), so the
+# EIP-3860 init-code limit is MaxInitCodeSize = 2*253952 = 507904 bytes — NOT
+# the stock 49152. Send one byte over the Metadium limit; EIP-3860 must reject
+# it, either at txpool admission (error) or during execution (status 0x0).
+OVERSIZE=507905   # MaxInitCodeSize (507904) + 1
+INITCODE_HEX=$(python3 -c "print('0x' + '00' * $OVERSIZE)" 2>/dev/null || true)
 if [[ -z "$INITCODE_HEX" ]]; then
   skip "I-07: initcode generation failed"
 else
-  TXHASH=$(send_tx "{\"from\":\"$FROM\",\"data\":\"$INITCODE_HEX\",\"gas\":\"0x500000\"}")
-  if [[ -z "$TXHASH" || "$TXHASH" == "0x" ]]; then
-    skip "I-07: tx send failed"
-  else
-    RECEIPT=$(wait_receipt "$TXHASH" 2>/dev/null || true)
+  RES=$(send_tx "{\"from\":\"$FROM\",\"data\":\"$INITCODE_HEX\",\"gas\":\"0x4000000\"}")
+  if [[ "$RES" == *"max initcode size exceeded"* ]]; then
+    pass "I-07: EIP-3860: oversized initcode ($OVERSIZE > 507904) rejected at submission"
+  elif [[ "$RES" == 0x* && ${#RES} -ge 66 ]]; then
+    RECEIPT=$(wait_receipt "$RES" 2>/dev/null || true)
     STATUS=$(echo "$RECEIPT" | cut -d'|' -f2)
     if [[ "$STATUS" == "0x0" ]]; then
-      pass "I-07: EIP-3860: 49153 bytes initcode rejected (status=0x0)"
+      pass "I-07: EIP-3860: oversized initcode ($OVERSIZE > 507904) rejected (status=0x0)"
     else
       fail "I-07: EIP-3860 not applied — oversized initcode accepted (status=$STATUS)"
     fi
+  else
+    skip "I-07: tx send failed for unrelated reason: $RES"
   fi
 fi
 echo ""


### PR DESCRIPTION
## Summary

Pre-mainnet (Camellia) hardening work: upstream security backports, audit-finding
fixes, and a new meta/69 protocol version that adds blob sidecar serving (M5) and
meta-message replay protection (M12), plus the #30125 blob-propagation backport.

All changes are backward-compatible with current v0.10.2 nodes (meta/66, meta/68);
meta/69 only activates between upgraded peers. 22 commits, linear on top of `dev`
(no rebase needed), 34 files changed.

## Security backports & hardening
- Backport go-ethereum v1.13.15 DoS fixes (CVE-2024-32972)
- Restrict unverified block acceptance in `verifyBlockSig`
- Validate secp256k1 point coordinates are reduced mod P (CVE-2026-26313/14/15),
  and add an on-curve guard before cgo scalar multiplication
- Reject ECIES ciphertext shorter than the cipher block size (CVE-2026-22862/68)
- Drop peers that send cryptographically invalid blob sidecars

## Audit findings
- Validate etcd cluster members against the governance node set (H4/H5)
- Bound goroutine creation in Metadium message handlers (M11)
- Bound etcd member operations with timeouts; split handler semaphores

## Sync policy
- Default to full sync instead of snap
- Hard-reject snap/fast sync on Metadium mainnet/testnet
- Add full-sync policy and snapshot bootstrap runbook (docs)

## meta/69 (Camellia-gated, backward-compatible)
- Protocol version scaffolding (ETH69=69, ProtocolVersions {69, 68, 66})
- Replay protection for meta messages: monotonic nonce + timestamp skew window (M12)
- Blob sidecar serving: GetBlobSidecars/BlobSidecars (0x17/0x18), fetch-on-import,
  KZG validation, and persistence (M5)
- Backport #30125: arrival-order tx fetching + blob skip-waitlist

## Consensus
- Pin testnet block 18 reward to the coinbase outcome (testnet-only, genesis-hash
  gated; mainnet is unaffected)

## Verification
- Unit tests: crypto/secp256k1, crypto/ecies, core/txpool, metadium, eth/fetcher,
  eth/protocols/eth (both CGO=0 and CGO=1 builds)
- SPoA 3-node integration: PASS=19 FAIL=0 SKIP=2 (baseline; the two SKIPs are
  pre-existing test-script parsing issues, unrelated to these changes)
- blob-tx-e2e all pass; M5 cross-node e2e verified (sidecar fetched, served,
  and persisted across nodes)
- Full clean-sync from genesis to tip on both testnet (through the Camellia fork
  at block 86,449,000) and mainnet, with no bad blocks or state mismatch

## Rollout note
meta/69 is bundled with the Camellia binary. Because M5 blob serving must be in
place before mainnet enables blobs at the Camellia fork, merge/rollout timing
should be coordinated with the mainnet Camellia fork schedule.
