### PR TITLE
params: restore testnet PetersburgBlock (0.10.x stored-config parity) + #64 review nits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,9 @@ tests/spec-tests/
 /core/txpool/blobpool/blobpool/
 
 # Operator-local files (never commit: addresses, accounts, keys, schedules)
-# Any *.local.* suffix, not just .md -- covers ad-hoc .sh/.html scratch too.
+# Any *.local.* suffix, not just .md -- covers ad-hoc .sh/.html scratch too,
+# plus extensionless foo.local. Note both globs also match intentionally
+# committed names like config.local.json -- none exist today; use
+# `git add -f` if one ever should.
 *.local.*
+*.local

--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,10 @@ tests/spec-tests/
 
 # Operator-local files (never commit: addresses, accounts, keys, schedules)
 # Any *.local.* suffix, not just .md -- covers ad-hoc .sh/.html scratch too,
-# plus extensionless foo.local. Note both globs also match intentionally
-# committed names like config.local.json -- none exist today; use
-# `git add -f` if one ever should.
+# plus extensionless foo.local. Caveats: *.local.* also matches names meant
+# to be committed (config.local.json -- none exist today; `git add -f` if one
+# ever should), and *.local also matches directories, which git won't descend
+# into -- files inside a data.local/ can only be re-included per-file with
+# `git add -f`, not with a negation pattern.
 *.local.*
 *.local

--- a/core/txpool/legacypool/txmaxsize_metadium_test.go
+++ b/core/txpool/legacypool/txmaxsize_metadium_test.go
@@ -3,7 +3,8 @@
 // A go-ethereum rebase once silently reverted txMaxSize to the upstream
 // default (4*txSlotSize, 128KB), which rejects max-size contract deployments
 // in the pool before the EIP-3860 check. This test makes the next rebase fail
-// loudly instead of shipping that regression again.
+// loudly instead of shipping that regression again. Each assertion has its
+// own failure message so the diagnosis matches the actual cause.
 
 package legacypool
 
@@ -13,27 +14,23 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// minCreationOverhead is the headroom the pool ceiling must leave above the
-// raw code size: constructor bytecode, ABI-encoded arguments, RLP envelope
-// and signature. 8KB matches the historical MaxTransactionSize-MaxCodeSize gap.
-const minCreationOverhead = 8192
-
 func TestTxMaxSizeCoversMaxCode(t *testing.T) {
-	// A creation tx carries initcode (up to MaxCodeSize) plus constructor
-	// arguments, signature and RLP envelope. The pool admission ceiling must
-	// leave room for that overhead above the raw code size -- zero headroom
-	// would pass a bare ">= MaxCodeSize" check while still rejecting every
-	// real max-size deployment.
-	if txMaxSize < params.MaxCodeSize+minCreationOverhead {
-		t.Fatalf("txMaxSize (%d) < params.MaxCodeSize+minCreationOverhead (%d): "+
-			"max-size contract deployments will be rejected by the pool before "+
-			"EIP-3860. A rebase likely reverted the Metadium ceiling to the "+
-			"upstream default.",
-			txMaxSize, params.MaxCodeSize+minCreationOverhead)
-	}
+	// The pool ceiling must track the fork-specific named constant -- an
+	// inlined value is invisible to the next rebase.
 	if txMaxSize != params.MaxTransactionSize {
-		t.Fatalf("txMaxSize (%d) != params.MaxTransactionSize (%d): the pool "+
-			"ceiling must track the fork-specific constant, not an inlined value.",
+		t.Errorf("txMaxSize (%d) != params.MaxTransactionSize (%d): the pool "+
+			"ceiling must track the fork-specific constant. A rebase likely "+
+			"reverted it to the upstream default.",
 			txMaxSize, params.MaxTransactionSize)
+	}
+	// And the constant itself must keep creation-tx headroom above
+	// MaxCodeSize -- with zero headroom every real max-size deployment is
+	// still rejected even though the ceiling nominally covers the code.
+	if params.MaxTransactionSize < params.MaxCodeSize+params.TxCreationOverhead {
+		t.Errorf("params.MaxTransactionSize (%d) < params.MaxCodeSize+"+
+			"params.TxCreationOverhead (%d): max-size contract deployments "+
+			"will be rejected by the pool before EIP-3860. If MaxCodeSize "+
+			"changed intentionally, move MaxTransactionSize with it.",
+			params.MaxTransactionSize, params.MaxCodeSize+params.TxCreationOverhead)
 	}
 }

--- a/core/txpool/legacypool/txmaxsize_metadium_test.go
+++ b/core/txpool/legacypool/txmaxsize_metadium_test.go
@@ -13,15 +13,23 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+// minCreationOverhead is the headroom the pool ceiling must leave above the
+// raw code size: constructor bytecode, ABI-encoded arguments, RLP envelope
+// and signature. 8KB matches the historical MaxTransactionSize-MaxCodeSize gap.
+const minCreationOverhead = 8192
+
 func TestTxMaxSizeCoversMaxCode(t *testing.T) {
 	// A creation tx carries initcode (up to MaxCodeSize) plus constructor
 	// arguments, signature and RLP envelope. The pool admission ceiling must
-	// leave room for that overhead above the raw code size.
-	if txMaxSize < params.MaxCodeSize {
-		t.Fatalf("txMaxSize (%d) < params.MaxCodeSize (%d): max-size contract "+
-			"deployments will be rejected by the pool before EIP-3860. A rebase "+
-			"likely reverted the Metadium ceiling to the upstream default.",
-			txMaxSize, params.MaxCodeSize)
+	// leave room for that overhead above the raw code size -- zero headroom
+	// would pass a bare ">= MaxCodeSize" check while still rejecting every
+	// real max-size deployment.
+	if txMaxSize < params.MaxCodeSize+minCreationOverhead {
+		t.Fatalf("txMaxSize (%d) < params.MaxCodeSize+minCreationOverhead (%d): "+
+			"max-size contract deployments will be rejected by the pool before "+
+			"EIP-3860. A rebase likely reverted the Metadium ceiling to the "+
+			"upstream default.",
+			txMaxSize, params.MaxCodeSize+minCreationOverhead)
 	}
 	if txMaxSize != params.MaxTransactionSize {
 		t.Fatalf("txMaxSize (%d) != params.MaxTransactionSize (%d): the pool "+

--- a/params/config.go
+++ b/params/config.go
@@ -172,8 +172,13 @@ var (
 
 	// MetadiumTestnetChainConfig contains the chain parameters to run a node on the Metadium test network.
 	MetadiumTestnetChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(12),
-		HomesteadBlock:      big.NewInt(0),
+		ChainID:        big.NewInt(12),
+		HomesteadBlock: big.NewInt(0),
+		// DAO fields intentionally differ from mainnet (0/true): re-arming
+		// DAOForkSupport would make VerifyDAOHeaderExtraData require the DAO
+		// extra-data marker over blocks 0-9, which testnet genesis does not
+		// carry -- that would break a from-genesis resync. nil/false is the
+		// correct form here; mainnet keeps 0/true for stored-config parity.
 		DAOForkBlock:        nil,
 		DAOForkSupport:      false,
 		EIP150Block:         big.NewInt(5623000),
@@ -181,17 +186,22 @@ var (
 		EIP158Block:         big.NewInt(0),
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(5623000),
-		PetersburgBlock:     nil,
-		IstanbulBlock:       big.NewInt(5623000),
-		MuirGlacierBlock:    big.NewInt(5623000),
-		BerlinBlock:         big.NewInt(38067000),
-		LondonBlock:         big.NewInt(38067000),
-		AvocadoBlock:        big.NewInt(40_759_810),
-		PangyoBlock:         big.NewInt(44_671_396),
-		ApplepieBlock:       big.NewInt(44_671_396),
-		BokbunjaBlock:       big.NewInt(44_671_396),
-		CamelliaBlock:       big.NewInt(86_449_000), // 2026-05-20 12:00 KST testnet activation
-		Ethash:              new(EthashConfig),
+		// Must stay non-nil (0.10.x parity): nodes that last ran 0.10.x store
+		// petersburgBlock=5623000 in chaindata, and a nil here fails the
+		// stored-config compatibility check on startup, silently rewinding the
+		// chain to 5,622,999. IsPetersburg() is unaffected either way since
+		// Constantinople is also 5623000.
+		PetersburgBlock:  big.NewInt(5623000),
+		IstanbulBlock:    big.NewInt(5623000),
+		MuirGlacierBlock: big.NewInt(5623000),
+		BerlinBlock:      big.NewInt(38067000),
+		LondonBlock:      big.NewInt(38067000),
+		AvocadoBlock:     big.NewInt(40_759_810),
+		PangyoBlock:      big.NewInt(44_671_396),
+		ApplepieBlock:    big.NewInt(44_671_396),
+		BokbunjaBlock:    big.NewInt(44_671_396),
+		CamelliaBlock:    big.NewInt(86_449_000), // 2026-05-20 12:00 KST testnet activation
+		Ethash:           new(EthashConfig),
 	}
 
 	// AllEthashProtocolChanges contains every protocol change (EIPs) introduced

--- a/params/config.go
+++ b/params/config.go
@@ -174,15 +174,16 @@ var (
 	MetadiumTestnetChainConfig = &ChainConfig{
 		ChainID:        big.NewInt(12),
 		HomesteadBlock: big.NewInt(0),
-		// DAO fields intentionally differ from mainnet (0/true). Both forms are
-		// inert on Metadium: the extra-data enforcement in
-		// VerifyDAOHeaderExtraData sits behind metaminer.IsPoW(), and a
-		// stored-config mismatch here cannot rewind -- the compat error's
-		// rewind target is genesis, which core/genesis.go suppresses and simply
-		// rewrites the stored config. nil/false is kept as the tidier form;
-		// mainnet keeps 0/true for parity with its 0.10.x stored configs.
-		DAOForkBlock:        nil,
-		DAOForkSupport:      false,
+		// 0/true matches mainnet and every 0.10.x-era stored config (including
+		// the embedded genesis JSON). Behaviourally inert on Metadium PoA --
+		// the extra-data enforcement in VerifyDAOHeaderExtraData sits behind
+		// metaminer.IsPoW() -- but the parity matters for checkCompatible: it
+		// returns on the first mismatch, and the DAO check runs before every
+		// later fork's check, so a nil/false here would mask Petersburg,
+		// Camellia and future-fork compatibility checks on the one startup
+		// (upgrade from 0.10.x) where they must run.
+		DAOForkBlock:        big.NewInt(0),
+		DAOForkSupport:      true,
 		EIP150Block:         big.NewInt(5623000),
 		EIP155Block:         big.NewInt(0),
 		EIP158Block:         big.NewInt(0),
@@ -190,9 +191,13 @@ var (
 		ConstantinopleBlock: big.NewInt(5623000),
 		// Must stay non-nil (0.10.x parity): nodes that last ran 0.10.x store
 		// petersburgBlock=5623000 in chaindata, and a nil here fails the
-		// stored-config compatibility check on startup, silently rewinding the
-		// chain to 5,622,999. IsPetersburg() is unaffected either way since
-		// Constantinople is also 5623000.
+		// stored-config compatibility check on startup, rewinding the chain to
+		// 5,622,999 (loud in the log -- "Rewinding chain to upgrade
+		// configuration" -- but easy to miss). IsPetersburg() is unaffected
+		// either way since Constantinople is also 5623000. Note the check only
+		// runs when this compiled config is consulted, i.e. nodes started with
+		// --metadium-testnet or a genesis file; a no-flag start takes the
+		// stored-config branch in core/genesis.go and never sees this value.
 		PetersburgBlock:  big.NewInt(5623000),
 		IstanbulBlock:    big.NewInt(5623000),
 		MuirGlacierBlock: big.NewInt(5623000),

--- a/params/config.go
+++ b/params/config.go
@@ -174,11 +174,13 @@ var (
 	MetadiumTestnetChainConfig = &ChainConfig{
 		ChainID:        big.NewInt(12),
 		HomesteadBlock: big.NewInt(0),
-		// DAO fields intentionally differ from mainnet (0/true): re-arming
-		// DAOForkSupport would make VerifyDAOHeaderExtraData require the DAO
-		// extra-data marker over blocks 0-9, which testnet genesis does not
-		// carry -- that would break a from-genesis resync. nil/false is the
-		// correct form here; mainnet keeps 0/true for stored-config parity.
+		// DAO fields intentionally differ from mainnet (0/true). Both forms are
+		// inert on Metadium: the extra-data enforcement in
+		// VerifyDAOHeaderExtraData sits behind metaminer.IsPoW(), and a
+		// stored-config mismatch here cannot rewind -- the compat error's
+		// rewind target is genesis, which core/genesis.go suppresses and simply
+		// rewrites the stored config. nil/false is kept as the tidier form;
+		// mainnet keeps 0/true for parity with its 0.10.x stored configs.
 		DAOForkBlock:        nil,
 		DAOForkSupport:      false,
 		EIP150Block:         big.NewInt(5623000),

--- a/params/metadium_config_test.go
+++ b/params/metadium_config_test.go
@@ -1,0 +1,111 @@
+// metadium_config_test.go -- Metadium fork guard.
+//
+// Every fork block in the built-in Metadium chain configs is consensus- or
+// upgrade-critical state that a go-ethereum rebase can silently revert (the
+// v1.13.14 rebase nil'd testnet PetersburgBlock, which rewinds upgrading
+// 0.10.x nodes by ~80M blocks, and CheckConfigForkOrder is stubbed out in
+// this fork). This table pins every field to its historical value so the
+// next such drift is a CI failure instead of a production discovery.
+
+package params
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestMetadiumChainConfigsPinned(t *testing.T) {
+	for _, network := range []struct {
+		name    string
+		config  *ChainConfig
+		forks   map[string]*big.Int
+		daoFork bool
+	}{
+		{
+			name:   "mainnet",
+			config: MetadiumMainnetChainConfig,
+			forks: map[string]*big.Int{
+				"ChainID":             big.NewInt(11),
+				"HomesteadBlock":      big.NewInt(0),
+				"DAOForkBlock":        big.NewInt(0),
+				"EIP150Block":         big.NewInt(11_441_000),
+				"EIP155Block":         big.NewInt(0),
+				"EIP158Block":         big.NewInt(0),
+				"ByzantiumBlock":      big.NewInt(0),
+				"ConstantinopleBlock": big.NewInt(11_441_000),
+				"PetersburgBlock":     big.NewInt(11_441_000),
+				"IstanbulBlock":       big.NewInt(11_441_000),
+				"MuirGlacierBlock":    big.NewInt(11_441_000),
+				"BerlinBlock":         big.NewInt(51_960_000),
+				"LondonBlock":         big.NewInt(51_960_000),
+				"AvocadoBlock":        big.NewInt(59_860_000),
+				"PangyoBlock":         big.NewInt(73_225_410),
+				"ApplepieBlock":       big.NewInt(73_225_410),
+				"BokbunjaBlock":       big.NewInt(73_225_410),
+				"CamelliaBlock":       big.NewInt(117_764_000),
+			},
+			daoFork: true,
+		},
+		{
+			name:   "testnet",
+			config: MetadiumTestnetChainConfig,
+			forks: map[string]*big.Int{
+				"ChainID":             big.NewInt(12),
+				"HomesteadBlock":      big.NewInt(0),
+				"DAOForkBlock":        big.NewInt(0),
+				"EIP150Block":         big.NewInt(5_623_000),
+				"EIP155Block":         big.NewInt(0),
+				"EIP158Block":         big.NewInt(0),
+				"ByzantiumBlock":      big.NewInt(0),
+				"ConstantinopleBlock": big.NewInt(5_623_000),
+				"PetersburgBlock":     big.NewInt(5_623_000),
+				"IstanbulBlock":       big.NewInt(5_623_000),
+				"MuirGlacierBlock":    big.NewInt(5_623_000),
+				"BerlinBlock":         big.NewInt(38_067_000),
+				"LondonBlock":         big.NewInt(38_067_000),
+				"AvocadoBlock":        big.NewInt(40_759_810),
+				"PangyoBlock":         big.NewInt(44_671_396),
+				"ApplepieBlock":       big.NewInt(44_671_396),
+				"BokbunjaBlock":       big.NewInt(44_671_396),
+				"CamelliaBlock":       big.NewInt(86_449_000),
+			},
+			daoFork: true,
+		},
+	} {
+		c := network.config
+		got := map[string]*big.Int{
+			"ChainID":             c.ChainID,
+			"HomesteadBlock":      c.HomesteadBlock,
+			"DAOForkBlock":        c.DAOForkBlock,
+			"EIP150Block":         c.EIP150Block,
+			"EIP155Block":         c.EIP155Block,
+			"EIP158Block":         c.EIP158Block,
+			"ByzantiumBlock":      c.ByzantiumBlock,
+			"ConstantinopleBlock": c.ConstantinopleBlock,
+			"PetersburgBlock":     c.PetersburgBlock,
+			"IstanbulBlock":       c.IstanbulBlock,
+			"MuirGlacierBlock":    c.MuirGlacierBlock,
+			"BerlinBlock":         c.BerlinBlock,
+			"LondonBlock":         c.LondonBlock,
+			"AvocadoBlock":        c.AvocadoBlock,
+			"PangyoBlock":         c.PangyoBlock,
+			"ApplepieBlock":       c.ApplepieBlock,
+			"BokbunjaBlock":       c.BokbunjaBlock,
+			"CamelliaBlock":       c.CamelliaBlock,
+		}
+		for field, want := range network.forks {
+			g := got[field]
+			if g == nil || g.Cmp(want) != 0 {
+				t.Errorf("%s %s = %v, want %v: a rebase likely dropped or changed a "+
+					"Metadium fork value. If this change is intentional, update this "+
+					"pin alongside it.", network.name, field, g, want)
+			}
+		}
+		if c.DAOForkSupport != network.daoFork {
+			t.Errorf("%s DAOForkSupport = %v, want %v (0.10.x stored-config parity; "+
+				"a mismatch masks later fork compatibility checks on upgrade, since "+
+				"checkCompatible returns on the first failing check)",
+				network.name, c.DAOForkSupport, network.daoFork)
+		}
+	}
+}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -155,6 +155,13 @@ const (
 	// hard fork.
 	MaxTransactionSize = 262144 // 256KB
 
+	// TxCreationOverhead is the minimum headroom MaxTransactionSize must keep
+	// above MaxCodeSize for the non-code parts of a creation tx: constructor
+	// bytecode, ABI-encoded arguments, RLP envelope and signature. 8KB is the
+	// historical MaxTransactionSize-MaxCodeSize gap, not an independently
+	// derived bound. Named once here; the guard test asserts the relationship.
+	TxCreationOverhead = 8192
+
 	// Precompiled contract gas prices
 
 	EcrecoverGas        uint64 = 3000 // Elliptic curve sender recovery gas price

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -149,6 +149,10 @@ const (
 	// the upstream default, and the regression only surfaced at release time. A
 	// bare 8*txSlotSize would be invisible to the next rebase; this name (and
 	// TestTxMaxSizeCoversMaxCode) is what makes it fail loudly.
+	//
+	// Not consensus-critical -- local pool admission policy only. It sits next
+	// to MaxCodeSize for the arithmetic relationship, but changing it needs no
+	// hard fork.
 	MaxTransactionSize = 262144 // 256KB
 
 	// Precompiled contract gas prices

--- a/tests/private-net/setup.sh
+++ b/tests/private-net/setup.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-GMET_BIN="${GMET_BIN:?set GMET_BIN to the gmet binary (e.g. GMET_BIN=../../build/bin/gmet ./setup.sh)}"
+# Defaults to the repo's build output; the -x check below owns the error path.
+GMET_BIN="${GMET_BIN:-$SCRIPT_DIR/../../build/bin/gmet}"
 USE_ROCKSDB="${USE_ROCKSDB:-1}"
 NETWORKID=1337
 PASSWORD="privatenet123"
@@ -16,7 +17,7 @@ PASSWORD="privatenet123"
 log()  { echo "[$(date '+%H:%M:%S')] $*"; }
 err()  { echo "[ERROR] $*" >&2; exit 1; }
 
-[[ -x "$GMET_BIN" ]] || err "gmet binary not found: $GMET_BIN"
+[[ -x "$GMET_BIN" ]] || err "gmet binary not found or not executable: $GMET_BIN (build it with 'make gmet', or point GMET_BIN at an absolute path)"
 
 log "=== Private network initialization started (chainId=$NETWORKID, CamelliaFork=100) ==="
 

--- a/tests/private-net/setup.sh
+++ b/tests/private-net/setup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-GMET_BIN="${GMET_BIN:-/path/to/gmet}"
+GMET_BIN="${GMET_BIN:?set GMET_BIN to the gmet binary (e.g. GMET_BIN=../../build/bin/gmet ./setup.sh)}"
 USE_ROCKSDB="${USE_ROCKSDB:-1}"
 NETWORKID=1337
 PASSWORD="privatenet123"


### PR DESCRIPTION
Fixes the testnet chain-config drift found in @cp-khs's #58 review, and folds in the four non-blocking nits from the #64 review. Round 2 (`3c7b89a0d`) additionally restores the DAO fields and adds a golden-config table test, per this PR's reviews.

## 1. `MetadiumTestnetChainConfig`: restore 0.10.x parity

**`PetersburgBlock`: `nil` → `big.NewInt(5623000)`.** The v1.13.14 rebase dropped the value. Consensus is unaffected either way (`IsPetersburg()` answers identically since Constantinople is also 5623000), but the **stored-config compatibility check** is not: a node whose chaindata was last written by 0.10.x stores `petersburgBlock: 5623000`; on startup with `nil` the check fails without reaching the Constantinople escape hatch, and the node rewinds to block 5,622,999 — an ~80M-block resync announced by one `Rewinding chain to upgrade configuration` log line. Restoring is safe from both starting states: stored `5623000` compares equal; stored `nil` (nodes on a Camellia build) passes the escape hatch (stored Constantinople == new Petersburg).

**`DAOForkBlock`/`DAOForkSupport`: `nil`/`false` → `0`/`true`** (review round 2, @trident90's finding). `checkCompatible` returns on the *first* failing check and the DAO check runs before Petersburg/Camellia — and every stored testnet config in the wild is `0`/`true`. Keeping `nil`/`false` meant the suppressed DAO mismatch would preempt every later fork's compatibility check on exactly the startup (0.10.x upgrade) where they must run. Restoring parity removes the mask entirely; the DAO extra-data enforcement is inert on PoA either way (`metaminer.IsPoW()` gate).

**Fork ID is unchanged by both restores** (@cp-khs's check, re-verified): `gatherForks` deduplicates adjacent equal values, and 5623000 is already contributed by EIP150/Constantinople/Istanbul/MuirGlacier (0 by Homestead/EIP155/EIP158/Byzantium for the DAO block), so the fork list stays `[5623000, 38067000, 40759810, 44671396, 86449000]` — no handshake split against 1.1.0 or 0.10.x peers during a rolling deploy.

**Mainnet config is untouched** — verified field-by-field identical to 0.10.2 apart from `CamelliaBlock`.

## 2. Golden-config guard test (both reviewers' ask)

`params/metadium_config_test.go` pins **every** fork field of both built-in Metadium configs to its historical value. `CheckConfigForkOrder` is stubbed out in this fork and nothing else validates the configs in CI, which is why the Petersburg nil survived two release lines; this makes the next config drift a CI failure instead of a production discovery.

## 3. #64 review nits (updated per round 2)

- Guard test: headroom named once as `params.TxCreationOverhead` (8192, the historical gap), assertions split with cause-matched messages — no more zero-slack identity that could misdiagnose a deliberate `MaxCodeSize` change as a rebase regression.
- `params.MaxTransactionSize`: "not consensus-critical — pool admission policy only" note.
- `tests/private-net/setup.sh`: working default (`$SCRIPT_DIR/../../build/bin/gmet`, the sibling private-net-poa shape) with the existing `-x` check owning the single error path — keeps bare `./setup.sh` working and the header accurate.
- `.gitignore`: `*.local` added, caveats corrected (directory-matching behaviour, per-file `git add -f` re-include).

## Verification

On the fleet toolchain: `gofmt -l params/ core/ tests/` clean, `go vet` clean, `TestMetadiumChainConfigsPinned` + `TestTxMaxSizeCoversMaxCode` pass, `go build ./params/... ./core/...` OK, `bash -n` passes.

Release-note entries drafted: 0.10.x testnet operators should skip 1.1.0 (it carries the nil) and go straight to 1.1.1; testnet nodes need `--metadium-testnet`/`TESTNET=1` for compiled-config updates to apply (the no-flag stored-config path — tracked with the embedded-genesis `camelliaBlock` follow-up).
