### PR TITLE
cmd/geth, metclient: fix 32-bit builds; give the i386 suite room

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,9 +18,9 @@ jobs:
           go-version: 1.21.4
       - name: Run tests
         # The v1.13.14 tree's triedb/pathdb suite runs long on 32-bit and
-        # blows go test's default 10m per-package timeout on this runner;
+        # exceeds go test's default per-package timeout on this runner
         # it passes, it is just slow.
-        run: go test -short -timeout 20m ./...
+        run: go test -short -timeout 40m ./...
         env:
           GOOS: linux
           GOARCH: 386

--- a/cmd/geth/governancedeploy.go
+++ b/cmd/geth/governancedeploy.go
@@ -88,7 +88,7 @@ func deployGovernanceContracts(cliCtx *cli.Context) error {
 	// get command line arguments
 	url := cliCtx.String(urlFlag.Name)
 	gas := cliCtx.Int(gasFlag.Name)
-	gasPrice := cliCtx.Int(gasPriceFlag.Name)
+	gasPrice := cliCtx.Int64(gasPriceFlag.Name)
 
 	if gas <= 0 {
 		gas = 0xF000000

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -503,8 +503,10 @@ func limitMaxRss(max int64) {
 		if err != nil {
 			log.Error("Getrusage() failed:", "reason", err)
 		} else {
-			// Maxrss is int32 on 32-bit platforms and int64 on 64-bit ones.
-			if int64(rusage.Maxrss) > max {
+			// Maxrss is int32 on 32-bit platforms and int64 on 64-bit
+			// ones, so the conversion is required there and redundant
+			// here -- which is why unconvert must be silenced.
+			if int64(rusage.Maxrss) > max { //nolint:unconvert
 				log.Info("Calling FreeOSMemory()", "Max", max, "Rusage.Maxrss", rusage.Maxrss)
 				godebug.FreeOSMemory()
 			}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -503,7 +503,8 @@ func limitMaxRss(max int64) {
 		if err != nil {
 			log.Error("Getrusage() failed:", "reason", err)
 		} else {
-			if rusage.Maxrss > max {
+			// Maxrss is int32 on 32-bit platforms and int64 on 64-bit ones.
+			if int64(rusage.Maxrss) > max {
 				log.Info("Calling FreeOSMemory()", "Max", max, "Rusage.Maxrss", rusage.Maxrss)
 				godebug.FreeOSMemory()
 			}

--- a/cmd/geth/metadiumcmd.go
+++ b/cmd/geth/metadiumcmd.go
@@ -189,9 +189,9 @@ To give password in command line, use "--password <(echo <password>)".
 		Name:  "gas",
 		Usage: "gas amount",
 	}
-	gasPriceFlag = &cli.IntFlag{
+	gasPriceFlag = &cli.Int64Flag{
 		Name:  "gasprice",
-		Usage: "gas price",
+		Usage: "gas price", // in wei; exceeds a 32-bit int
 	}
 	urlFlag = &cli.StringFlag{
 		Name:  "url",
@@ -504,7 +504,7 @@ func deployContract(ctx *cli.Context) error {
 	passwd := ctx.String(utils.PasswordFileFlag.Name)
 	url := ctx.String(urlFlag.Name)
 	gas := ctx.Int(gasFlag.Name)
-	gasPrice := ctx.Int(gasPriceFlag.Name)
+	gasPrice := ctx.Int64(gasPriceFlag.Name)
 
 	if len(url) == 0 || ctx.Args().Len() != 3 {
 		return fmt.Errorf("Invalid Arguments")

--- a/metadium/metclient/util.go
+++ b/metadium/metclient/util.go
@@ -245,7 +245,7 @@ func GetContractReceipt(ctx context.Context, cli *ethclient.Client, hash common.
 }
 
 func Deploy(ctx context.Context, cli *ethclient.Client, from *keystore.Key,
-	contractData *ContractData, args []interface{}, gas, _gasPrice int) (
+	contractData *ContractData, args []interface{}, gas int, _gasPrice int64) (
 	hash common.Hash, err error) {
 	// pull transaction parameters from metadium node
 	chainId, gasPrice, nonce, err := GetOpportunisticTxParams(
@@ -255,7 +255,7 @@ func Deploy(ctx context.Context, cli *ethclient.Client, from *keystore.Key,
 	}
 
 	if _gasPrice > 0 {
-		gasPrice = big.NewInt(int64(_gasPrice))
+		gasPrice = big.NewInt(_gasPrice)
 	}
 
 	var data []byte
@@ -436,14 +436,14 @@ func SendContract(ctx context.Context, contract *RemoteContract, method string,
 	return
 }
 
-func SendValue(ctx context.Context, cli *ethclient.Client, from *keystore.Key, to common.Address, amount, gas, _gasPrice int) (hash common.Hash, err error) {
+func SendValue(ctx context.Context, cli *ethclient.Client, from *keystore.Key, to common.Address, amount, gas int, _gasPrice int64) (hash common.Hash, err error) {
 	chainId, gasPrice, nonce, err := GetOpportunisticTxParams(
 		ctx, cli, from.Address, false, true)
 	if err != nil {
 		return
 	}
 	if _gasPrice > 0 {
-		gasPrice = big.NewInt(int64(_gasPrice))
+		gasPrice = big.NewInt(_gasPrice)
 	}
 
 	var tx, stx *types.Transaction


### PR DESCRIPTION
The i386 workflow's second run on #58 surfaced two real GOARCH=386 compile errors in fork code — exactly the class of bug that workflow exists to catch:

- `cmd/geth/governancedeploy.go`: the default gas price (80000000000 wei) does not fit a 32-bit `int`. The `gasprice` flag and the `Deploy`/`SendValue` price parameters are widened to `int64` — wei amounts never belonged in a platform-sized int.
- `cmd/geth/main.go`: `syscall.Rusage.Maxrss` is `int32` on 32-bit platforms; the comparison now goes through an explicit `int64` conversion.

Verified: `GOOS=linux GOARCH=386 go build ./cmd/geth ./metadium/...` now compiles (it did not before), amd64 build unaffected, `go vet` clean.

Also raises the i386 test timeout to 40m — the `core` suite alone exceeds 20m under 386 on the shared runner.