### PR TITLE
ci: teach master-ci and dev-cron the Camellia toolchain

### DIFF
--- a/.github/workflows/dev-cron.yml
+++ b/.github/workflows/dev-cron.yml
@@ -6,54 +6,53 @@ on:
 
 jobs:
   build_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: dev
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
-      
+        go-version: '1.21'
+
     - name: Build Go-Metadium
+      env:
+        CFLAGS: "-Wno-error=unused-parameter"
+        CXXFLAGS: "-Wno-error=unused-parameter"
       run: make metadium
     - name: Check Build
       run: ls -al build/metadium.tar.gz
 
   lint_test:
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [1.17, 1.18, 1.19]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: dev
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.version }}
-      
+        go-version: '1.21'
+
     - name: Check Lint
       run: make lint
 
   unit_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: dev
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: '1.21'
 
-    - name: Check golang Test Cases 
+    - name: Check golang Test Cases
       run: |
         unset ANDROID_HOME
         make test

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -5,19 +5,22 @@ on:
     branches:
       - master
 
+# master carries the Camellia (go-ethereum v1.13.14) tree, which needs the
+# same toolchain as dev-ci; the old 1.17-1.19 matrix predates the rebase and
+# cannot build this codebase.
 jobs:
   build_test:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
-      
+        go-version: '1.21'
+
     - name: Build Go-Metadium
       env:
         CFLAGS: "-Wno-error=unused-parameter"
@@ -27,37 +30,33 @@ jobs:
       run: ls -al build/metadium.tar.gz
 
   lint_test:
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [1.17, 1.18, 1.19]
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.version }}
-      
+        go-version: '1.21'
+
     - name: Check Lint
       run: make lint
 
   unit_test:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: '1.21'
 
-    - name: Check golang Test Cases 
+    - name: Check golang Test Cases
       run: |
         unset ANDROID_HOME
-        make test
+        make test-short


### PR DESCRIPTION
Both workflows predate the v1.13.14 rebase and still build with Go 1.17–1.19, which cannot compile this codebase — `master-ci` fails on every PR to `master` (first fired on #58) and `dev-cron` fails nightly. This aligns them with `dev-ci`: checkout@v4, setup-go@v5, Go 1.21, single lint job. `master-ci` runs `test-short` like dev-ci; `dev-cron` keeps the full `make test` as the nightly deep pass.

Unblocks #58 (the release-line transition), which will be rebuilt on top of dev once this lands so its tree stays bit-identical to dev.