### PR TITLE
ci: give the i386 tests room for the v1.13.14 tree

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,13 +11,16 @@ jobs:
   build:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
       - name: Run tests
-        run: go test -short ./...
+        # The v1.13.14 tree's triedb/pathdb suite runs long on 32-bit and
+        # blows go test's default 10m per-package timeout on this runner;
+        # it passes, it is just slow.
+        run: go test -short -timeout 20m ./...
         env:
           GOOS: linux
           GOARCH: 386


### PR DESCRIPTION
The Camellia tree's `triedb/pathdb` suite exceeds `go test`'s default 10m per-package timeout under GOARCH=386 on the self-hosted runner — first observed on #58, where this workflow ran against the new tree for the first time. The failure stack shows the suite mid-work, not deadlocked; 20m gives it headroom. Also refreshes checkout/setup-go action versions. Unblocks the remaining red check on #58.