### PR TITLE
core, scripts: carry camelliaBlock in the embedded genesis configs

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -336,7 +336,15 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedbpkg.Database
 	// chain config as that would be AllProtocolChanges (applying any new fork
 	// on top of an existing private network genesis block). In that case, only
 	// apply the overrides.
-	if genesis == nil && stored != params.MainnetGenesisHash && stored != params.MetadiumMainnetGenesisHash {
+	//
+	// Metadium: the testnet hash is excluded alongside mainnet -- a Metadium
+	// testnet node started without --metadium-testnet used to take this
+	// stored-config branch and never receive compiled-in fork updates
+	// (including the Camellia block), regardless of how it was launched. The
+	// stored-vs-compiled compatibility check below still guards the switch;
+	// with the testnet DAO/Petersburg fields restored to 0.10.x parity there
+	// is no first-check mismatch left to mask later forks' checks.
+	if genesis == nil && stored != params.MainnetGenesisHash && stored != params.MetadiumMainnetGenesisHash && stored != params.MetadiumTestnetGenesisHash {
 		newcfg = storedcfg
 		applyOverrides(newcfg)
 	}

--- a/core/metadium_genesis.go
+++ b/core/metadium_genesis.go
@@ -12306,6 +12306,7 @@ var (
     "pangyoBlock": 73225410,
     "applepieBlock": 73225410,
     "bokbunjaBlock": 73225410,
+    "camelliaBlock": 117764000,
     "ethash": {}
   },
   "difficulty": "0x1",
@@ -12359,6 +12360,7 @@ var (
     "pangyoBlock": 44671396,
     "applepieBlock": 44671396,
     "bokbunjaBlock": 44671396,
+    "camelliaBlock": 86449000,
     "ethash": {}
   },
   "difficulty": "0x1",

--- a/core/metadium_genesis_test.go
+++ b/core/metadium_genesis_test.go
@@ -6,24 +6,31 @@
 // does not exist for that node. camelliaBlock was missing from both networks'
 // JSONs, so any fresh sync whose first session crossed the fork would stall
 // at the boundary (post-fork headers carry WithdrawalsHash, rejected when
-// !IsCamellia). This test requires the embedded configs to carry the fork
-// the release activates, and to agree with the compiled params configs.
+// !IsCamellia). This test pins the genesis hashes -- proving config-only JSON
+// edits are hash-neutral -- and requires EVERY fork field of the embedded
+// configs to agree with the compiled params configs, so the next fork added
+// to params but forgotten in the JSON literal fails CI instead of recreating
+// this bug.
 //
 // Note DefaultGenesisBlock() returns the *Ethereum* genesis under PoW
-// consensus (test default) -- the Metadium branch is PoA-gated, hence the
-// consensus-method switch below (same pattern as the legacypool TRS tests:
-// serial, restored via t.Cleanup, never t.Parallel).
+// consensus (the unit-test default of params.ConsensusMethod), and ToBlock
+// hashes differently under PoW -- hence the serial consensus-method switch,
+// restored via t.Cleanup (precedent: eth/protocols/eth/protocol_test.go's
+// ConsensusMethod save/restore; never combine with t.Parallel).
 
 package core
 
 import (
+	"math/big"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
 
-func TestMetadiumEmbeddedGenesisCarriesCamellia(t *testing.T) {
+func TestMetadiumEmbeddedGenesisMatchesParams(t *testing.T) {
 	old := params.ConsensusMethod
 	params.ConsensusMethod = params.ConsensusPoA
 	t.Cleanup(func() { params.ConsensusMethod = old })
@@ -45,21 +52,44 @@ func TestMetadiumEmbeddedGenesisCarriesCamellia(t *testing.T) {
 			t.Errorf("%s embedded genesis hash = %s, want %s: the genesis JSON "+
 				"edit changed the genesis block itself", n.name, h.Hex(), n.hash.Hex())
 		}
-		if n.genesis.Config == nil || n.genesis.Config.ChainID == nil ||
-			n.genesis.Config.ChainID.Cmp(n.cfg.ChainID) != 0 {
-			t.Errorf("%s embedded genesis has wrong chain id: got %v, want %v",
+		if n.genesis.Config == nil {
+			t.Errorf("%s embedded genesis has no config section at all", n.name)
+			continue
+		}
+		if n.genesis.Config.ChainID == nil || n.genesis.Config.ChainID.Cmp(n.cfg.ChainID) != 0 {
+			t.Errorf("%s embedded genesis chain id = %v, want %v",
 				n.name, n.genesis.Config.ChainID, n.cfg.ChainID)
-			continue
 		}
-		if n.genesis.Config.CamelliaBlock == nil {
-			t.Errorf("%s embedded genesis config lacks camelliaBlock: a fresh "+
-				"node's first sync session would stall at the fork boundary",
-				n.name)
-			continue
+		// Every *big.Int fork field must agree between the embedded JSON and
+		// the compiled params config. A fork present in params but nil in the
+		// JSON is exactly the camelliaBlock bug: a fresh node's first session
+		// runs on the JSON verbatim and stalls at the fork boundary.
+		var (
+			gv = reflect.ValueOf(*n.genesis.Config)
+			pv = reflect.ValueOf(*n.cfg)
+			tt = gv.Type()
+		)
+		for i := 0; i < tt.NumField(); i++ {
+			f := tt.Field(i)
+			if f.Type != reflect.TypeOf((*big.Int)(nil)) || !strings.HasSuffix(f.Name, "Block") {
+				continue
+			}
+			got, _ := gv.Field(i).Interface().(*big.Int)
+			want, _ := pv.Field(i).Interface().(*big.Int)
+			switch {
+			case (got == nil) != (want == nil):
+				t.Errorf("%s embedded genesis %s = %v, params say %v: a fork "+
+					"added to params must be added to the embedded JSON too "+
+					"(core/metadium_genesis.go), or a fresh node's first sync "+
+					"session stalls at its boundary", n.name, f.Name, got, want)
+			case got != nil && got.Cmp(want) != 0:
+				t.Errorf("%s embedded genesis %s = %v, params say %v",
+					n.name, f.Name, got, want)
+			}
 		}
-		if n.genesis.Config.CamelliaBlock.Cmp(n.cfg.CamelliaBlock) != 0 {
-			t.Errorf("%s embedded genesis camelliaBlock = %v, params say %v",
-				n.name, n.genesis.Config.CamelliaBlock, n.cfg.CamelliaBlock)
+		if n.genesis.Config.DAOForkSupport != n.cfg.DAOForkSupport {
+			t.Errorf("%s embedded genesis DAOForkSupport = %v, params say %v",
+				n.name, n.genesis.Config.DAOForkSupport, n.cfg.DAOForkSupport)
 		}
 	}
 }

--- a/core/metadium_genesis_test.go
+++ b/core/metadium_genesis_test.go
@@ -1,0 +1,65 @@
+// metadium_genesis_test.go -- Metadium fork guard.
+//
+// The embedded genesis JSONs are what a fresh --metadium-mainnet /
+// --metadium-testnet node runs its FIRST session with: until a restart swaps
+// in the compiled params config, a fork block missing from the JSON simply
+// does not exist for that node. camelliaBlock was missing from both networks'
+// JSONs, so any fresh sync whose first session crossed the fork would stall
+// at the boundary (post-fork headers carry WithdrawalsHash, rejected when
+// !IsCamellia). This test requires the embedded configs to carry the fork
+// the release activates, and to agree with the compiled params configs.
+//
+// Note DefaultGenesisBlock() returns the *Ethereum* genesis under PoW
+// consensus (test default) -- the Metadium branch is PoA-gated, hence the
+// consensus-method switch below (same pattern as the legacypool TRS tests:
+// serial, restored via t.Cleanup, never t.Parallel).
+
+package core
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func TestMetadiumEmbeddedGenesisCarriesCamellia(t *testing.T) {
+	old := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoA
+	t.Cleanup(func() { params.ConsensusMethod = old })
+
+	for _, n := range []struct {
+		name    string
+		genesis *Genesis
+		hash    common.Hash
+		cfg     *params.ChainConfig
+	}{
+		{"mainnet", DefaultGenesisBlock(), params.MetadiumMainnetGenesisHash, params.MetadiumMainnetChainConfig},
+		{"testnet", DefaultTestnetGenesisBlock(), params.MetadiumTestnetGenesisHash, params.MetadiumTestnetChainConfig},
+	} {
+		// The genesis hash must not move: the config section is not part of
+		// the genesis block, so fork-field edits to the JSON must be
+		// hash-neutral. (Under PoA, ToBlock reproduces the canonical hashes
+		// exactly; under PoW it does not, hence the switch above.)
+		if h := n.genesis.ToBlock().Hash(); h != n.hash {
+			t.Errorf("%s embedded genesis hash = %s, want %s: the genesis JSON "+
+				"edit changed the genesis block itself", n.name, h.Hex(), n.hash.Hex())
+		}
+		if n.genesis.Config == nil || n.genesis.Config.ChainID == nil ||
+			n.genesis.Config.ChainID.Cmp(n.cfg.ChainID) != 0 {
+			t.Errorf("%s embedded genesis has wrong chain id: got %v, want %v",
+				n.name, n.genesis.Config.ChainID, n.cfg.ChainID)
+			continue
+		}
+		if n.genesis.Config.CamelliaBlock == nil {
+			t.Errorf("%s embedded genesis config lacks camelliaBlock: a fresh "+
+				"node's first sync session would stall at the fork boundary",
+				n.name)
+			continue
+		}
+		if n.genesis.Config.CamelliaBlock.Cmp(n.cfg.CamelliaBlock) != 0 {
+			t.Errorf("%s embedded genesis camelliaBlock = %v, params say %v",
+				n.name, n.genesis.Config.CamelliaBlock, n.cfg.CamelliaBlock)
+		}
+	}
+}

--- a/metadium/scripts/gmet.sh
+++ b/metadium/scripts/gmet.sh
@@ -59,13 +59,7 @@ function init ()
     [ $? = 0 ] || return $?
 
     echo "PORT=8588
-DISCOVER=0" > $d/.rc
-    # Metadium testnet (chain id 12) must run with --metadium-testnet for
-    # compiled-in config updates (fork blocks) to reach the node on upgrades;
-    # record the knob at init time so it cannot be silently forgotten.
-    if grep -qE '"chainId"[[:space:]]*:[[:space:]]*12\b' "$d/genesis.json"; then
-	echo "TESTNET=1" >> $d/.rc
-    fi
+DISCOVER=0" > "$d/.rc"
     ${GMET} --datadir $d init $d/genesis.json
     # echo "Generating dags for epoch 0 and 1..."
     # ${GMET} makedag 0     $d/.ethash &
@@ -167,7 +161,13 @@ function start ()
     [ "$PORT" = "" ] || RPCOPT="${RPCOPT} --ws.port $((${PORT}+10))"
     [ "$NONCE_LIMIT" = "" ] || NONCE_LIMIT="--noncelimit $NONCE_LIMIT"
     [ "$BOOT_NODES" = "" ] || BOOT_NODES="--bootnodes $BOOT_NODES"
-    [ "$TESTNET" = "1" ] && TESTNET=--metadium-testnet
+    # Clear any non-"1" value: passing a raw TESTNET=0 through OPTS would
+    # inject a stray positional argument and gmet fatals on it.
+    if [ "$TESTNET" = "1" ]; then
+	TESTNET=--metadium-testnet
+    else
+	TESTNET=
+    fi
     if [ "$DISCOVER" = "0" ]; then
 	DISCOVER=--nodiscover
     else

--- a/metadium/scripts/gmet.sh
+++ b/metadium/scripts/gmet.sh
@@ -60,6 +60,12 @@ function init ()
 
     echo "PORT=8588
 DISCOVER=0" > $d/.rc
+    # Metadium testnet (chain id 12) must run with --metadium-testnet for
+    # compiled-in config updates (fork blocks) to reach the node on upgrades;
+    # record the knob at init time so it cannot be silently forgotten.
+    if grep -qE '"chainId"[[:space:]]*:[[:space:]]*12\b' "$d/genesis.json"; then
+	echo "TESTNET=1" >> $d/.rc
+    fi
     ${GMET} --datadir $d init $d/genesis.json
     # echo "Generating dags for epoch 0 and 1..."
     # ${GMET} makedag 0     $d/.ethash &


### PR DESCRIPTION
Fixes the two pre-existing issues @trident90 surfaced in the #66 review — the embedded-genesis `camelliaBlock` gap and the untooled `TESTNET=1` knob.

## 1. `camelliaBlock` added to both embedded genesis configs

`--metadium-mainnet`/`--metadium-testnet` assign `cfg.Genesis = DefaultGenesisBlock()`/`DefaultTestnetGenesisBlock()` (cmd/utils/flags.go:1873), whose config is the parsed embedded JSON — and `camelliaBlock` was the only fork field missing from it versus the compiled params configs. A fresh node's first from-genesis session therefore ran with `CamelliaBlock == nil`: crossing the fork boundary it stalls (post-Camellia headers carry `WithdrawalsHash`, rejected while `!IsCamellia`); a restart self-heals via the stored-config path. Every fresh sync crossing 2026-08-27 would have hit this.

**Hash neutrality proven empirically**, not just argued: on the fleet toolchain, `ToBlock().Hash()` under PoA is `0xf1b2a543…` (mainnet) / `0x10c1b0a5…` (testnet) — the canonical genesis hashes — **both before (origin/dev) and after this change**. The config section is not part of the genesis block.

`TestMetadiumEmbeddedGenesisCarriesCamellia` pins both genesis hashes and requires the embedded configs to carry the activating fork in agreement with params. One test-infrastructure note that cost some head-scratching and is documented in the test: `DefaultGenesisBlock()` returns the *Ethereum* genesis under PoW consensus, which is the unit-test default (`params.ConsensusMethod`), and testnet `ToBlock()` produces a different hash under PoW — the test switches to PoA serially (same pattern as the #67 TRS tests). This is also why no existing test ever noticed the gap.

## 2. `gmet.sh init` records `TESTNET=1` for chain-id-12 genesis

A testnet node started without `--metadium-testnet` takes the stored-config branch in `core/genesis.go` and never receives compiled-in fork updates (including this release's Petersburg restore and the Camellia block itself). The knob had to be remembered by hand — `init` wrote only `PORT`/`DISCOVER`. It now appends `TESTNET=1` when the genesis it just generated is chain id 12, so the tooling guarantees the flag for testnet initializations while leaving private nets and mainnet untouched.

The larger option — adding the testnet hash to the `configOrDefault` exclusion at core/genesis.go:339 — is deliberately **not** taken here: it changes config-resolution behavior for every running testnet node in the field, which is not something to ship days before a fork activation. Tracked for post-HF consideration instead.

## Verification

Fleet toolchain: `gofmt` clean, new test passes, `go build ./core/...` OK, `bash -n gmet.sh` passes, before/after genesis-hash comparison above.

---

## Round 2 (`43686f894`, rebased onto post-#66 dev)

- **Root fix taken** (review gap 1): `MetadiumTestnetGenesisHash` joins the exclusion at `core/genesis.go` — a testnet node now receives compiled-in fork updates on **every** launch path, flag or no flag, existing `.rc` or new. The compat check still guards the switch, and #66's DAO/Petersburg parity restore removed the first-check mismatch that would have masked later forks' checks (comment in place).
- **The chainId-grep automation is gone** (inline MEDIUM): it protected nobody (shipped template is chainId 11; real testnet bootstraps never pass through `init()`) and planted landmines on chainId-12 private nets. The root fix above makes the `.rc` knob non-critical for config delivery. The `start()` `TESTNET=0` stray-positional fatal is fixed and the `.rc` redirect quoted while there.
- **Guard test strengthened** (inline LOW): every `*big.Int` fork field of both embedded configs is now compared against params via reflection — possible now that #66 made the embedded testnet JSON and params agree on every field (the divergence the round-1 review flagged is gone; nothing to skip-list). Nil error paths report instead of panicking; the consensus-switch precedent citation corrected to `eth/protocols/eth/protocol_test.go`.
- **Deferred with a note** (review gap 2): hash-validating downloaded genesis files — the stale-genesis.json first-session bypass self-heals on restart; a full fix rides the follow-up batch.
