### PR TITLE
core/txpool: reapply pool-side TRS enforcement lost in the v1.13.14 rebase

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -92,6 +93,8 @@ type blobTxMeta struct {
 	id   uint64      // Storage ID in the pool's persistent store
 	size uint32      // Byte size in the pool's persistent store
 
+	to *common.Address // Recipient, needed for the Metadium TRS purge (blob txs always have one)
+
 	nonce      uint64       // Needed to prioritize inclusion order within an account
 	costCap    *uint256.Int // Needed to validate cumulative balance sufficiency
 	execTipCap *uint256.Int // Needed to prioritize inclusion order across accounts and validate replacement price bump
@@ -115,6 +118,7 @@ func newBlobTxMeta(id uint64, size uint32, tx *types.Transaction) *blobTxMeta {
 		hash:       tx.Hash(),
 		id:         id,
 		size:       size,
+		to:         tx.To(),
 		nonce:      tx.Nonce(),
 		costCap:    uint256.MustFromBig(tx.Cost()),
 		execTipCap: uint256.MustFromBig(tx.GasTipCap()),
@@ -315,6 +319,9 @@ type BlobPool struct {
 	insertFeed   event.Feed // Event feed to send out new tx events on pool inclusion (reorg included)
 
 	lock sync.RWMutex // Mutex protecting the pool during reorg handling
+
+	trsListMap   map[common.Address]bool // Metadium TRS restriction list at the current head
+	trsSubscribe bool                    // Whether this node subscribes to TRS enforcement
 }
 
 // New creates a new blob transaction pool to gather, sort and filter inbound
@@ -780,10 +787,38 @@ func (p *BlobPool) offload(addr common.Address, nonce uint64, id uint64, inclusi
 // Reset implements txpool.SubPool, allowing the blob pool's internal state to be
 // kept in sync with the main transaction pool's internal state.
 func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
+	// Metadium: prefetch the TRS restriction list BEFORE taking the pool lock
+	// -- the governance read can block on TrieAccessMu (see the matching
+	// prefetch in legacypool.runReorg).
+	var (
+		trsMap map[common.Address]bool
+		trsSub bool
+		trsErr error
+	)
+	if !metaminer.IsPoW() {
+		trsMap, trsSub, trsErr = metaminer.GetTRSListMap(newHead.Number)
+	}
+
 	waitStart := time.Now()
 	p.lock.Lock()
 	resetwaitHist.Update(time.Since(waitStart).Nanoseconds())
 	defer p.lock.Unlock()
+
+	// Metadium: assign the prefetched TRS list; on a failed read keep the
+	// previous list rather than failing open. Purge any stored restricted
+	// transactions -- admission (validateTx) rejects new ones, and the miner
+	// filter keeps them out of blocks either way, but they must not linger in
+	// the store and keep being gossiped.
+	if !metaminer.IsPoW() {
+		if trsErr == nil {
+			p.trsListMap, p.trsSubscribe = trsMap, trsSub
+		} else if trsErr != metaminer.ErrNotInitialized {
+			log.Warn("TRS list refresh failed; keeping previous list", "err", trsErr)
+		}
+		if p.trsSubscribe && len(p.trsListMap) > 0 {
+			p.dropRestricted()
+		}
+	}
 
 	defer func(start time.Time) {
 		resettimeHist.Update(time.Since(start).Nanoseconds())
@@ -1076,6 +1111,53 @@ func (p *BlobPool) SetGasTip(tip *big.Int) {
 	p.updateStorageMetrics()
 }
 
+// dropRestricted evicts every stored transaction whose sender or recipient is
+// on the Metadium TRS restriction list. Blob nonces must stay gapless, so the
+// first restricted transaction in an account takes everything after it down
+// too, mirroring the SetGasTip eviction shape. The caller holds p.lock.
+func (p *BlobPool) dropRestricted() {
+	for addr, txs := range p.index {
+		match := -1
+		for i, tx := range txs {
+			if metaminer.TRSRestricted(p.trsListMap, addr, tx.to) {
+				match = i
+				break
+			}
+		}
+		if match < 0 {
+			continue
+		}
+		var (
+			ids    []uint64
+			nonces []uint64
+		)
+		for _, tx := range txs[match:] {
+			ids = append(ids, tx.id)
+			nonces = append(nonces, tx.nonce)
+
+			p.spent[addr] = new(uint256.Int).Sub(p.spent[addr], tx.costCap)
+			p.stored -= uint64(tx.size)
+			delete(p.lookup, tx.hash)
+		}
+		if match > 0 {
+			p.index[addr] = txs[:match]
+			heap.Fix(p.evict, p.evict.index[addr])
+		} else {
+			delete(p.index, addr)
+			delete(p.spent, addr)
+
+			heap.Remove(p.evict, p.evict.index[addr])
+			p.reserve(addr, false)
+		}
+		log.Warn("Dropping TRS-restricted blob transactions", "from", addr, "drop", nonces, "ids", ids)
+		for _, id := range ids {
+			if err := p.store.Delete(id); err != nil {
+				log.Error("Failed to delete dropped transaction", "id", id, "err", err)
+			}
+		}
+	}
+}
+
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (p *BlobPool) validateTx(tx *types.Transaction) error {
@@ -1089,6 +1171,14 @@ func (p *BlobPool) validateTx(tx *types.Transaction) error {
 	}
 	if err := txpool.ValidateTransaction(tx, p.head, p.signer, baseOpts); err != nil {
 		return err
+	}
+	// Metadium: nodes subscribing to TRS reject transactions whose sender or
+	// recipient is on the restriction list (parity with legacypool admission).
+	if !metaminer.IsPoW() && p.trsSubscribe {
+		from, _ := types.Sender(p.signer, tx)
+		if metaminer.TRSRestricted(p.trsListMap, from, tx.To()) {
+			return txpool.ErrIncludedTRSList
+		}
 	}
 	// Ensure the transaction adheres to the stateful pool filters (nonce, balance)
 	stateOpts := &txpool.ValidationOptionsWithState{

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -789,14 +789,21 @@ func (p *BlobPool) offload(addr common.Address, nonce uint64, id uint64, inclusi
 func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	// Metadium: prefetch the TRS restriction list BEFORE taking the pool lock
 	// -- the governance read can block on TrieAccessMu (see the matching
-	// prefetch in legacypool.runReorg).
+	// prefetch in legacypool.runReorg). Gated on the pool being able to hold
+	// anything at all: before Cancun/Camellia activates, type-3 transactions
+	// fail validation, the index is necessarily empty, and an unconditional
+	// per-head read here would only duplicate legacypool's for zero benefit.
 	var (
-		trsMap map[common.Address]bool
-		trsSub bool
-		trsErr error
+		trsMap  map[common.Address]bool
+		trsSub  bool
+		trsErr  error
+		trsRead bool
 	)
-	if !metaminer.IsPoW() {
-		trsMap, trsSub, trsErr = metaminer.GetTRSListMap(newHead.Number)
+	if !metaminer.IsPoW() && newHead != nil {
+		if cfg := p.chain.Config(); cfg.IsCancun(newHead.Number, newHead.Time) || cfg.IsCamellia(newHead.Number) {
+			trsMap, trsSub, trsErr = metaminer.GetTRSListMap(newHead.Number)
+			trsRead = true
+		}
 	}
 
 	waitStart := time.Now()
@@ -809,7 +816,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	// transactions -- admission (validateTx) rejects new ones, and the miner
 	// filter keeps them out of blocks either way, but they must not linger in
 	// the store and keep being gossiped.
-	if !metaminer.IsPoW() {
+	if trsRead {
 		if trsErr == nil {
 			p.trsListMap, p.trsSubscribe = trsMap, trsSub
 		} else if trsErr != metaminer.ErrNotInitialized {
@@ -1131,13 +1138,15 @@ func (p *BlobPool) dropRestricted() {
 			ids    []uint64
 			nonces []uint64
 		)
-		for _, tx := range txs[match:] {
+		for i := match; i < len(txs); i++ {
+			tx := txs[i]
 			ids = append(ids, tx.id)
 			nonces = append(nonces, tx.nonce)
 
 			p.spent[addr] = new(uint256.Int).Sub(p.spent[addr], tx.costCap)
 			p.stored -= uint64(tx.size)
 			delete(p.lookup, tx.hash)
+			txs[i] = nil // release the meta through the retained backing array
 		}
 		if match > 0 {
 			p.index[addr] = txs[:match]
@@ -1156,6 +1165,7 @@ func (p *BlobPool) dropRestricted() {
 			}
 		}
 	}
+	p.updateStorageMetrics()
 }
 
 // validateTx checks whether a transaction is valid according to the consensus

--- a/core/txpool/blobpool/trs_metadium_test.go
+++ b/core/txpool/blobpool/trs_metadium_test.go
@@ -1,0 +1,128 @@
+// trs_metadium_test.go -- Metadium fork guard.
+//
+// dropRestricted evicts stored blob transactions whose sender or recipient is
+// on the TRS restriction list, using the SetGasTip eviction shape: blob
+// nonces must stay gapless, so the first restricted transaction in an account
+// takes everything after it down too. This test seeds a store, initializes
+// the pool from it, and pins the three account shapes: tail-drop on a
+// restricted recipient, whole-account drop on a restricted sender, and an
+// untouched bystander.
+
+package blobpool
+
+import (
+	"crypto/ecdsa"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/ethereum/go-ethereum/rlp"
+	billy "github.com/holiman/billy"
+	"github.com/holiman/uint256"
+)
+
+// makeTxTo is makeTx with an explicit recipient.
+func makeTxTo(nonce uint64, to common.Address, key *ecdsa.PrivateKey) *types.Transaction {
+	blobtx := makeUnsignedTx(nonce, 1, 1000, 100)
+	blobtx.To = &to
+	return types.MustSignNewTx(key, types.LatestSigner(testChainConfig), blobtx)
+}
+
+func TestBlobPoolDropRestricted(t *testing.T) {
+	storage, _ := os.MkdirTemp("", "blobpool-trs-")
+	defer os.RemoveAll(storage)
+
+	os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700)
+	store, _ := billy.Open(billy.Options{Path: filepath.Join(storage, pendingTransactionStore)}, newSlotter(), nil)
+
+	var (
+		key1, _ = crypto.GenerateKey()
+		key2, _ = crypto.GenerateKey()
+		key3, _ = crypto.GenerateKey()
+
+		addr1 = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2 = crypto.PubkeyToAddress(key2.PublicKey)
+		addr3 = crypto.PubkeyToAddress(key3.PublicKey)
+
+		cleanTo      = common.Address{0xcc}
+		restrictedTo = common.Address{0xbb}
+	)
+	// addr1: clean tx at nonce 0, restricted recipient at nonce 1 -> tail drop.
+	// addr2: restricted sender -> whole account drop.
+	// addr3: untouched bystander.
+	txs := []*types.Transaction{
+		makeTxTo(0, cleanTo, key1),
+		makeTxTo(1, restrictedTo, key1),
+		makeTxTo(0, cleanTo, key2),
+		makeTxTo(0, cleanTo, key3),
+	}
+	for _, tx := range txs {
+		blob, _ := rlp.EncodeToBytes(tx)
+		store.Put(blob)
+	}
+	store.Close()
+
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewDatabase(memorydb.New())), nil)
+	for _, addr := range []common.Address{addr1, addr2, addr3} {
+		statedb.AddBalance(addr, uint256.NewInt(1_000_000_000))
+	}
+	statedb.Commit(0, true)
+
+	chain := &testBlockChain{
+		config:  testChainConfig,
+		basefee: uint256.NewInt(1050),
+		blobfee: uint256.NewInt(105),
+		statedb: statedb,
+	}
+	pool := New(Config{Datadir: storage}, chain)
+	if err := pool.Init(1, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+		t.Fatalf("failed to create blob pool: %v", err)
+	}
+	defer pool.Close()
+
+	if have := len(pool.index); have != 3 {
+		t.Fatalf("want 3 accounts before purge, have %d", have)
+	}
+
+	pool.lock.Lock()
+	pool.trsListMap = map[common.Address]bool{restrictedTo: true, addr2: true}
+	pool.trsSubscribe = true
+	pool.dropRestricted()
+	pool.lock.Unlock()
+
+	// addr1 keeps nonce 0, loses the restricted-recipient tail.
+	if have := len(pool.index[addr1]); have != 1 {
+		t.Errorf("addr1: want 1 tx after purge, have %d", have)
+	}
+	if pool.Has(txs[1].Hash()) {
+		t.Errorf("addr1 restricted tx still tracked after purge")
+	}
+	if !pool.Has(txs[0].Hash()) {
+		t.Errorf("addr1 clean tx lost by purge")
+	}
+	// addr2 (restricted sender) is gone entirely.
+	if _, ok := pool.index[addr2]; ok {
+		t.Errorf("addr2 (restricted sender) still indexed after purge")
+	}
+	if pool.Has(txs[2].Hash()) {
+		t.Errorf("addr2 tx still tracked after purge")
+	}
+	// addr3 untouched.
+	if !pool.Has(txs[3].Hash()) {
+		t.Errorf("addr3 bystander tx lost by purge")
+	}
+	// Heap/index/store bookkeeping stays consistent.
+	verifyPoolInternals(t, pool)
+
+	// The freed account must be claimable again (reservation released).
+	if err := pool.reserve(addr2, true); err != nil {
+		t.Errorf("addr2 reservation not released by whole-account purge: %v", err)
+	}
+	pool.reserve(addr2, false)
+}

--- a/core/txpool/errors.go
+++ b/core/txpool/errors.go
@@ -34,6 +34,10 @@ var (
 	// with a different one without the required price bump.
 	ErrReplaceUnderpriced = errors.New("replacement transaction underpriced")
 
+	// ErrIncludedTRSList is returned if the address included in the TRSList.
+	// (Metadium TRS -- Transaction Restriction Service, 0.10.x parity)
+	ErrIncludedTRSList = errors.New("included in the TRSList")
+
 	// ErrAccountLimitExceeded is returned if a transaction would exceed the number
 	// allowed by a pool for a single account.
 	ErrAccountLimitExceeded = errors.New("account limit exceeded")

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -420,14 +420,19 @@ func (pool *LegacyPool) loop() {
 			}
 
 		// Metadium: periodically remove pending transactions on the TRS
-		// restriction list, regardless of TRS subscription (0.10.x parity).
+		// restriction list (0.10.x parity). Deliberate asymmetries, inherited
+		// from 0.10.x -- do not "fix" in either direction: this ticker
+		// ignores pool.trsSubscribe while admission and the demote sweep
+		// require it (a non-subscribed node admits restricted txs and only
+		// purges them here, up to 3h later), and the queue is intentionally
+		// not swept (queued restricted txs surface in pending first).
 		case <-trs.C:
 			if !metaminer.IsPoW() {
 				pool.mu.Lock()
 				if len(pool.trsListMap) > 0 {
 					for addr := range pool.pending {
 						for _, tx := range pool.pending[addr].Flatten() {
-							if pool.trsListMap[addr] || (tx.To() != nil && pool.trsListMap[*tx.To()]) {
+							if metaminer.TRSRestricted(pool.trsListMap, addr, tx.To()) {
 								log.Debug("Discard pending transaction included in trsList", "hash", tx.Hash(), "addr", addr)
 								pool.removeTx(tx.Hash(), true, true)
 								pendingDiscardMeter.Mark(1)
@@ -720,9 +725,9 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Metadium: nodes subscribing to TRS reject transactions whose sender or
 	// recipient is on the restriction list (0.10.x parity).
-	if !metaminer.IsPoW() && len(pool.trsListMap) > 0 && pool.trsSubscribe {
+	if pool.trsEnforced() {
 		from, _ := types.Sender(pool.signer, tx) // validated above
-		if pool.trsListMap[from] || (tx.To() != nil && pool.trsListMap[*tx.To()]) {
+		if metaminer.TRSRestricted(pool.trsListMap, from, tx.To()) {
 			return txpool.ErrIncludedTRSList
 		}
 	}
@@ -1339,10 +1344,39 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 		// the flatten operation can be avoided.
 		promoteAddrs = dirtyAccounts.flatten()
 	}
+	// Metadium: prefetch the TRS restriction list for the new head BEFORE
+	// taking pool.mu. The governance read goes through callContractSerialized,
+	// whose TrieAccessMu wait is unbounded -- fetched under the pool lock it
+	// would freeze admission, the miner and this reorg loop for as long as an
+	// archive-mode triedb commit holds the write lock.
+	var (
+		trsMap map[common.Address]bool
+		trsSub bool
+		trsErr error
+	)
+	if reset != nil && !metaminer.IsPoW() {
+		head := reset.newHead
+		if head == nil {
+			head = pool.chain.CurrentBlock() // Special case during testing
+		}
+		if head != nil {
+			trsMap, trsSub, trsErr = metaminer.GetTRSListMap(head.Number)
+		}
+	}
 	pool.mu.Lock()
 	if reset != nil {
 		// Reset from the old head to the new, rescheduling any reorged transactions
 		pool.reset(reset.oldHead, reset.newHead)
+
+		// Metadium: assign the prefetched TRS list. On a failed read keep the
+		// previous list rather than failing open with no enforcement at all.
+		if !metaminer.IsPoW() {
+			if trsErr == nil {
+				pool.trsListMap, pool.trsSubscribe = trsMap, trsSub
+			} else if trsErr != metaminer.ErrNotInitialized {
+				log.Warn("TRS list refresh failed; keeping previous list", "err", trsErr)
+			}
+		}
 
 		// Nonces were reset, discard any events that became stale
 		for addr := range events {
@@ -1498,14 +1532,10 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	pool.currentHead.Store(newHead)
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
-
-	// Metadium: refresh the TRS restriction list at the new head (0.10.x parity).
-	if !metaminer.IsPoW() {
-		pool.trsListMap, pool.trsSubscribe, _ = metaminer.GetTRSListMap(newHead.Number)
-	} else {
-		pool.trsListMap = nil
-		pool.trsSubscribe = false
-	}
+	// Metadium: the TRS restriction list for this head was prefetched by
+	// runReorg before pool.mu was taken (the governance read can block on
+	// TrieAccessMu, and a synchronous fetch here would freeze the whole pool
+	// through the held lock) and is assigned there right after this returns.
 
 	// Inject any transactions discarded due to reorgs
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
@@ -1513,36 +1543,77 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	pool.addTxsLocked(reinject, false)
 }
 
+// trsEnforced reports whether this node enforces TRS at admission and in the
+// promote/demote sweeps: PoA consensus and an active TRS subscription. The
+// 3-hour purge ticker deliberately does NOT use this -- it ignores the
+// subscription, matching 0.10.x semantics.
+func (pool *LegacyPool) trsEnforced() bool {
+	return !metaminer.IsPoW() && pool.trsSubscribe
+}
+
 // trsAndFeePayerSweep removes from list any transaction whose sender or
 // recipient is TRS-restricted (when this node subscribes to TRS) and any
-// fee-delegated transaction whose fee payer can no longer cover its cost,
-// returning the dropped transactions. It restores the 0.10.x pool behaviour
-// that the v1.13.14 rebase dropped. The caller holds pool.mu and accounts for
-// the returned transactions in the lookup set and priced heap, exactly as it
-// does for balance-filter drops.
-func (pool *LegacyPool) trsAndFeePayerSweep(addr common.Address, list *list) types.Transactions {
-	doTrs := !metaminer.IsPoW() && len(pool.trsListMap) > 0 && pool.trsSubscribe
+// fee-delegated transaction whose fee payer can no longer cover its cost.
+// It restores the 0.10.x pool behaviour that the v1.13.14 rebase dropped.
+//
+// It returns the dropped transactions plus any higher-nonce transactions a
+// strict (pending) list cascaded out with them. The caller holds pool.mu and
+// must account for drops like balance-filter drops (lookup + priced) and
+// re-enqueue cascaded like balance-filter invalids -- dropping the cascade on
+// the floor leaks them: still in pool.all (blocking resubmission with
+// ErrAlreadyKnown), in no list any sweep or ticker reaches, and pinning the
+// address reservation state out of sync.
+func (pool *LegacyPool) trsAndFeePayerSweep(addr common.Address, list *list, pending bool) (drops, cascaded types.Transactions) {
+	doTrs := pool.trsEnforced()
 	if !pool.feedelegation && !doTrs {
-		return nil
+		return nil, nil
 	}
-	var drops types.Transactions
-	for _, tx := range list.Flatten() {
+	// Collect matches directly off the nonce map: no sort, no copy, and no
+	// invalidation of the sorted cache the miner is about to use.
+	var matched types.Transactions
+	for _, tx := range list.txs.items {
 		if pool.feedelegation && tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
 			feePayer := *tx.FeePayer()
-			if cost, _ := uint256.FromBig(tx.FeePayerCost()); cost != nil && pool.currentState.GetBalance(feePayer).Cmp(cost) < 0 {
-				log.Trace("Removed drained fee-delegation transaction", "hash", tx.Hash())
-				list.Remove(tx)
-				drops = append(drops, tx)
+			if cost, _ := uint256.FromBig(tx.FeePayerCost()); pool.currentState.GetBalance(feePayer).Cmp(cost) < 0 {
+				matched = append(matched, tx)
 				continue
 			}
 		}
-		if doTrs && (pool.trsListMap[addr] || (tx.To() != nil && pool.trsListMap[*tx.To()])) {
-			log.Trace("Removed transaction included in trsList", "hash", tx.Hash(), "addr", addr)
-			list.Remove(tx)
-			drops = append(drops, tx)
+		if doTrs && metaminer.TRSRestricted(pool.trsListMap, addr, tx.To()) {
+			matched = append(matched, tx)
 		}
 	}
-	return drops
+	if len(matched) == 0 {
+		return nil, nil
+	}
+	matchSet := make(map[common.Hash]struct{}, len(matched))
+	for _, tx := range matched {
+		matchSet[tx.Hash()] = struct{}{}
+	}
+	for _, tx := range matched {
+		removed, invalids := list.Remove(tx)
+		if !removed {
+			// Already cascaded out by an earlier removal; it is accounted for
+			// below when its cascade batch is partitioned.
+			continue
+		}
+		log.Trace("Removed restricted or unpayable transaction", "hash", tx.Hash(), "addr", addr)
+		drops = append(drops, tx)
+		if pending {
+			pool.pendingNonces.setIfLower(addr, tx.Nonce())
+		}
+		// A strict list cascades every higher-nonce tx out with the match.
+		// Cascade victims that themselves match are drops; the innocent rest
+		// must be handed back for re-enqueueing.
+		for _, itx := range invalids {
+			if _, ok := matchSet[itx.Hash()]; ok {
+				drops = append(drops, itx)
+			} else {
+				cascaded = append(cascaded, itx)
+			}
+		}
+	}
+	return drops, cascaded
 }
 
 // promoteExecutables moves transactions that have become processable from the
@@ -1568,8 +1639,10 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(pool.currentState.GetBalance(addr), gasLimit)
-		// Metadium: drop TRS-restricted and drained-fee-payer transactions too
-		drops = append(drops, pool.trsAndFeePayerSweep(addr, list)...)
+		// Metadium: drop TRS-restricted and drained-fee-payer transactions
+		// too (queue lists are non-strict, so there is no cascade here)
+		trsDrops, _ := pool.trsAndFeePayerSweep(addr, list, false)
+		drops = append(drops, trsDrops...)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
@@ -1771,8 +1844,15 @@ func (pool *LegacyPool) demoteUnexecutables() {
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
 		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), gasLimit)
-		// Metadium: drop TRS-restricted and drained-fee-payer transactions too
-		drops = append(drops, pool.trsAndFeePayerSweep(addr, list)...)
+		// Metadium: drop TRS-restricted and drained-fee-payer transactions
+		// too. Pending lists are strict, so a removal cascades every
+		// higher-nonce tx out with it -- innocent cascade victims are routed
+		// through the invalids path below, exactly like balance-filter
+		// invalids, so they get re-enqueued instead of leaking out of every
+		// list while still occupying pool.all.
+		trsDrops, trsCascaded := pool.trsAndFeePayerSweep(addr, list, true)
+		drops = append(drops, trsDrops...)
+		invalids = append(invalids, trsCascaded...)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			log.Trace("Removed unpayable pending transaction", "hash", hash)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -70,6 +71,7 @@ var (
 var (
 	evictionInterval    = time.Minute     // Time interval to check for evictable transactions
 	statsReportInterval = 8 * time.Second // Time interval to report transaction pool stats
+	trsTickerInterval   = 3 * time.Hour   // Metadium: time interval to purge TRS-restricted transactions
 )
 
 var (
@@ -361,10 +363,12 @@ func (pool *LegacyPool) loop() {
 		report  = time.NewTicker(statsReportInterval)
 		evict   = time.NewTicker(evictionInterval)
 		journal = time.NewTicker(pool.config.Rejournal)
+		trs     = time.NewTicker(trsTickerInterval)
 	)
 	defer report.Stop()
 	defer evict.Stop()
 	defer journal.Stop()
+	defer trs.Stop()
 
 	// Notify tests that the init phase is done
 	close(pool.initDoneCh)
@@ -411,6 +415,25 @@ func (pool *LegacyPool) loop() {
 				pool.mu.Lock()
 				if err := pool.journal.rotate(pool.local()); err != nil {
 					log.Warn("Failed to rotate local tx journal", "err", err)
+				}
+				pool.mu.Unlock()
+			}
+
+		// Metadium: periodically remove pending transactions on the TRS
+		// restriction list, regardless of TRS subscription (0.10.x parity).
+		case <-trs.C:
+			if !metaminer.IsPoW() {
+				pool.mu.Lock()
+				if len(pool.trsListMap) > 0 {
+					for addr := range pool.pending {
+						for _, tx := range pool.pending[addr].Flatten() {
+							if pool.trsListMap[addr] || (tx.To() != nil && pool.trsListMap[*tx.To()]) {
+								log.Debug("Discard pending transaction included in trsList", "hash", tx.Hash(), "addr", addr)
+								pool.removeTx(tx.Hash(), true, true)
+								pendingDiscardMeter.Mark(1)
+							}
+						}
+					}
 				}
 				pool.mu.Unlock()
 			}
@@ -694,6 +717,14 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	if err := txpool.ValidateTransactionWithState(tx, pool.signer, opts); err != nil {
 		return err
+	}
+	// Metadium: nodes subscribing to TRS reject transactions whose sender or
+	// recipient is on the restriction list (0.10.x parity).
+	if !metaminer.IsPoW() && len(pool.trsListMap) > 0 && pool.trsSubscribe {
+		from, _ := types.Sender(pool.signer, tx) // validated above
+		if pool.trsListMap[from] || (tx.To() != nil && pool.trsListMap[*tx.To()]) {
+			return txpool.ErrIncludedTRSList
+		}
 	}
 	return nil
 }
@@ -1468,10 +1499,50 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
 
+	// Metadium: refresh the TRS restriction list at the new head (0.10.x parity).
+	if !metaminer.IsPoW() {
+		pool.trsListMap, pool.trsSubscribe, _ = metaminer.GetTRSListMap(newHead.Number)
+	} else {
+		pool.trsListMap = nil
+		pool.trsSubscribe = false
+	}
+
 	// Inject any transactions discarded due to reorgs
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
 	core.SenderCacher.Recover(pool.signer, reinject)
 	pool.addTxsLocked(reinject, false)
+}
+
+// trsAndFeePayerSweep removes from list any transaction whose sender or
+// recipient is TRS-restricted (when this node subscribes to TRS) and any
+// fee-delegated transaction whose fee payer can no longer cover its cost,
+// returning the dropped transactions. It restores the 0.10.x pool behaviour
+// that the v1.13.14 rebase dropped. The caller holds pool.mu and accounts for
+// the returned transactions in the lookup set and priced heap, exactly as it
+// does for balance-filter drops.
+func (pool *LegacyPool) trsAndFeePayerSweep(addr common.Address, list *list) types.Transactions {
+	doTrs := !metaminer.IsPoW() && len(pool.trsListMap) > 0 && pool.trsSubscribe
+	if !pool.feedelegation && !doTrs {
+		return nil
+	}
+	var drops types.Transactions
+	for _, tx := range list.Flatten() {
+		if pool.feedelegation && tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
+			feePayer := *tx.FeePayer()
+			if cost, _ := uint256.FromBig(tx.FeePayerCost()); cost != nil && pool.currentState.GetBalance(feePayer).Cmp(cost) < 0 {
+				log.Trace("Removed drained fee-delegation transaction", "hash", tx.Hash())
+				list.Remove(tx)
+				drops = append(drops, tx)
+				continue
+			}
+		}
+		if doTrs && (pool.trsListMap[addr] || (tx.To() != nil && pool.trsListMap[*tx.To()])) {
+			log.Trace("Removed transaction included in trsList", "hash", tx.Hash(), "addr", addr)
+			list.Remove(tx)
+			drops = append(drops, tx)
+		}
+	}
+	return drops
 }
 
 // promoteExecutables moves transactions that have become processable from the
@@ -1497,6 +1568,8 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(pool.currentState.GetBalance(addr), gasLimit)
+		// Metadium: drop TRS-restricted and drained-fee-payer transactions too
+		drops = append(drops, pool.trsAndFeePayerSweep(addr, list)...)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
@@ -1698,6 +1771,8 @@ func (pool *LegacyPool) demoteUnexecutables() {
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
 		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), gasLimit)
+		// Metadium: drop TRS-restricted and drained-fee-payer transactions too
+		drops = append(drops, pool.trsAndFeePayerSweep(addr, list)...)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			log.Trace("Removed unpayable pending transaction", "hash", hash)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1350,17 +1350,18 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 	// would freeze admission, the miner and this reorg loop for as long as an
 	// archive-mode triedb commit holds the write lock.
 	var (
-		trsMap map[common.Address]bool
-		trsSub bool
-		trsErr error
+		trsMap  map[common.Address]bool
+		trsSub  bool
+		trsErr  error
+		trsHead *types.Header
 	)
 	if reset != nil && !metaminer.IsPoW() {
-		head := reset.newHead
-		if head == nil {
-			head = pool.chain.CurrentBlock() // Special case during testing
+		trsHead = reset.newHead
+		if trsHead == nil {
+			trsHead = pool.chain.CurrentBlock() // Special case during testing
 		}
-		if head != nil {
-			trsMap, trsSub, trsErr = metaminer.GetTRSListMap(head.Number)
+		if trsHead != nil {
+			trsMap, trsSub, trsErr = metaminer.GetTRSListMap(trsHead.Number)
 		}
 	}
 	pool.mu.Lock()
@@ -1368,13 +1369,18 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 		// Reset from the old head to the new, rescheduling any reorged transactions
 		pool.reset(reset.oldHead, reset.newHead)
 
-		// Metadium: assign the prefetched TRS list. On a failed read keep the
-		// previous list rather than failing open with no enforcement at all.
-		if !metaminer.IsPoW() {
-			if trsErr == nil {
-				pool.trsListMap, pool.trsSubscribe = trsMap, trsSub
-			} else if trsErr != metaminer.ErrNotInitialized {
-				log.Warn("TRS list refresh failed; keeping previous list", "err", trsErr)
+		// Metadium: assign the prefetched TRS list -- but only if reset
+		// actually adopted the head it was fetched for (reset bails early on
+		// e.g. a StateAt failure, and the pool then still enforces against
+		// its old head). On a failed read keep the previous list rather than
+		// failing open with no enforcement at all.
+		if !metaminer.IsPoW() && trsHead != nil {
+			if cur := pool.currentHead.Load(); cur != nil && cur.Hash() == trsHead.Hash() {
+				if trsErr == nil {
+					pool.trsListMap, pool.trsSubscribe = trsMap, trsSub
+				} else if trsErr != metaminer.ErrNotInitialized {
+					log.Warn("TRS list refresh failed; keeping previous list", "err", trsErr)
+				}
 			}
 		}
 
@@ -1568,13 +1574,16 @@ func (pool *LegacyPool) trsAndFeePayerSweep(addr common.Address, list *list, pen
 	if !pool.feedelegation && !doTrs {
 		return nil, nil
 	}
-	// Collect matches directly off the nonce map: no sort, no copy, and no
-	// invalidation of the sorted cache the miner is about to use.
+	// Collect matches directly off the nonce map: no sort, no copy, and --
+	// on the common no-match path -- no invalidation of the sorted cache the
+	// miner is about to use (list.Remove below invalidates it regardless once
+	// anything actually matches).
 	var matched types.Transactions
 	for _, tx := range list.txs.items {
 		if pool.feedelegation && tx.Type() == types.FeeDelegateDynamicFeeTxType && tx.FeePayer() != nil {
 			feePayer := *tx.FeePayer()
-			if cost, _ := uint256.FromBig(tx.FeePayerCost()); pool.currentState.GetBalance(feePayer).Cmp(cost) < 0 {
+			// A cost too large for uint256 reads as unpayable, not solvent.
+			if cost, overflow := uint256.FromBig(tx.FeePayerCost()); overflow || pool.currentState.GetBalance(feePayer).Cmp(cost) < 0 {
 				matched = append(matched, tx)
 				continue
 			}

--- a/core/txpool/legacypool/trs_metadium_test.go
+++ b/core/txpool/legacypool/trs_metadium_test.go
@@ -1,0 +1,103 @@
+// trs_metadium_test.go -- Metadium fork guard.
+//
+// The v1.13.14 rebase silently dropped the pool-side TRS (Transaction
+// Restriction Service) enforcement while leaving the trsListMap fields in
+// place, so nothing failed at compile time and no test caught it. These tests
+// pin the restored 0.10.x behaviour: a TRS-subscribed node rejects restricted
+// transactions at admission and purges any that slipped in earlier.
+
+package legacypool
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// asPoA switches the process-wide consensus method to PoA for the duration of
+// one test, since the TRS gates sit behind !metaminer.IsPoW() and the default
+// is PoW outside a running node. Tests using it must NOT call t.Parallel() --
+// serial tests finish (and restore the global) before the parallel batch runs.
+func asPoA(t *testing.T) {
+	t.Helper()
+	old := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoA
+	t.Cleanup(func() { params.ConsensusMethod = old })
+}
+
+func TestTRSRejectsRestrictedSender(t *testing.T) {
+	asPoA(t)
+
+	pool, key := setupPool()
+	defer pool.Close()
+
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	testAddBalance(pool, from, big.NewInt(1000000))
+
+	// Not subscribed: the transaction is accepted even if listed.
+	pool.trsListMap = map[common.Address]bool{from: true}
+	pool.trsSubscribe = false
+	if err := pool.addRemote(transaction(0, 100000, key)); err != nil {
+		t.Fatalf("unsubscribed node rejected listed tx: %v", err)
+	}
+
+	// Subscribed: the next transaction from the listed sender is rejected.
+	pool.trsSubscribe = true
+	if err := pool.addRemote(transaction(1, 100000, key)); !errors.Is(err, txpool.ErrIncludedTRSList) {
+		t.Fatalf("want ErrIncludedTRSList, got %v", err)
+	}
+}
+
+func TestTRSRejectsRestrictedRecipient(t *testing.T) {
+	asPoA(t)
+
+	pool, key := setupPool()
+	defer pool.Close()
+
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	testAddBalance(pool, from, big.NewInt(1000000))
+
+	// transaction() sends to the zero address; restrict that recipient.
+	pool.trsListMap = map[common.Address]bool{{}: true}
+	pool.trsSubscribe = true
+	if err := pool.addRemote(transaction(0, 100000, key)); !errors.Is(err, txpool.ErrIncludedTRSList) {
+		t.Fatalf("want ErrIncludedTRSList, got %v", err)
+	}
+}
+
+func TestTRSSweepPurgesPending(t *testing.T) {
+	asPoA(t)
+
+	pool, key := setupPool()
+	defer pool.Close()
+
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	testAddBalance(pool, from, big.NewInt(1000000))
+
+	if err := pool.addRemote(transaction(0, 100000, key)); err != nil {
+		t.Fatalf("failed to add tx: %v", err)
+	}
+	pending, _ := pool.Stats()
+	if pending != 1 {
+		t.Fatalf("want 1 pending before sweep, got %d", pending)
+	}
+
+	// The sender lands on the list after admission (e.g. governance update at
+	// the next head); the demotion sweep must purge the pending transaction.
+	pool.trsListMap = map[common.Address]bool{from: true}
+	pool.trsSubscribe = true
+
+	pool.mu.Lock()
+	pool.demoteUnexecutables()
+	pool.mu.Unlock()
+
+	pending, queued := pool.Stats()
+	if pending != 0 || queued != 0 {
+		t.Fatalf("want pool empty after sweep, got pending=%d queued=%d", pending, queued)
+	}
+}

--- a/core/txpool/legacypool/trs_metadium_test.go
+++ b/core/txpool/legacypool/trs_metadium_test.go
@@ -9,12 +9,14 @@
 package legacypool
 
 import (
+	"crypto/ecdsa"
 	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -67,6 +69,73 @@ func TestTRSRejectsRestrictedRecipient(t *testing.T) {
 	pool.trsSubscribe = true
 	if err := pool.addRemote(transaction(0, 100000, key)); !errors.Is(err, txpool.ErrIncludedTRSList) {
 		t.Fatalf("want ErrIncludedTRSList, got %v", err)
+	}
+}
+
+// toTransaction is transaction() with an explicit recipient.
+func toTransaction(nonce uint64, to common.Address, key *ecdsa.PrivateKey) *types.Transaction {
+	tx, _ := types.SignTx(types.NewTransaction(nonce, to, big.NewInt(100), 100000, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	return tx
+}
+
+// TestTRSSweepCascade pins the strict-list cascade contract: pending lists
+// are strict, so removing a restricted transaction at a low nonce also expels
+// every higher-nonce transaction behind it. Those innocent cascade victims
+// must be re-enqueued -- not leaked into a state where they occupy pool.all
+// (blocking resubmission) while belonging to no list.
+func TestTRSSweepCascade(t *testing.T) {
+	asPoA(t)
+
+	pool, key := setupPool()
+	defer pool.Close()
+
+	var (
+		from       = crypto.PubkeyToAddress(key.PublicKey)
+		restricted = common.Address{0xbb}
+		clean      = common.Address{0xcc}
+	)
+	testAddBalance(pool, from, big.NewInt(1000000))
+
+	// nonce 0 pays a soon-to-be-restricted recipient; 1 and 2 are innocent.
+	txs := []*types.Transaction{
+		toTransaction(0, restricted, key),
+		toTransaction(1, clean, key),
+		toTransaction(2, clean, key),
+	}
+	for i, tx := range txs {
+		if err := pool.addRemote(tx); err != nil {
+			t.Fatalf("failed to add tx %d: %v", i, err)
+		}
+	}
+	if pending, _ := pool.Stats(); pending != 3 {
+		t.Fatalf("want 3 pending before sweep, got %d", pending)
+	}
+
+	// The recipient lands on the list; the demote sweep must drop nonce 0 and
+	// re-queue (not leak) nonces 1 and 2.
+	pool.trsListMap = map[common.Address]bool{restricted: true}
+	pool.trsSubscribe = true
+
+	pool.mu.Lock()
+	pool.demoteUnexecutables()
+	pool.mu.Unlock()
+
+	pending, queued := pool.Stats()
+	if pending != 0 || queued != 2 {
+		t.Fatalf("want pending=0 queued=2 after sweep, got pending=%d queued=%d", pending, queued)
+	}
+	if pool.Has(txs[0].Hash()) {
+		t.Errorf("restricted tx still tracked by the pool after sweep")
+	}
+	for i := 1; i <= 2; i++ {
+		if !pool.Has(txs[i].Hash()) {
+			t.Errorf("cascade victim %d leaked out of the pool entirely", i)
+		}
+	}
+	// The freed nonce must be reusable: a ghost in pool.all would answer
+	// ErrAlreadyKnown / nonce-gap here forever.
+	if err := pool.addRemote(toTransaction(0, clean, key)); err != nil {
+		t.Fatalf("resubmission at the freed nonce failed: %v", err)
 	}
 }
 

--- a/metadium/miner/miner.go
+++ b/metadium/miner/miner.go
@@ -212,4 +212,15 @@ func GetTRSListMap(height *big.Int) (trsListMap map[common.Address]bool, trsSubs
 	return
 }
 
+// TRSRestricted reports whether a transaction between from and to touches the
+// TRS restriction list. to is nil for contract creations. This is the single
+// definition of the restriction predicate -- the tx pools and the miner all
+// call it, so admission, sweeping and block building cannot drift apart.
+func TRSRestricted(trsListMap map[common.Address]bool, from common.Address, to *common.Address) bool {
+	if len(trsListMap) == 0 {
+		return false
+	}
+	return trsListMap[from] || (to != nil && trsListMap[*to])
+}
+
 // EOF

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -989,12 +989,10 @@ func (w *worker) commitTransactions(env *environment, plainTxs, blobTxs *transac
 		from, _ := types.Sender(env.signer, tx)
 
 		// Metadium: TRS (Transaction Restriction Service) filtering
-		if env.trsListMap != nil && len(env.trsListMap) > 0 && env.trsSubscribe {
-			if env.trsListMap[from] || (tx.To() != nil && env.trsListMap[*tx.To()]) {
-				log.Debug("included in trsList", "hash", tx.Hash(), "from", from)
-				txs.Pop()
-				continue
-			}
+		if env.trsSubscribe && metaminer.TRSRestricted(env.trsListMap, from, tx.To()) {
+			log.Debug("included in trsList", "hash", tx.Hash(), "from", from)
+			txs.Pop()
+			continue
 		}
 
 		// Check whether the tx is replay protected. If we're not in the EIP155 hf


### PR DESCRIPTION
Reapplies the pool-side TRS (Transaction Restriction Service) enforcement that the v1.13.14 rebase silently dropped — found by the consensus-surface audit @cp-khs requested in #58, and the same drift class as the Petersburg find (#66): the rebase carried the `trsListMap`/`trsSubscribe` fields into legacypool but dropped **every use of them**, so nothing failed at compile time and no test caught it.

## What was lost vs 0.10.x master

| Enforcement point | master (`core/tx_pool.go`) | dev before this PR |
|---|---|---|
| Admission rejection (`ErrIncludedTRSList`) | :733-738 | symbol did not exist |
| Per-head list refresh (`GetTRSListMap`) | :1441-1447 | never called from `core/` |
| Queued/pending purge on promote/demote | :1474-1497 / :1695-1721 | absent |
| 3-hour purge ticker | :446-456 | absent |
| Miner-side filter at block build | ✅ | ✅ **survived** (`worker.go:991-998`) |

So restricted transactions could never be **mined** (the on-chain guarantee held), but every node accepted them into its pool, gossiped them network-wide, reported them as pending over RPC, and retried them indefinitely — defense-in-depth collapsed to a single point.

## What this PR restores (0.10.x parity, same shape)

- `validateTx`: rejects sender/recipient on the TRS list when this node subscribes (`ErrIncludedTRSList`, same error text as master)
- `reset()`: refreshes `trsListMap`/`trsSubscribe` from governance at each new head
- `promoteExecutables`/`demoteUnexecutables`: sweep restricted transactions out of queued/pending — the same sweep also restores the **drained-fee-payer eviction** (fee-delegated tx whose fee payer no longer covers `FeePayerCost`) that the rebase dropped in the same loops
- 3-hour ticker purging pending restricted transactions regardless of subscription

Scope matches master exactly: legacy pool only (the blob pool never had TRS checks; the miner-side filter still covers everything at block build). All gates sit behind `!metaminer.IsPoW()` as before.

## Tests

New guard tests (`trs_metadium_test.go`) pin admission rejection, recipient matching, the subscription gate, and the demotion sweep — written so the next rebase that drops this again fails loudly. Note: the gates are inert in unit tests by default because `params.ConsensusMethod` defaults to PoW outside a running node (this is also why the original omission was invisible to CI); the tests switch to PoA serially and restore.

Verified on the fleet toolchain: `gofmt` clean, `go vet ./core/txpool/...` clean, new tests 3/3 pass, full `./core/txpool/...` suite passes (no regression), full-tree `go build ./...` OK.

---

## Round 2 (`06fb8c6c6`) — both reviews addressed

- **Cascade leak (both reviewers, independently)**: the sweep now returns `(drops, cascaded)`; the demote call site routes innocent cascade victims through the invalids/`enqueueTx` path exactly like balance-filter invalids, matched victims stay drops, and `pendingNonces.setIfLower` mirrors `removeTx`. `TestTRSSweepCascade` pins it: restricted recipient at nonce 0, clean txs at 1–2, asserting they come back queued, `pool.all` stays consistent, and the freed nonce is resubmittable.
- **Blobpool parity** (trident90 MEDIUM): admission rejects restricted parties in `BlobPool.validateTx`; `Reset` refreshes the list (prefetched before the pool lock) and purges stored restricted txs with the `SetGasTip` eviction shape — first match takes the gapless tail; `blobTxMeta` carries the recipient.
- **Reset hot-path** (trident90): the governance read is prefetched in `runReorg` before `pool.mu`; a failed read keeps the previous list with a `log.Warn` instead of silently failing open.
- **Sweep cost**: matches collected off the nonce map directly — no `Flatten` sort/copy/cache invalidation per account per block; unreachable nil check removed.
- **One predicate**: `metaminer.TRSRestricted` is now the single definition used by admission (both pools), the sweep, the purge ticker and the miner filter; the ticker's deliberate 0.10.x asymmetries (ignores `trsSubscribe`; queue not swept) are documented in place.

Deferred with the reviewers' framing: separate drop meters (nofunds-meter parity kept for now), fetcher memoization of `ErrIncludedTRSList`, and the **Applepie gate loss** (pool + `state_transition` — out of this PR's diff; tracked for the follow-up batch, no impact on networks where Applepie is long active).

---

## Round 3 (`d9339cb94`) — full scope listing

1. `core/txpool/blobpool/blobpool.go` — the TRS read in `Reset` is now **conditional** on the pool being able to hold blobs (`IsCancun || IsCamellia` at the head, nil-head guarded): zero extra per-block reads before the fork activates. `dropRestricted` calls `updateStorageMetrics`, nils dropped meta slots, and gains a test.
2. `core/txpool/blobpool/trs_metadium_test.go` — **new**: `TestBlobPoolDropRestricted` seeds a store, initializes the pool from it, and pins tail-drop (restricted recipient), whole-account drop (restricted sender, reservation released), untouched bystander, plus `verifyPoolInternals`.
3. `core/txpool/legacypool/legacypool.go` — `runReorg` adopts the prefetched TRS list only when `reset` actually adopted the head it was fetched for (head-hash compare; covers the `StateAt`-failure early-outs); fee-payer costs that overflow uint256 read as unpayable; the sorted-cache comment no longer overclaims.

Note on "the blobpool cannot hold anything": type-3 admission is live post-Camellia via the `IsCamellia` branch in `core/txpool/validation.go` (see `blobpool/camellia_regression_test.go` and the blob-tx e2e; testnet passed the fork in May) — but the conditionality request stands on its own merits and is taken: pre-fork mainnet pays nothing, post-fork the read is a cache hit in `getTRSListWithCache`.
