### PR TITLE
Camellia mainnet activation at block 117,764,000 (2026-08-27), v1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ tests/spec-tests/
 
 # Build artifacts
 /core/txpool/blobpool/blobpool/
+
+# Operator-local notes (never commit: addresses, accounts, keys, schedules)
+*.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,49 +42,13 @@ Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fo
 ## Project Management
 - Method: file
 
-## Server Access
+## Deployment Targets
 
-### SSH Key
-- Key: `~/.ssh/aws-jsong-nopass.pem`
-- Direct access (no jump box required)
+Operational node details -- addresses, accounts, SSH keys, service names -- are
+intentionally kept out of this repository. Keep them in a local, untracked file
+(`SERVERS.local.md`, see `.gitignore`) or in your own operator notes.
 
-### Server 151 (testnet, RocksDB)
-- SSH: `ssh -i ~/.ssh/aws-jsong-nopass.pem jsong@192.168.0.151`
-- Binary: `/data/jsong/gmet-rocksdb`
-- Source: `/data/jsong/go-metadium` (git)
-- RPC: `http://127.0.0.1:8588` (`--metadium-testnet`, RocksDB)
-- API: `eth,net,web3,admin,debug`
-
-### Build (Server 151)
-```bash
-cd /data/jsong/go-metadium
-CGO_ENABLED=1 CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd" \
-  /usr/local/go/bin/go build -tags rocksdb -o /data/jsong/gmet-rocksdb ./cmd/geth
-```
-
-### Server 25 (testnet, LevelDB)
-- SSH: `ssh -i ~/.ssh/aws-jsong-nopass.pem ubuntu@192.168.0.25`
-- Binary: `/usr/local/bin/gmet`
-- Source: `/data/go-metadium` (git)
-- Service: `gmet-testnet.service` (systemd)
-- RPC: `http://127.0.0.1:8588` (`--metadium-testnet`, LevelDB)
-- API: `eth,net,web3,admin,debug`
-
-### Server 150 (mainnet, 2 nodes)
-- SSH: `ssh -i ~/.ssh/aws-jsong-nopass.pem jsong@192.168.0.150`
-- Binary: `/home/jsong/gmet-rocksdb`
-- Source: `/home/jsong/go-metadium` (git)
-- Node 1 (LevelDB): `http://127.0.0.1:8588` (`--mainnet --userocksdb 0`)
-- Node 2 (RocksDB): `http://127.0.0.1:8590` (`--mainnet --userocksdb 1`)
-- API: `eth,net,web3,admin,debug`
-
-### Server 36 (long-term private network testing)
-- SSH: `ssh -i ~/.ssh/aws-jsong-nopass.pem cplabs@10.150.255.36`
-- Docker-based 4-node private network (3 miners + 1 sync)
-- Mixed DB: LevelDB + RocksDB
-- Purpose: Camellia fork stability and governance reward verification
-
-### Private Network (local Docker)
+## Private Network (local Docker)
 ```bash
 cd tests/private-net-poa
 ./setup.sh              # Initialize (builds Docker image)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fo
 - Backend: Go 1.21+
 - DB: LevelDB (default) / RocksDB (`-tags rocksdb`)
 - Consensus: Metadium PoA (ethash placeholder, custom sealing)
-- Version: 1.0.0-stable
+- Version: 1.1.1-stable
 
 ## Directory Structure
 - `cmd/geth/` -- main binary entrypoint

--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@ Metadium blockchain node implementation, forked from [go-ethereum](https://githu
 
 Metadium is a Proof-of-Authority (PoA) blockchain with on-chain governance. It uses a custom consensus layer built on top of go-ethereum's ethash engine, with block signing via node keys and reward distribution through governance smart contracts.
 
-**Current version:** 1.0.0-stable (Camellia fork)
+**Current version:** 1.1.1-stable (Camellia fork)
 
 ## Camellia Fork
 
 Camellia is Metadium's hard fork that activates Ethereum's Shanghai and Cancun EIPs in a single upgrade:
+
+| Network | Activation block | Activation time |
+|---------|------------------|-----------------|
+| Testnet | 86,449,000 | 2026-05-20 12:00 KST (activated) |
+| Mainnet | 117,764,000 | 2026-08-27 12:00 KST (scheduled) |
+
+Nodes must run this release before the mainnet activation block; older binaries will follow a diverging chain.
 
 | EIP | Feature | Status |
 |-----|---------|--------|

--- a/docs/camellia-mainnet-hf-plan.md
+++ b/docs/camellia-mainnet-hf-plan.md
@@ -95,6 +95,14 @@ no extra step is needed, provided it is running a binary that knows the fork.
 - **Verify every node before the activation day**: `gmet version` plus the
   `Camellia Fork: #<block>` line in the startup banner. This also catches any node that was
   rebuilt or restored from an image carrying an older binary.
+- **Upgrade snapshot-publishing nodes first.** Any node that periodically stops, tars its
+  chaindata and publishes it for others to bootstrap from must be on the fork-aware binary
+  *before* its first publish after activation — otherwise it follows a pre-fork chain past the
+  activation block and hands that chaindata to downstream users. Their next publishing window,
+  not the activation day, is the real deadline.
+- **Bootstrapping after the fork** requires the fork-aware binary. A pre-fork chaindata
+  snapshot is fine as a starting point (see the section above), but pairing it with a pre-fork
+  binary stalls at the activation block. Say so in the release notes.
 
 ### Relative timeline
 

--- a/docs/camellia-mainnet-hf-plan.md
+++ b/docs/camellia-mainnet-hf-plan.md
@@ -1,7 +1,7 @@
 # Camellia Mainnet Hard Fork — Activation Plan
 
-**Status:** proposal — the fork block is **not finalized yet**
-**Date:** 2026-08-03
+**Status:** confirmed — fork block `117,764,000`, activating 2026-08-27 12:00 KST
+**Date:** 2026-08-03 (decision recorded 2026-08-06)
 **Target binary:** `v1.1.0-stable` (`e3f51b3e6`) **plus the shutdown deadlock fix** — see
 [Shutdown behaviour](#shutdown-behaviour). `e3f51b3e6` on its own must not be rolled out.
 
@@ -9,7 +9,7 @@
 
 | Network | `CamelliaBlock` | Notes |
 |---|---|---|
-| Mainnet | `nil` | not activated (`params/config.go`) |
+| Mainnet | `117,764,000` | activates 2026-08-27 12:00 KST (`params/config.go`) |
 | Testnet | `86,449,000` | activated 2026-05-20 12:00 KST, ~2.5 months with no incident |
 
 ## Choosing the fork block
@@ -28,8 +28,13 @@ last 1k / 10k / 100k blocks), **43,200 blocks/day**.
 Conventions, both following the testnet precedent: round the fork block to the nearest
 **1,000**, and pick an activation time of **12:00 KST**.
 
-**Recommendation: `117,764,000` (2026-08-27 12:00 KST)** — leaves a two-week window for
+**Confirmed: `117,764,000` (2026-08-27 12:00 KST)** — leaves a two-week window for
 exchange notice while keeping enough lead time to build, stage and roll out.
+
+Re-measured 2026-08-06 14:51 KST against a synced node: head **116,861,511**, block time
+**2.000014 s** over the last 100k / 500k / 1M blocks. The exact block for 12:00 KST is
+`117,763,549`; rounded to the nearest 1,000 the fork lands at roughly **12:15 KST**, which
+keeps activation inside working hours.
 
 ## Code change
 

--- a/docs/camellia-mainnet-hf-plan.md
+++ b/docs/camellia-mainnet-hf-plan.md
@@ -1,0 +1,131 @@
+# Camellia Mainnet Hard Fork — Activation Plan
+
+**Status:** proposal — the fork block is **not finalized yet**
+**Date:** 2026-08-03
+**Target binary:** `v1.1.0-stable` (`e3f51b3e6`)
+
+## Current state
+
+| Network | `CamelliaBlock` | Notes |
+|---|---|---|
+| Mainnet | `nil` | not activated (`params/config.go`) |
+| Testnet | `86,449,000` | activated 2026-05-20 12:00 KST, ~2.5 months with no incident |
+
+## Choosing the fork block
+
+Measured 2026-08-03 13:04 KST: head **116,728,688**, block time **2.000 s** (identical over the
+last 1k / 10k / 100k blocks), **43,200 blocks/day**.
+
+| Activation (12:00 KST) | Fork block | Notice deadline (D-14) |
+|---|---|---|
+| 2026-08-20 | 117,461,000 | 2026-08-06 |
+| 2026-08-25 | 117,677,000 | 2026-08-11 |
+| **2026-08-27** | **117,764,000** | **2026-08-13** |
+| 2026-08-31 | 117,936,000 | 2026-08-17 |
+| 2026-09-03 | 118,066,000 | 2026-08-20 |
+
+Conventions, both following the testnet precedent: round the fork block to the nearest
+**1,000**, and pick an activation time of **12:00 KST**.
+
+**Recommendation: `117,764,000` (2026-08-27 12:00 KST)** — leaves a two-week window for
+exchange notice while keeping enough lead time to build, stage and roll out.
+
+## Code change
+
+Activating the fork is a single line:
+
+```go
+// params/config.go — MetadiumMainnetChainConfig
+- CamelliaBlock:       nil, // Not yet activated on mainnet
++ CamelliaBlock:       big.NewInt(117_764_000), // 2026-08-27 12:00 KST mainnet activation
+```
+
+### No genesis redistribution is required
+
+Mainnet nodes start without an explicit genesis, so `SetupGenesisBlockWithOverride` resolves
+the config through `configOrDefault(MetadiumMainnetGenesisHash)`, which returns the hardcoded
+`MetadiumMainnetChainConfig`. That value takes precedence over the config stored in the
+database — the branch that keeps the stored config (`core/genesis.go`, the
+`genesis == nil && stored != …` case) explicitly excludes the Metadium mainnet genesis hash.
+
+**Swapping the binary is enough to schedule the fork.**
+
+### Deploying before the fork block is safe
+
+`CheckCompatible` reaches `isForkBlockIncompatible(nil, N, head)`, which is
+`(isBlockForked(nil, head) || isBlockForked(N, head)) && !configBlockEqual(nil, N)`.
+While `head < N` both `isBlockForked` calls are false, so the check passes and no rewind is
+requested. This is what makes it possible to ship the binary days ahead of activation.
+
+Once `head >= N`, a node whose stored config still has `CamelliaBlock = nil` will fail to
+start with a `rewind to N-1` compatibility error. Only a node left on a pre-fork binary past
+the activation block can get into that state.
+
+### Fork ordering
+
+`camelliaBlock` is an optional entry in `CheckConfigForkOrder`, and the preceding mainnet fork
+(Bokbunja, `73,225,410`) is well below the proposed block, so ordering validation passes.
+
+### Escape hatch
+
+`--override.camellia=<block>` (`cmd/utils/flags.go`, applied in `core/genesis.go`) injects a
+fork block without rebuilding. Useful for testing and emergencies.
+
+> Do not use it in steady-state operation: if nodes disagree on the value, the chain splits.
+
+## Restoring an older chaindata snapshot
+
+A snapshot taken before the upgrade stores `CamelliaBlock = nil`, but as described above the
+hardcoded mainnet config overrides it, and `CheckCompatible` passes while the restored head is
+behind the fork block. Such a node catches up and applies Camellia at the fork block normally —
+no extra step is needed, provided it is running a binary that knows the fork.
+
+## Rollout
+
+- **One tarball per database engine.** The fleet runs both LevelDB and RocksDB builds; a
+  mismatched binary cannot open the datadir.
+- **Restart one sealer at a time.** Consensus is PoA backed by an etcd quorum, so stopping
+  several block producers together is never acceptable. Non-sealers first as a canary, then
+  sealers one by one, leader last.
+- **Graceful shutdown only** — never `kill -9`, especially with RocksDB. Stops on large
+  datadirs can take a while; run them detached so a client timeout does not interrupt them.
+- **Ship binaries ahead of activation.** The fork block is compiled in, so deployment and
+  activation are naturally separate events. The rollback window is the gap between them; once
+  the fork activates, rollback means a chain split and is no longer possible.
+- **Verify every node before the activation day**: `gmet version` plus the
+  `Camellia Fork: #<block>` line in the startup banner. This also catches any node that was
+  rebuilt or restored from an image carrying an older binary.
+
+### Relative timeline
+
+| When | Step |
+|---|---|
+| D-14 | Exchange notice sent; fork block committed and merged |
+| D-12 | Build one tarball per engine |
+| D-10 | Stage on follower nodes, confirm the fork block in the banner |
+| D-7 | Fleet rollout: canary → non-sealers → sealers one at a time → leader |
+| D-3 | Fleet-wide check of `gmet version` and the fork block value |
+| D-day 12:00 KST | Fork activates; monitor |
+| D+1 | Post-activation report |
+
+## Verification status
+
+| Item | Status |
+|---|---|
+| Testnet fleet on `e3f51b3e6` (meta/69) | done — no incident since rollout |
+| Camellia transition matches canonical on testnet | done — pre/post fork block hashes match |
+| Clean sync genesis → tip, both chains | done — no BAD BLOCK, no state mismatch |
+| Private-net PoA suite | 19 pass / 0 fail / 2 skip |
+| Blob-tx and mixed-tx e2e | done |
+| CGO unit tests (secp256k1, KZG guards) | done |
+
+## Included in the target binary
+
+`e3f51b3e6` carries, on top of the Camellia fork itself:
+
+- secp256k1 coordinate validation, ECIES guards, full sync as the default
+- cgo `ScalarMult` guard, blob KZG peer-drop
+- meta/69: replay protection (M12) and blob sidecar serving (M5)
+- upstream #30125 — arrival-order transaction fetching
+
+It stays backward compatible with the current mainnet release over meta/66 and meta/68.

--- a/docs/camellia-mainnet-hf-plan.md
+++ b/docs/camellia-mainnet-hf-plan.md
@@ -2,7 +2,8 @@
 
 **Status:** proposal — the fork block is **not finalized yet**
 **Date:** 2026-08-03
-**Target binary:** `v1.1.0-stable` (`e3f51b3e6`)
+**Target binary:** `v1.1.0-stable` (`e3f51b3e6`) **plus the shutdown deadlock fix** — see
+[Shutdown behaviour](#shutdown-behaviour). `e3f51b3e6` on its own must not be rolled out.
 
 ## Current state
 
@@ -80,6 +81,54 @@ hardcoded mainnet config overrides it, and `CheckCompatible` passes while the re
 behind the fork block. Such a node catches up and applies Camellia at the fork block normally —
 no extra step is needed, provided it is running a binary that knows the fork.
 
+## Shutdown behaviour
+
+A rolling upgrade stops every node once, so shutdown has to be reliable. Two problems were
+found and fixed while preparing this rollout.
+
+### The node could ignore SIGTERM indefinitely
+
+`metclient.CallContract` held the global `metaminer.TrieAccessMu` read lock across the whole
+contract read, and its callers pass a context with no deadline. `contract.Cli` is an in-process
+client, so once the node begins shutting down the call can stop being answered — and the read
+lock is then never released:
+
+- the admin loop parks inside the call while holding the read lock
+- `writeBlockWithState`, running under the downloader's block import, blocks on the write lock
+- that goroutine is one of the downloader's fetchers, so `Downloader.Cancel` never returns
+- `chainSyncer.loop` never releases its `handler.wg` entry, so `handler.Stop` blocks in
+  `wg.Wait` and `node.Close` never returns
+
+The process then survives SIGTERM indefinitely and only dies on SIGKILL — the unclean shutdown
+the lock exists to prevent. The fix bounds the lock hold with a deadline and releases it via
+`defer`; the lock itself is unchanged, so the state-commit serialisation it provides is intact.
+
+Reproduced on isolated nodes and confirmed with a goroutine dump: **4 of 4 hangs before the
+fix** (LevelDB and RocksDB alike, surviving 150–200 s+), **9 of 9 clean shutdowns after**
+(1–17 s, each logging `Blockchain stopped`).
+
+### The control script escalated to SIGKILL on a fixed timer
+
+`gmet.sh stop` waited a hardcoded 200 s and then sent SIGKILL unconditionally, so any node
+slower than that — or wedged, as above — was killed with an unclean database. The timeout and
+the escalation are now `.rc` settings (`STOP_TIMEOUT`, `STOP_FORCE`, `LOCK_TIMEOUT`) whose
+defaults reproduce the old behaviour. With `STOP_FORCE=0` the stop fails instead of killing,
+which also required fixing `restart`: it previously ran `start` regardless of whether the stop
+succeeded, which would leave two nodes running against one datadir.
+
+### Operational rule
+
+**Treat a stop as complete only when the process is gone _and_ the log shows
+`Blockchain stopped`.** A missing `Blockchain stopped` after `Got interrupt` means the shutdown
+did not finish, and anything that reads the datadir afterwards — a tarball, a snapshot, a
+restore — is being taken from a node that never flushed. Automation that stops a node in order
+to copy its data must verify this rather than assume it, and must not fall through to the copy
+when verification fails.
+
+If a node does hang, capture `kill -QUIT <pid>` before resorting to SIGKILL: the runtime dumps
+every goroutine to stderr, which is what identified the cause above. The IPC socket is already
+closed by that point, so `debug.stacks()` over IPC is not available.
+
 ## Rollout
 
 - **One tarball per database engine.** The fleet runs both LevelDB and RocksDB builds; a
@@ -137,3 +186,9 @@ no extra step is needed, provided it is running a binary that knows the fork.
 - upstream #30125 — arrival-order transaction fetching
 
 It stays backward compatible with the current mainnet release over meta/66 and meta/68.
+
+On top of that, the rollout binary must carry the shutdown fixes described in
+[Shutdown behaviour](#shutdown-behaviour): the bounded `TrieAccessMu` hold in
+`metadium/metclient`, and the configurable stop behaviour in `metadium/scripts/gmet.sh`. The
+deadlock only manifests while stopping, which is why months of steady-state operation did not
+surface it.

--- a/metadium/metclient/util.go
+++ b/metadium/metclient/util.go
@@ -304,9 +304,9 @@ func IsArray(x interface{}) bool {
 }
 
 // callContractTimeout bounds how long a single contract read may hold
-// metaminer.TrieAccessMu for reading. A governance read against the in-process
-// client is a sub-millisecond operation, so this only ever fires when the RPC
-// stack has stopped answering.
+// metaminer.TrieAccessMu for reading. Once the lock is held, a governance read
+// against the in-process client is a sub-millisecond operation, so this only
+// ever fires when the RPC stack has stopped answering.
 const callContractTimeout = 30 * time.Second
 
 // callContractSerialized runs the EVM read while holding metaminer.TrieAccessMu
@@ -324,15 +324,20 @@ const callContractTimeout = 30 * time.Second
 // deadlocks node shutdown (the process then only dies via SIGKILL). Bounding
 // the call with a deadline, and releasing via defer so a panic cannot leak the
 // lock either, keeps the writer able to make progress.
+//
+// The deadline is armed only after the lock is acquired. Time spent waiting on
+// a slow writer must not consume the budget: reward reads arrive with no
+// deadline of their own, and calculateRewards treats any error as "governance
+// not initialized" and quietly falls back to fees-only distribution, so an
+// expired-while-waiting context would let a >30s triedb commit turn a
+// correct-but-slow read into a wrong-rewards block. Blocking on the lock is
+// the pre-existing, safe behaviour; only the hold is bounded.
 func callContractSerialized(ctx context.Context, contract *RemoteContract,
 	msg ethereum.CallMsg, block *big.Int) ([]byte, error) {
-	if _, ok := ctx.Deadline(); !ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, callContractTimeout)
-		defer cancel()
-	}
 	metaminer.TrieAccessMu.RLock()
 	defer metaminer.TrieAccessMu.RUnlock()
+	ctx, cancel := context.WithTimeout(ctx, callContractTimeout)
+	defer cancel()
 	return contract.Cli.CallContract(ctx, msg, block)
 }
 

--- a/metadium/metclient/util.go
+++ b/metadium/metclient/util.go
@@ -303,6 +303,39 @@ func IsArray(x interface{}) bool {
 	}
 }
 
+// callContractTimeout bounds how long a single contract read may hold
+// metaminer.TrieAccessMu for reading. A governance read against the in-process
+// client is a sub-millisecond operation, so this only ever fires when the RPC
+// stack has stopped answering.
+const callContractTimeout = 30 * time.Second
+
+// callContractSerialized runs the EVM read while holding metaminer.TrieAccessMu
+// for reading.
+//
+// The lock serializes the read against archive-mode triedb commits: the read
+// dispatches on a fresh statedb sharing the same triedb backend as the
+// block-import goroutine, and without serialization it can observe a transient
+// missing-state for just-committed accounts.
+//
+// The lock must never be held indefinitely. contract.Cli is an in-process
+// client, and once the node begins shutting down the call can stop being
+// answered; a reader parked here forever blocks writeBlockWithState on
+// TrieAccessMu.Lock, which in turn wedges the downloader's cancel WaitGroup and
+// deadlocks node shutdown (the process then only dies via SIGKILL). Bounding
+// the call with a deadline, and releasing via defer so a panic cannot leak the
+// lock either, keeps the writer able to make progress.
+func callContractSerialized(ctx context.Context, contract *RemoteContract,
+	msg ethereum.CallMsg, block *big.Int) ([]byte, error) {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, callContractTimeout)
+		defer cancel()
+	}
+	metaminer.TrieAccessMu.RLock()
+	defer metaminer.TrieAccessMu.RUnlock()
+	return contract.Cli.CallContract(ctx, msg, block)
+}
+
 func CallContract(ctx context.Context, contract *RemoteContract,
 	method string, input, output interface{}, block *big.Int) error {
 	var in, out []byte
@@ -330,14 +363,7 @@ func CallContract(ctx context.Context, contract *RemoteContract,
 		To:   contract.To,
 		Data: in,
 	}
-	// Serialize against archive-mode triedb commits (see metaminer.TrieAccessMu).
-	// CallContract dispatches an EVM read on a fresh statedb that shares the
-	// same triedb backend as the main block-import goroutine; without this
-	// lock, the read can race with a concurrent triedb.Commit in archive
-	// mode and observe a transient missing-state.
-	metaminer.TrieAccessMu.RLock()
-	out, err = contract.Cli.CallContract(ctx, msg, block)
-	metaminer.TrieAccessMu.RUnlock()
+	out, err = callContractSerialized(ctx, contract, msg, block)
 	if err != nil {
 		return err
 	}

--- a/metadium/scripts/gmet-bp-override.conf
+++ b/metadium/scripts/gmet-bp-override.conf
@@ -1,0 +1,14 @@
+# Sealer (block producer) override for gmet.service.
+#
+# Install:
+#   mkdir -p /etc/systemd/system/gmet.service.d
+#   cp gmet-bp-override.conf /etc/systemd/system/gmet.service.d/override.conf
+#   systemctl daemon-reload
+#   systemctl disable gmet   # boot start stays manual on sealers
+#
+# A sealer that dies must not rejoin consensus untended: an unclean database
+# or a stale volume behind the crash needs an operator's judgement first.
+# Crashes should page a human instead of restarting.
+
+[Service]
+Restart=no

--- a/metadium/scripts/gmet.service
+++ b/metadium/scripts/gmet.service
@@ -8,10 +8,18 @@
 # /etc/systemd/system/gmet.service.d/override.conf and stay disabled at boot,
 # so a sealer never rejoins consensus without an operator's judgement.
 #
-# The stop policy must match the .rc knobs (STOP_TIMEOUT / STOP_FORCE) that
-# gmet.sh honors: TimeoutStopSec has to exceed STOP_TIMEOUT and SendSIGKILL
-# must stay off, otherwise systemd SIGKILLs the node mid-flush and the .rc
-# no-force policy is silently voided.
+# The stop policy must match the .rc knobs (STOP_TIMEOUT / STOP_FORCE /
+# LOCK_TIMEOUT) that gmet.sh honors: ExecStop can legitimately take up to
+# 30s (leader handoff) + STOP_TIMEOUT + LOCK_TIMEOUT, so keep
+# TimeoutStopSec above that sum when raising the knobs, and keep SendSIGKILL
+# off, otherwise systemd SIGKILLs the node mid-flush and the .rc no-force
+# policy is silently voided. The default 1830 covers the default knobs
+# (200+200) with wide margin.
+#
+# First boot of a brand-new node: the ExecStartPre gates below require an
+# existing chaindata and nodekey (restore a snapshot / place the nodekey, or
+# run the node once by hand via gmet.sh), so provision the volume before
+# `systemctl enable --now gmet` -- a bare volume fails the gates by design.
 
 [Unit]
 Description=Metadium gmet node
@@ -29,6 +37,9 @@ Group=ubuntu
 WorkingDirectory=/opt/meta
 # Refuse to start a node whose volume lost its config, chain data or identity
 # (e.g. a replaced instance-store volume) -- that recovery needs an operator.
+# The binary check keeps a partial deploy (scripts without gmet) from being
+# reported as a successful start.
+ExecStartPre=/usr/bin/test -x /opt/meta/bin/gmet
 ExecStartPre=/usr/bin/test -f /opt/meta/.rc
 ExecStartPre=/usr/bin/test -d /opt/meta/geth/chaindata
 ExecStartPre=/usr/bin/test -s /opt/meta/geth/nodekey

--- a/metadium/scripts/gmet.service
+++ b/metadium/scripts/gmet.service
@@ -1,0 +1,44 @@
+# Metadium gmet node -- systemd unit template (non-sealer defaults).
+#
+# Install:
+#   cp gmet.service /etc/systemd/system/gmet.service
+#   systemctl daemon-reload && systemctl enable --now gmet
+#
+# Sealers (block producers) additionally install gmet-bp-override.conf as
+# /etc/systemd/system/gmet.service.d/override.conf and stay disabled at boot,
+# so a sealer never rejoins consensus without an operator's judgement.
+#
+# The stop policy must match the .rc knobs (STOP_TIMEOUT / STOP_FORCE) that
+# gmet.sh honors: TimeoutStopSec has to exceed STOP_TIMEOUT and SendSIGKILL
+# must stay off, otherwise systemd SIGKILLs the node mid-flush and the .rc
+# no-force policy is silently voided.
+
+[Unit]
+Description=Metadium gmet node
+Documentation=file:///opt/meta/bin/gmet.sh
+After=network-online.target
+Wants=network-online.target
+RequiresMountsFor=/opt/meta
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/opt/meta
+# Refuse to start a node whose volume lost its config, chain data or identity
+# (e.g. a replaced instance-store volume) -- that recovery needs an operator.
+ExecStartPre=/usr/bin/test -f /opt/meta/.rc
+ExecStartPre=/usr/bin/test -d /opt/meta/geth/chaindata
+ExecStartPre=/usr/bin/test -s /opt/meta/geth/nodekey
+ExecStart=/opt/meta/bin/gmet.sh start-inner /opt/meta
+ExecStop=/opt/meta/bin/gmet.sh stop /opt/meta
+Restart=on-failure
+RestartSec=15
+TimeoutStopSec=1830
+SendSIGKILL=no
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target

--- a/metadium/scripts/gmet.sh
+++ b/metadium/scripts/gmet.sh
@@ -142,21 +142,22 @@ function start ()
     if [ -x "$d/bin/gmet" ]; then
 	GMET="$d/bin/gmet"
     else
-	echo "Cannot find gmet"
-	return
+	# Fail loudly: under systemd (Type=simple, Restart=on-failure) a zero
+	# exit here would count as a successful run and the unit would go
+	# inactive without ever starting a node.
+	echo "Cannot find gmet" >&2
+	return 1
     fi
 
     [ -f "$d/.rc" ] && source "$d/.rc"
     [ "$COINBASE" = "" ] && COINBASE="" || COINBASE="--miner.etherbase $COINBASE"
 
-    # Bind address for the JSON-RPC / WS endpoints. Override per node in .rc,
-    # e.g. HTTP_ADDR=127.0.0.1 on a block producer that must not expose RPC.
-    # The default stays 0.0.0.0 so that a node whose .rc predates these knobs
-    # keeps serving the endpoint it served before, rather than silently
-    # dropping to loopback on the next restart.
-    RPCOPT="--http --http.addr ${HTTP_ADDR:-0.0.0.0}"
+    # Bind address for the JSON-RPC / WS endpoints. The default is loopback
+    # (the audited, safe-by-default choice); a node that serves RPC/WS
+    # externally opts in per node with HTTP_ADDR/WS_ADDR in its .rc.
+    RPCOPT="--http --http.addr ${HTTP_ADDR:-127.0.0.1}"
     [ "$PORT" = "" ] || RPCOPT="${RPCOPT} --http.port ${PORT}"
-    RPCOPT="${RPCOPT} --ws --ws.addr ${WS_ADDR:-0.0.0.0}"
+    RPCOPT="${RPCOPT} --ws --ws.addr ${WS_ADDR:-127.0.0.1}"
     [ "$PORT" = "" ] || RPCOPT="${RPCOPT} --ws.port $((${PORT}+10))"
     [ "$NONCE_LIMIT" = "" ] || NONCE_LIMIT="--noncelimit $NONCE_LIMIT"
     [ "$BOOT_NODES" = "" ] || BOOT_NODES="--bootnodes $BOOT_NODES"
@@ -210,20 +211,29 @@ function get_gmet_pids ()
 # but I could not recognize it" - see the "stop" case below.
 function get_chaindata_holders ()
 {
-    local d=$1 log=$1/geth/chaindata/LOG p
+    # Resolve symlinks first: /proc fd paths come back fully resolved, and
+    # lsof is asked for the resolved file, so a symlinked datadir
+    # (/opt/meta -> /data/meta) or a relative path would otherwise never match.
+    local d=$(readlink -f -- "$1") log p fd
+    [ "$d" = "" ] && return 0
+    log=$d/geth/chaindata/LOG
 
     [ -e "$log" ] || return 0
     if command -v lsof > /dev/null 2>&1; then
-	lsof -- "$log" 2>/dev/null | awk 'NR > 1 && $1 == "gmet" { print $2 }' | sort -u
+	# Prefix match, not exact: lsof truncates COMMAND to 9 chars and
+	# renamed binaries (gmet-rocksdb) are a documented deploy practice.
+	lsof -- "$log" 2>/dev/null | \
+	    awk 'NR > 1 && index($1, "gmet") == 1 { print $2 }' | sort -u
 	return 0
     fi
     # No lsof: fall back to /proc. Only processes owned by the caller are
     # visible there, which covers the normal case of gmet.sh having started
     # the node itself.
     for p in /proc/[0-9]*; do
-	[ "$(cat $p/comm 2>/dev/null)" = "gmet" ] || continue
-	readlink $p/fd/* 2>/dev/null | grep -q "^${d}/geth/chaindata/" && \
-	    echo ${p#/proc/}
+	case "$(cat $p/comm 2>/dev/null)" in gmet*) ;; *) continue;; esac
+	for fd in $(readlink $p/fd/* 2>/dev/null); do
+	    case "$fd" in "${d}/geth/chaindata/"*) echo ${p#/proc/}; break;; esac
+	done
     done
 }
 
@@ -282,18 +292,33 @@ case "$1" in
 "stop")
     echo -n "stopping..."
     dir=$(get_data_dir $2)
-    # Shutdown knobs, overridable per node in $dir/.rc. The defaults reproduce
-    # the historical behaviour: wait 200s for SIGTERM, then SIGKILL.
+    # A data dir we cannot resolve must stop the world here: passed further
+    # down, an empty ${dir} degrades the get_gmet_pids pattern to
+    # "gmet.*datadir.*", which matches every gmet on the host and would kill
+    # unrelated nodes on a multi-node machine.
+    if [ "${dir}" = "" ]; then
+	echo "failed."
+	echo "$0: cannot resolve the data directory for '$2'" >&2
+	exit 1
+    fi
+    # Shutdown knobs. Precedence: environment > $dir/.rc > default, so an
+    # operator can raise a knob for a single invocation
+    # (STOP_TIMEOUT=1800 gmet.sh stop ...) without editing the node's .rc.
+    # The defaults reproduce the historical behaviour: wait 200s for SIGTERM,
+    # then SIGKILL.
     #   STOP_TIMEOUT  seconds to wait for the node to exit on its own
     #   STOP_FORCE    1 = escalate to SIGKILL, 0 = never SIGKILL and fail instead
     #   LOCK_TIMEOUT  seconds to wait for the chaindata lock to be released
     # A node with a large database can need well over 200s to flush; SIGKILL
     # there means an unclean database, so raise STOP_TIMEOUT (or set
     # STOP_FORCE=0) instead of letting the escalation fire.
+    ENV_STOP_TIMEOUT=$STOP_TIMEOUT
+    ENV_STOP_FORCE=$STOP_FORCE
+    ENV_LOCK_TIMEOUT=$LOCK_TIMEOUT
     [ -f "${dir}/.rc" ] && source "${dir}/.rc"
-    STOP_TIMEOUT=${STOP_TIMEOUT:-200}
-    STOP_FORCE=${STOP_FORCE:-1}
-    LOCK_TIMEOUT=${LOCK_TIMEOUT:-200}
+    STOP_TIMEOUT=${ENV_STOP_TIMEOUT:-${STOP_TIMEOUT:-200}}
+    STOP_FORCE=${ENV_STOP_FORCE:-${STOP_FORCE:-1}}
+    LOCK_TIMEOUT=${ENV_LOCK_TIMEOUT:-${LOCK_TIMEOUT:-200}}
     PIDS=$(get_gmet_pids ${dir})
     if [ "$PIDS" = "" ]; then
 	# Nothing matched the command line. Before reporting success, confirm the
@@ -347,7 +372,16 @@ if (admin.metadiumInfo != null && admin.metadiumInfo.self != null) {
   }
   check_if_mining()
 }'
-	${dir}/bin/gmet attach --exec "$CMD" ipc:${dir}/gmet.ipc | grep -v "undefined"
+	# The handoff is best-effort: a node whose RPC stack is wedged accepts
+	# the IPC connection but never answers, and an unbounded attach here
+	# would eat the whole stop budget before the first SIGTERM is sent.
+	if command -v timeout > /dev/null 2>&1; then
+	    timeout 30 ${dir}/bin/gmet attach --exec "$CMD" ipc:${dir}/gmet.ipc | \
+		grep -v "undefined"
+	else
+	    ${dir}/bin/gmet attach --exec "$CMD" ipc:${dir}/gmet.ipc | \
+		grep -v "undefined"
+	fi
 	echo $PIDS | xargs -L1 kill
     fi
     i=0

--- a/metadium/scripts/gmet.sh
+++ b/metadium/scripts/gmet.sh
@@ -202,6 +202,31 @@ function get_gmet_pids ()
     ps axww | grep -v grep | grep "gmet.*datadir.*${1}" | awk '{print $1}'
 }
 
+# Print the pids of gmet processes holding this node's chaindata open.
+#
+# This identifies a running node by an open file instead of by its command
+# line, so it stays correct when the get_gmet_pids match fails. The two
+# together are what lets "stop" tell "already stopped" apart from "running,
+# but I could not recognize it" - see the "stop" case below.
+function get_chaindata_holders ()
+{
+    local d=$1 log=$1/geth/chaindata/LOG p
+
+    [ -e "$log" ] || return 0
+    if command -v lsof > /dev/null 2>&1; then
+	lsof -- "$log" 2>/dev/null | awk 'NR > 1 && $1 == "gmet" { print $2 }' | sort -u
+	return 0
+    fi
+    # No lsof: fall back to /proc. Only processes owned by the caller are
+    # visible there, which covers the normal case of gmet.sh having started
+    # the node itself.
+    for p in /proc/[0-9]*; do
+	[ "$(cat $p/comm 2>/dev/null)" = "gmet" ] || continue
+	readlink $p/fd/* 2>/dev/null | grep -q "^${d}/geth/chaindata/" && \
+	    echo ${p#/proc/}
+    done
+}
+
 function do_nodes ()
 {
     LHN=$(hostname)
@@ -270,7 +295,23 @@ case "$1" in
     STOP_FORCE=${STOP_FORCE:-1}
     LOCK_TIMEOUT=${LOCK_TIMEOUT:-200}
     PIDS=$(get_gmet_pids ${dir})
-    if [ ! "$PIDS" = "" ]; then
+    if [ "$PIDS" = "" ]; then
+	# Nothing matched the command line. Before reporting success, confirm the
+	# node really is down: an empty match used to be indistinguishable from a
+	# running node whose command line we failed to recognize, and in that case
+	# stop returned 0 without ever sending a signal. Callers that archive the
+	# chaindata afterwards then tar a live database, which yields a snapshot
+	# with no state trie. Refuse loudly instead of stopping nothing quietly.
+	HOLDERS=$(get_chaindata_holders ${dir})
+	if [ ! "$HOLDERS" = "" ]; then
+	    echo "failed."
+	    echo "$0: ${dir}/geth/chaindata is open by gmet pid(s) $(echo $HOLDERS)," >&2
+	    echo "$0: but no matching command line was found, so the node was left" >&2
+	    echo "$0: running. Refusing to report a stop that did not happen." >&2
+	    ps -o pid=,args= -p $(echo $HOLDERS | tr ' ' ',') >&2
+	    exit 1
+	fi
+    else
         # check if we're the miner or leader
         CMD='
 function check_if_mining() {
@@ -329,10 +370,16 @@ if (admin.metadiumInfo != null && admin.metadiumInfo.self != null) {
     # wait until geth/chaindata is free
     i=0
     while [ $i -lt $LOCK_TIMEOUT ]; do
-	lsof ${dir}/geth/chaindata/LOG 2>&1 | grep -q gmet > /dev/null 2>&1 || break
+	HOLDERS=$(get_chaindata_holders ${dir})
+	[ "$HOLDERS" = "" ] && break
 	sleep 1
 	i=$((i + 1))
     done
+    if [ ! "$(get_chaindata_holders ${dir})" = "" ]; then
+	echo "failed."
+	echo "$0: ${dir}/geth/chaindata is still open after ${LOCK_TIMEOUT}s." >&2
+	exit 1
+    fi
     echo "done."
     ;;
 

--- a/metadium/scripts/gmet.sh
+++ b/metadium/scripts/gmet.sh
@@ -149,9 +149,14 @@ function start ()
     [ -f "$d/.rc" ] && source "$d/.rc"
     [ "$COINBASE" = "" ] && COINBASE="" || COINBASE="--miner.etherbase $COINBASE"
 
-    RPCOPT="--http --http.addr ${HTTP_ADDR:-127.0.0.1}"
+    # Bind address for the JSON-RPC / WS endpoints. Override per node in .rc,
+    # e.g. HTTP_ADDR=127.0.0.1 on a block producer that must not expose RPC.
+    # The default stays 0.0.0.0 so that a node whose .rc predates these knobs
+    # keeps serving the endpoint it served before, rather than silently
+    # dropping to loopback on the next restart.
+    RPCOPT="--http --http.addr ${HTTP_ADDR:-0.0.0.0}"
     [ "$PORT" = "" ] || RPCOPT="${RPCOPT} --http.port ${PORT}"
-    RPCOPT="${RPCOPT} --ws --ws.addr ${WS_ADDR:-127.0.0.1}"
+    RPCOPT="${RPCOPT} --ws --ws.addr ${WS_ADDR:-0.0.0.0}"
     [ "$PORT" = "" ] || RPCOPT="${RPCOPT} --ws.port $((${PORT}+10))"
     [ "$NONCE_LIMIT" = "" ] || NONCE_LIMIT="--noncelimit $NONCE_LIMIT"
     [ "$BOOT_NODES" = "" ] || BOOT_NODES="--bootnodes $BOOT_NODES"
@@ -252,6 +257,18 @@ case "$1" in
 "stop")
     echo -n "stopping..."
     dir=$(get_data_dir $2)
+    # Shutdown knobs, overridable per node in $dir/.rc. The defaults reproduce
+    # the historical behaviour: wait 200s for SIGTERM, then SIGKILL.
+    #   STOP_TIMEOUT  seconds to wait for the node to exit on its own
+    #   STOP_FORCE    1 = escalate to SIGKILL, 0 = never SIGKILL and fail instead
+    #   LOCK_TIMEOUT  seconds to wait for the chaindata lock to be released
+    # A node with a large database can need well over 200s to flush; SIGKILL
+    # there means an unclean database, so raise STOP_TIMEOUT (or set
+    # STOP_FORCE=0) instead of letting the escalation fire.
+    [ -f "${dir}/.rc" ] && source "${dir}/.rc"
+    STOP_TIMEOUT=${STOP_TIMEOUT:-200}
+    STOP_FORCE=${STOP_FORCE:-1}
+    LOCK_TIMEOUT=${LOCK_TIMEOUT:-200}
     PIDS=$(get_gmet_pids ${dir})
     if [ ! "$PIDS" = "" ]; then
         # check if we're the miner or leader
@@ -292,20 +309,29 @@ if (admin.metadiumInfo != null && admin.metadiumInfo.self != null) {
 	${dir}/bin/gmet attach --exec "$CMD" ipc:${dir}/gmet.ipc | grep -v "undefined"
 	echo $PIDS | xargs -L1 kill
     fi
-    for i in {1..200}; do
+    i=0
+    while [ $i -lt $STOP_TIMEOUT ]; do
 	PIDS=$(get_gmet_pids ${dir})
 	[ "$PIDS" = "" ] && break
 	echo -n "."
 	sleep 1
+	i=$((i + 1))
     done
     PIDS=$(get_gmet_pids ${dir})
     if [ ! "$PIDS" = "" ]; then
+	if [ "$STOP_FORCE" = "0" ]; then
+	    echo "still running after ${STOP_TIMEOUT}s, refusing to SIGKILL (STOP_FORCE=0)."
+	    exit 1
+	fi
+	echo -n "forcing..."
 	echo $PIDS | xargs -L1 kill -9
     fi
     # wait until geth/chaindata is free
-    for i in {1..200}; do
+    i=0
+    while [ $i -lt $LOCK_TIMEOUT ]; do
 	lsof ${dir}/geth/chaindata/LOG 2>&1 | grep -q gmet > /dev/null 2>&1 || break
 	sleep 1
+	i=$((i + 1))
     done
     echo "done."
     ;;
@@ -323,7 +349,8 @@ if (admin.metadiumInfo != null && admin.metadiumInfo.self != null) {
     ;;
 
 "restart")
-    $0 stop $2
+    # Never start a second instance on top of a node that refused to stop.
+    $0 stop $2 || exit 1
     start $2
     ;;
 

--- a/params/config.go
+++ b/params/config.go
@@ -166,7 +166,7 @@ var (
 		PangyoBlock:         big.NewInt(73_225_410),
 		ApplepieBlock:       big.NewInt(73_225_410),
 		BokbunjaBlock:       big.NewInt(73_225_410),
-		CamelliaBlock:       nil, // Not yet activated on mainnet
+		CamelliaBlock:       big.NewInt(117_764_000), // 2026-08-27 12:00 KST mainnet activation
 		Ethash:              new(EthashConfig),
 	}
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 1        // Minor version component of the current release
-	VersionPatch = 0        // Patch version component of the current release
+	VersionPatch = 1        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 

--- a/tests/scripts/gmet_stop_test.sh
+++ b/tests/scripts/gmet_stop_test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# gmet_stop_test.sh - exercise the "stop" paths of metadium/scripts/gmet.sh
+#
+# Usage:
+#   ./gmet_stop_test.sh                  # test metadium/scripts/gmet.sh
+#   ./gmet_stop_test.sh /opt/meta/bin/gmet.sh   # test a deployed copy
+#
+# The fake gmet is a copy of /bin/sleep, so its process name really is "gmet"
+# (which is what get_chaindata_holders filters on), and argv[0] is rewritten
+# with "exec -a" to control whether get_gmet_pids' command line match hits.
+
+set -u
+SRC=${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../metadium/scripts" && pwd)/gmet.sh}
+T=$(mktemp -d)
+HOLDERS=""
+cleanup () {
+    for p in $HOLDERS; do kill -9 $p 2>/dev/null; done
+    rm -rf "$T"
+}
+trap cleanup EXIT
+
+mkdir -p "$T/node/bin" "$T/node/geth/chaindata"
+cp "$SRC" "$T/node/bin/gmet.sh"
+cp /bin/sleep "$T/node/bin/gmet"
+echo "fake rocksdb LOG" > "$T/node/geth/chaindata/LOG"
+GMETSH="$T/node/bin/gmet.sh"
+LOG="$T/node/geth/chaindata/LOG"
+
+PASS=0; FAIL=0
+check () { # check <name> <want rc> <got rc> [<must contain>] [<output>]
+    if [ "$2" = "$3" ] && { [ $# -lt 4 ] || echo "$5" | grep -q "$4"; }; then
+	echo "  PASS  $1 (rc=$3)"; PASS=$((PASS + 1))
+    else
+	echo "  FAIL  $1 (want rc=$2 got rc=$3, wanted /${4:-}/)"; FAIL=$((FAIL + 1))
+	echo "$5" | sed 's/^/        | /'
+    fi
+}
+alive () { kill -0 $1 2>/dev/null; }
+
+# Start a fake node holding chaindata/LOG open, advertising argv[0] "$1".
+# Output is detached so it does not hold this shell's pipes open.
+start_holder () {
+    if [ "${2:-}" = "ignore-term" ]; then
+	( exec 9< "$LOG"; trap '' TERM
+	  exec -a "$1" "$T/node/bin/gmet" 600 ) > /dev/null 2>&1 &
+    else
+	( exec 9< "$LOG"; exec -a "$1" "$T/node/bin/gmet" 600 ) > /dev/null 2>&1 &
+    fi
+    HOLDER=$!
+    HOLDERS="$HOLDERS $HOLDER"
+    sleep 0.5
+}
+run_stop () { timeout 60 env "$@" "$GMETSH" stop 2>&1; }
+
+echo "== A. node genuinely stopped: fast path, success =="
+OUT=$(run_stop STOP_TIMEOUT=3 LOCK_TIMEOUT=3); RC=$?
+check "reports done and exits 0" 0 $RC "done." "$OUT"
+
+echo "== B. node running, command line NOT matched (the fn2 failure) =="
+start_holder "$T/node/bin/gmet"   # no "datadir" in argv -> get_gmet_pids misses
+OUT=$(run_stop STOP_TIMEOUT=3 LOCK_TIMEOUT=3); RC=$?
+check "refuses instead of claiming success" 1 $RC "did not happen" "$OUT"
+check "names the offending pid" 1 $RC "$HOLDER" "$OUT"
+alive $HOLDER && { echo "  PASS  node left running, not tar-able"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  node died unexpectedly"; FAIL=$((FAIL + 1)); }
+kill -9 $HOLDER 2>/dev/null; sleep 0.3
+
+echo "== C. node running, command line matched: normal SIGTERM path =="
+start_holder "$T/node/bin/gmet --datadir $T/node"
+OUT=$(run_stop STOP_TIMEOUT=10 LOCK_TIMEOUT=10); RC=$?
+check "stops the node and exits 0" 0 $RC "done." "$OUT"
+alive $HOLDER && { echo "  FAIL  process survived"; FAIL=$((FAIL + 1)); } \
+    || { echo "  PASS  process is gone"; PASS=$((PASS + 1)); }
+
+echo "== D. matched but ignores SIGTERM, STOP_FORCE=0: refuse to SIGKILL =="
+start_holder "$T/node/bin/gmet --datadir $T/node" ignore-term
+OUT=$(run_stop STOP_TIMEOUT=3 LOCK_TIMEOUT=3 STOP_FORCE=0); RC=$?
+check "refuses to SIGKILL" 1 $RC "refusing to SIGKILL" "$OUT"
+alive $HOLDER && { echo "  PASS  node left running (clean DB preserved)"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  node was killed anyway"; FAIL=$((FAIL + 1)); }
+
+echo "== E. same node, STOP_FORCE=1: escalate to SIGKILL =="
+OUT=$(run_stop STOP_TIMEOUT=3 LOCK_TIMEOUT=5 STOP_FORCE=1); RC=$?
+check "escalates and succeeds" 0 $RC "forcing" "$OUT"
+alive $HOLDER && { echo "  FAIL  survived SIGKILL"; FAIL=$((FAIL + 1)); } \
+    || { echo "  PASS  process is gone"; PASS=$((PASS + 1)); }
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ $FAIL -eq 0 ]

--- a/tests/scripts/gmet_stop_test.sh
+++ b/tests/scripts/gmet_stop_test.sh
@@ -85,6 +85,28 @@ check "escalates and succeeds" 0 $RC "forcing" "$OUT"
 alive $HOLDER && { echo "  FAIL  survived SIGKILL"; FAIL=$((FAIL + 1)); } \
     || { echo "  PASS  process is gone"; PASS=$((PASS + 1)); }
 
+echo "== F. unresolvable data dir: refuse, and do not touch other nodes =="
+# A decoy that the degraded 'gmet.*datadir.*' pattern would have matched:
+# with an empty dir the old code killed every gmet on the host.
+start_holder "$T/node/bin/gmet --datadir /some/other/node"
+DECOY=$HOLDER
+OUT=$(timeout 60 "$GMETSH" stop "/does/not/exist" 2>&1); RC=$?
+check "refuses on unresolvable dir" 1 $RC "cannot resolve" "$OUT"
+alive $DECOY && { echo "  PASS  unrelated node untouched"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  unrelated node was killed"; FAIL=$((FAIL + 1)); }
+kill -9 $DECOY 2>/dev/null; sleep 0.3
+
+echo "== G. renamed binary (gmet-rocksdb) holding chaindata: still detected =="
+# lsof truncates COMMAND to 9 chars ("gmet-rock"); exact-matching 'gmet'
+# could never see this documented deploy practice.
+cp /bin/sleep "$T/node/bin/gmet-rocksdb"
+( exec 9< "$LOG"; exec -a "gmet-rocksdb" "$T/node/bin/gmet-rocksdb" 600 ) > /dev/null 2>&1 &
+HOLDER=$!; HOLDERS="$HOLDERS $HOLDER"; sleep 0.5
+OUT=$(run_stop STOP_TIMEOUT=3 LOCK_TIMEOUT=3); RC=$?
+check "refuses instead of claiming success" 1 $RC "did not happen" "$OUT"
+check "names the renamed holder pid" 1 $RC "$HOLDER" "$OUT"
+kill -9 $HOLDER 2>/dev/null; sleep 0.3
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [ $FAIL -eq 0 ]


### PR DESCRIPTION
## Summary

Activates the Camellia hard fork on Metadium mainnet at block **117,764,000** (2026-08-27 12:00 KST), bumps the version to **1.1.1**, and carries the shutdown-deadlock fixes that the rollout depends on.

Testnet has been running Camellia since block 86,449,000 (2026-05-20) with no incidents in ~2.5 months, including a verified fork transition.

## Why these pieces ship together

- **Fork block** — one line in `params/config.go`. The number is derived from a measured block time of 2.000014 s (sampled over the last 100k/500k/1M blocks from a synced node, head 116,861,511 at 2026-08-06 05:51 UTC). The exact target for 12:00 KST is 117,763,549; rounding to the nearest 1,000 follows the testnet precedent and lands activation at ~12:15 KST, inside working hours.
- **Shutdown fixes** — the rollout is a one-node-at-a-time rolling restart across the production fleet. The previous binary could hang on shutdown and get SIGKILLed after 200 s, corrupting the database exactly in the path the rollout exercises. `gmet.sh stop` also used to report success without stopping anything when its process match failed. Shipping the fork without these fixes makes the deployment itself the risk.
- **Version bump to 1.1.1** — 1.1.0 (`e3f51b3e6`) is already published as `m1.1.0.testnet` and must not be rolled out on its own (it predates the shutdown fix). Without a bump, `gmet version` cannot tell the two builds apart; the rollout plan verifies every node by version string at D-3, and the exchange notice points operators at this release.

## Verification

- Built and deployed on three operator nodes (LevelDB full node, RocksDB full node with `-tags rocksdb`, and an archive node), mainnet + testnet services: graceful stops in 0–3 s, static peers reattached, block heights in lockstep with the network, zero BAD BLOCK / panic.
- Startup banner confirms the fork is loaded: `Camellia Fork: #117764000`.
- Shutdown fix regression test: `tests/scripts/gmet_stop_test.sh` (4/4 failed before the fix, 9/9 pass after).

## Commits

- `metadium/scripts: make gmet.sh shutdown knobs configurable` — `STOP_TIMEOUT` / `STOP_FORCE` / `LOCK_TIMEOUT` overridable per node via `.rc`; defaults unchanged (200 s, then SIGKILL).
- `metadium/metclient: bound the TrieAccessMu hold in CallContract` — the shutdown deadlock root cause.
- `metadium/scripts: refuse to report a stop that never happened` — verify by open chaindata handles, not just the command-line match; `restart` no longer starts a second instance on a failed stop.
- `params: activate Camellia on Metadium mainnet at block 117,764,000`
- `docs: add Camellia mainnet hard fork activation plan`
- `docs: note snapshot-publishing nodes in the Camellia rollout`
- `docs: document the shutdown deadlock and the stop-verification rule`
- `docs: drop operator server details from CLAUDE.md`
- `docs: record the confirmed Camellia mainnet fork block`
- `params: bump version to 1.1.1`
- `README: record current version and Camellia activation schedule`

## Rollout (for reference)

Binary ships ahead of activation — deployment and activation are separate events, leaving a 7-day rollback window before the fork block. Exchange notice goes out by 2026-08-13 (D-14). Fleet rolling deploy at D-7, full-fleet version check at D-3.
