### PR TITLE
README: document the operational changes for 0.10.x operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,61 @@ whole network is upgraded, nodes still on old binaries do not propagate
 128–256KB transactions, so propagation of large contract deployments is
 path-dependent during a rolling upgrade.
 
+## Node Configuration Reference (`gmet.sh` / `.rc`)
+
+The standard deployment runs `gmet` through `bin/gmet.sh`, which reads the
+node's configuration from a `.rc` file in the datadir (`/opt/meta/.rc` in the
+stock layout). Every knob, with its default:
+
+| `.rc` variable | Default | Meaning |
+|---|---|---|
+| `PORT` | `8588` | HTTP-RPC port. WS is `PORT+10`, p2p is `PORT+1`. |
+| `HTTP_ADDR` / `WS_ADDR` | `127.0.0.1` | RPC / WS bind address. Set `0.0.0.0` (or a specific interface) only on nodes that must serve other machines. |
+| `TESTNET` | unset | `1` → `--metadium-testnet`. Anything else is ignored. |
+| `DISCOVER` | unset (on) | `0` → `--nodiscover`. Leave discovery on for ordinary full nodes; mainnet/testnet bootnodes are compiled into the binary, so no `BOOT_NODES` is needed. |
+| `SYNC_MODE` | unset (**archive**) | `full` → pruned full node (recommended for exchange/API nodes, ~600GB-class). **Unset means `--syncmode full --gcmode archive`** — a multi-TB archive node; only choose that if you need historical `debug_traceTransaction`. |
+| `BOOT_NODES` | unset | Extra `--bootnodes` enodes (rarely needed, see above). |
+| `GMET_OPTS` | unset | Extra flags appended verbatim to the command line. |
+| `STOP_TIMEOUT` | `200` | Seconds `gmet.sh stop` waits for graceful shutdown before escalating. |
+| `STOP_FORCE` | `1` | `0` = never SIGKILL; `stop` exits non-zero instead (recommended for RocksDB nodes and anything driven by automation). |
+| `LOCK_TIMEOUT` | `200` | Seconds to wait for the chaindata lock to be released after exit. |
+| `COINBASE`, `HUB`, `MAX_TXS_PER_BLOCK`, `NONCE_LIMIT` | unset | Special-purpose (sealer / relay setups); ordinary full nodes leave these alone. |
+
+The stop knobs also take one-shot environment overrides
+(`STOP_TIMEOUT=1800 gmet.sh stop`) without editing the `.rc`.
+
+### Example: exchange / API full node
+
+```bash
+# /opt/meta/.rc -- pruned mainnet full node serving RPC to internal backends
+PORT=8588
+SYNC_MODE=full          # pruned; omit this line only if you need an archive node
+HTTP_ADDR=0.0.0.0       # internal backends connect over the network
+WS_ADDR=0.0.0.0         # (firewall the ports -- these binds are not auth)
+STOP_TIMEOUT=1800
+STOP_FORCE=0            # never SIGKILL; fail loudly and retry instead
+```
+
+Equivalent direct invocation without `gmet.sh`:
+
+```bash
+gmet --datadir /opt/meta --syncmode full \
+  --http --http.addr 0.0.0.0 --http.port 8588 --http.api eth,net,web3 \
+  --ws --ws.addr 0.0.0.0 --ws.port 8598 \
+  --port 8589 --rpc.txfeecap 0 --metrics
+```
+
+Deploy/upgrade cycle (datadir, `geth/nodekey` and `.rc` live outside the
+tarball and survive):
+
+```bash
+cd /opt/meta
+bin/gmet.sh stop        # graceful; check the exit code -- never kill -9
+tar xzvf metadium-<version>-linux-<leveldb|rocksdb>.tar.gz
+bin/gmet.sh start
+bin/gmet version        # verify version and fork banner
+```
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -120,30 +120,49 @@ before — but review the following **before** restarting on the new binary.
 
    Without these, the upgraded node silently stops serving external clients
    while looking healthy in every other way.
-4. **`gmet.sh stop` semantics changed.** It now exits non-zero when the node
+4. **★ The `personal` RPC namespace is disabled by default.** Upstream
+   deprecated it: the node only registers `personal_*` (including
+   `personal_unlockAccount` and `personal_sendTransaction`, common in
+   exchange wallet backends) when started with
+   `--rpc.enabledeprecatedpersonal`. `gmet.sh` does not pass it. Same failure
+   shape as the bind change: the node comes up healthy and the backend stops
+   working. If your tooling uses `personal_*`, add the flag (via
+   `GMET_OPTS="--rpc.enabledeprecatedpersonal"` in `.rc`) — and plan a
+   migration off the namespace, since upstream has removed it entirely in
+   later releases.
+5. **★ `--syncmode light` no longer starts.** 0.10.x shipped a light-client
+   implementation (`les/`); v1.1.x does not — the flag still parses, but the
+   node refuses to start with "light mode has been deprecated". If any
+   launcher or unit file passes `--syncmode light`, change it to `full` (or
+   `snap`) before restarting.
+6. **`gmet.sh stop` semantics changed.** It now exits non-zero when the node
    did not actually stop (previously it could report success without stopping
    anything), and gained `.rc` tunables: `STOP_TIMEOUT` (seconds to wait for
-   graceful shutdown before escalating), `STOP_FORCE` (`0` = never SIGKILL,
-   exit non-zero instead), `LOCK_TIMEOUT`. Automation that wraps `stop` must
-   check the exit code rather than assume success. Never `kill -9` a node —
-   RocksDB especially.
-5. **Testnet operators: skip 1.1.0, go straight to 1.1.1.** The 1.1.0 testnet
+   graceful shutdown before escalating, default `200`), `STOP_FORCE` (`0` =
+   never SIGKILL, exit non-zero instead), `LOCK_TIMEOUT` (default `200`).
+   Automation that wraps `stop` must check the exit code rather than assume
+   success, and size its own timeout above `STOP_TIMEOUT`. Never `kill -9` a
+   node — RocksDB especially.
+7. **Testnet operators: skip 1.1.0, go straight to 1.1.1.** The 1.1.0 testnet
    build carries a chain-config regression that rewinds a 0.10.x node to
    block 5,622,999 (~80M-block resync) on first start. 1.1.1 is safe from
    both 0.10.x and 1.1.0 starting states. Run testnet nodes with
    `--metadium-testnet` (or `TESTNET=1` in `.rc` when using `gmet.sh`).
-6. **RPC fee cap**: `gmet.sh` now passes `--rpc.txfeecap 0`, preserving the
+8. **RPC fee cap**: `gmet.sh` now passes `--rpc.txfeecap 0`, preserving the
    0.10.x behaviour of no cap on `eth_sendTransaction` fees. Operators who
    launch `gmet` directly without this flag get upstream's default 1-ether
    cap — set it explicitly if your tooling sends high-fee transactions.
-7. **Direct-CLI launchers**: the flag surface is upstream go-ethereum
+9. **Direct-CLI launchers**: the flag surface is upstream go-ethereum
    v1.13.14. If you maintain a custom launch script or systemd unit instead
    of `gmet.sh`, dry-run it against the new binary (`gmet --help`); valid
-   `--syncmode` values are `full`, `snap` and `light`. systemd unit templates
-   are provided at `metadium/scripts/gmet.service` (plus a sealer override).
-8. **`metadium/metclient` library users**: `SendValue` and `Deploy` signatures
-   changed (`amount`/`gas` are no longer platform-sized ints). External tools
-   linking the package fail loudly at compile time; update the call sites.
+   `--syncmode` values are `full` and `snap` (`light` refuses to start, see
+   item 5). systemd unit templates are provided at
+   `metadium/scripts/gmet.service` (plus a sealer override).
+10. **`metadium/metclient` library users**: compile-time signature changes —
+    `SendValue`'s `amount` went `int` → `*big.Int`, and `_gasPrice` went
+    `int` → `int64` in both `SendValue` and `Deploy` (`gas` is unchanged).
+    External tools linking the package fail loudly at compile time; update
+    the call sites.
 
 Transaction-behaviour note: the pool again admits transactions up to 256KB
 (0.10.x parity; the intermediate 1.1.0 line rejected above 128KB). Until the

--- a/README.md
+++ b/README.md
@@ -46,17 +46,21 @@ See [docs/camellia-test-report.md](docs/camellia-test-report.md) for full test r
 
 Prerequisites: Go 1.21+, C compiler (for RocksDB builds).
 
-### LevelDB (default)
+The canonical builds are the Makefile targets — they are what CI validates
+and what the release tarballs ship:
 
 ```bash
-CGO_ENABLED=0 go build -o gmet ./cmd/geth
+make gmet                    # gmet binary (RocksDB; USE_ROCKSDB=NO for LevelDB)
+make metadium                # full deploy bundle: build/metadium.tar.gz (bin/ + conf/)
 ```
 
-### RocksDB
+Direct `go build` works for development (`./cmd/gmet` and `./cmd/geth` are
+the same entrypoint; the Makefile uses `./cmd/gmet`):
 
 ```bash
+CGO_ENABLED=0 go build -o gmet ./cmd/gmet                    # LevelDB
 CGO_ENABLED=1 CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd" \
-  go build -tags rocksdb -o gmet ./cmd/geth
+  go build -tags rocksdb -o gmet ./cmd/gmet                  # RocksDB
 ```
 
 ### Docker
@@ -142,15 +146,23 @@ before — but review the following **before** restarting on the new binary.
    did not actually stop (previously it could report success without stopping
    anything), and gained `.rc` tunables: `STOP_TIMEOUT` (seconds to wait for
    graceful shutdown before escalating, default `200`), `STOP_FORCE` (`0` =
-   never SIGKILL, exit non-zero instead), `LOCK_TIMEOUT` (default `200`).
-   Automation that wraps `stop` must check the exit code rather than assume
-   success, and size its own timeout above `STOP_TIMEOUT`. Never `kill -9` a
-   node — RocksDB especially.
-7. **Testnet operators: skip 1.1.0, go straight to 1.1.1.** The 1.1.0 testnet
-   build carries a chain-config regression that rewinds a 0.10.x node to
-   block 5,622,999 (~80M-block resync) on first start. 1.1.1 is safe from
-   both 0.10.x and 1.1.0 starting states. Run testnet nodes with
-   `--metadium-testnet` (or `TESTNET=1` in `.rc` when using `gmet.sh`).
+   never SIGKILL, exit non-zero instead; default `1`), `LOCK_TIMEOUT`
+   (default `200`). One coupling to understand: **under the default
+   `STOP_FORCE=1`, a node that outlives `STOP_TIMEOUT` is SIGKILLed by the
+   script itself and `stop` still exits 0** — the exit code only guarantees
+   a graceful shutdown when `STOP_FORCE=0` is set. Automation must check the
+   exit code *and* set `STOP_FORCE=0`, sizing its own timeout above
+   `STOP_TIMEOUT`. Never `kill -9` a node — RocksDB especially.
+7. **Testnet operators: skip 1.1.0, go straight to the m1.1.1 release
+   build.** The 1.1.0 testnet build carries a chain-config regression that
+   rewinds a 0.10.x node to block 5,622,999 (~80M-block resync) on first
+   start. The fix landed *after* the version string moved to 1.1.1, so
+   "reports 1.1.1-stable" does not prove a build is safe — use the official
+   m1.1.1 release asset, or verify `gmet version`'s `Git Commit` is at or
+   after `e2c0d7413`. Order matters on the remediation too: run testnet
+   nodes with `--metadium-testnet` (or `TESTNET=1` in `.rc`) **only once on
+   a fixed build** — adding the flag while still on a pre-fix binary is
+   exactly what arms the rewind.
 8. **RPC fee cap**: `gmet.sh` now passes `--rpc.txfeecap 0`, preserving the
    0.10.x behaviour of no cap on `eth_sendTransaction` fees. Operators who
    launch `gmet` directly without this flag get upstream's default 1-ether
@@ -161,17 +173,21 @@ before — but review the following **before** restarting on the new binary.
    `--syncmode` that starts on Metadium networks is `full` (item 5). systemd
    unit templates are provided at `metadium/scripts/gmet.service` (plus a
    sealer override).
-10. **`metadium/metclient` library users**: compile-time signature changes —
+10. **`metadium/metclient` library users**: signature changes —
     `SendValue`'s `amount` went `int` → `*big.Int`, and `_gasPrice` went
     `int` → `int64` in both `SendValue` and `Deploy` (`gas` is unchanged).
-    External tools linking the package fail loudly at compile time; update
-    the call sites.
+    `SendValue` call sites fail at compile time; **`Deploy` call sites that
+    pass a constant gas price compile unchanged** (untyped constants satisfy
+    `int64`) — audit those by hand. Note `amount` may now be `nil`, which is
+    a 0-value transfer rather than an error.
 
-Transaction-behaviour note: the pool again admits transactions up to 256KB
-(0.10.x parity; the intermediate 1.1.0 line rejected above 128KB). Until the
-whole network is upgraded, nodes still on old binaries do not propagate
-128–256KB transactions, so propagation of large contract deployments is
-path-dependent during a rolling upgrade.
+Transaction-behaviour note: the pool admits transactions of code plus
+constructor data up to 256KB total, restoring 0.10.x parity — 0.10.x has
+carried the same 256KB ceiling since 2018, so a mixed 0.10.x + 1.1.1 fleet
+behaves uniformly. Only the intermediate **1.1.0** line rejected above
+128KB: propagation of 128–256KB transactions is path-dependent only while
+1.1.0 nodes are present (relevant on testnet; the mainnet fleet upgrades
+straight from 0.10.x).
 
 ## Node Configuration Reference (`gmet.sh` / `.rc`)
 
@@ -181,11 +197,11 @@ stock layout). Every knob, with its default:
 
 | `.rc` variable | Default | Meaning |
 |---|---|---|
-| `PORT` | `8588` | HTTP-RPC port. WS is `PORT+10`, p2p is `PORT+1`. |
+| `PORT` | unset | When set: HTTP-RPC = `PORT`, WS = `PORT+10`, p2p = `PORT+1`. When unset, `gmet.sh` passes no port flags and the binary defaults apply: HTTP **8545**, WS **8546**, p2p **8589**. `init`-generated `.rc` files set `PORT=8588`. |
 | `HTTP_ADDR` / `WS_ADDR` | `127.0.0.1` | RPC / WS bind address. Set `0.0.0.0` (or a specific interface) only on nodes that must serve other machines. |
 | `TESTNET` | unset | `1` → `--metadium-testnet`. Anything else is ignored. |
-| `DISCOVER` | unset (on) | `0` → `--nodiscover`. Leave discovery on for ordinary full nodes; mainnet/testnet bootnodes are compiled into the binary, so no `BOOT_NODES` is needed. |
-| `SYNC_MODE` | unset (**archive**) | `full` → pruned full node (recommended for exchange/API nodes, ~600GB-class). **Unset means `--syncmode full --gcmode archive`** — a multi-TB archive node; only choose that if you need historical `debug_traceTransaction`. Any other value refuses to start on Metadium networks (full sync only, see the upgrade checklist). |
+| `DISCOVER` | unset (on) | `0` → `--nodiscover`. Note **`init`-generated `.rc` files contain `DISCOVER=0`** — remove or change it for ordinary full nodes, or the node dials no one. Mainnet/testnet bootnodes are compiled into the binary, so no `BOOT_NODES` is needed. |
+| `SYNC_MODE` | unset (**archive**) | `full` → pruned full node (recommended for exchange/API nodes, ~600GB-class). **Unset — or any unrecognized value, typos included — means `--syncmode full --gcmode archive`**: a multi-TB archive node. `fast`/`snap` make the node exit at startup (Metadium networks are full-sync only) — and since `gmet.sh start` backgrounds the node, `start` itself still returns 0, so check the log. |
 | `BOOT_NODES` | unset | Extra `--bootnodes` enodes (rarely needed, see above). |
 | `GMET_OPTS` | unset | Extra flags appended verbatim to the command line. |
 | `STOP_TIMEOUT` | `200` | Seconds `gmet.sh stop` waits for graceful shutdown before escalating. |
@@ -222,10 +238,16 @@ tarball and survive):
 
 ```bash
 cd /opt/meta
-bin/gmet.sh stop        # graceful; check the exit code -- never kill -9
+bin/gmet.sh stop        # graceful; see item 6 -- exit 0 under the default
+                        # STOP_FORCE=1 may still hide an internal SIGKILL
 tar xzvf metadium-<version>-linux-<leveldb|rocksdb>.tar.gz
+                        # ^ the GitHub release asset name; `make metadium`
+                        #   itself produces build/metadium.tar.gz
 bin/gmet.sh start
-bin/gmet version        # verify version and fork banner
+bin/gmet version        # verify the Git Commit line (gmet version prints
+                        # no fork or engine info)
+grep -m1 Camellia logs/log   # fork config is printed at chain init --
+                             # expect the Camellia activation height
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -130,17 +130,27 @@ before — but review the following **before** restarting on the new binary.
    exchange wallet backends) when started with
    `--rpc.enabledeprecatedpersonal`. `gmet.sh` does not pass it. Same failure
    shape as the bind change: the node comes up healthy and the backend stops
-   working. If your tooling uses `personal_*`, add the flag (via
-   `GMET_OPTS="--rpc.enabledeprecatedpersonal"` in `.rc`) — and plan a
-   migration off the namespace, since upstream has removed it entirely in
+   working. If your tooling uses `personal_*`, **two** things are required:
+   the enable flag *and* `personal` in the HTTP module list (the default is
+   `net,web3` only) — e.g. in `.rc`:
+
+   ```bash
+   GMET_OPTS="--rpc.enabledeprecatedpersonal --http.api eth,net,web3,personal"
+   ```
+
+   (`gmet.sh` passes no `--http.api` of its own, so anyone using the
+   namespace over HTTP is already supplying a module list — extend it.) And
+   plan a migration off the namespace: upstream has removed it entirely in
    later releases.
 5. **★ Metadium networks run full sync only — every other `--syncmode`
    refuses to start.** `light` is gone from the tree (0.10.x shipped `les/`;
    v1.1.x does not), and `snap`/`fast` are deliberately rejected on Metadium
    mainnet/testnet because the snap state-healing fixes are not backported to
    this base (state-corruption risk). If any launcher or unit file passes a
-   `--syncmode` other than `full`, change it before restarting. For fast
-   new-node bring-up, bootstrap from a published chain snapshot instead
+   `--syncmode` other than `full`, change it before restarting. (The guard
+   exempts only the upstream test networks and `--dev` — private chains run
+   off this binary are under it too.) For fast new-node bring-up, bootstrap
+   from a published chain snapshot instead
    (`docs/sync-policy-and-snapshot-bootstrap.md`).
 6. **`gmet.sh stop` semantics changed.** It now exits non-zero when the node
    did not actually stop (previously it could report success without stopping
@@ -158,8 +168,10 @@ before — but review the following **before** restarting on the new binary.
    rewinds a 0.10.x node to block 5,622,999 (~80M-block resync) on first
    start. The fix landed *after* the version string moved to 1.1.1, so
    "reports 1.1.1-stable" does not prove a build is safe — use the official
-   m1.1.1 release asset, or verify `gmet version`'s `Git Commit` is at or
-   after `e2c0d7413`. Order matters on the remediation too: run testnet
+   m1.1.1 release asset (its exact commit hash is published in the release
+   notes). Self-builders can check their commit contains the fix with
+   `git merge-base --is-ancestor e2c0d7413 <your-commit>` (exit 0 = fixed).
+   Order matters on the remediation too: run testnet
    nodes with `--metadium-testnet` (or `TESTNET=1` in `.rc`) **only once on
    a fixed build** — adding the flag while still on a pre-fix binary is
    exactly what arms the rewind.

--- a/README.md
+++ b/README.md
@@ -130,11 +130,14 @@ before — but review the following **before** restarting on the new binary.
    `GMET_OPTS="--rpc.enabledeprecatedpersonal"` in `.rc`) — and plan a
    migration off the namespace, since upstream has removed it entirely in
    later releases.
-5. **★ `--syncmode light` no longer starts.** 0.10.x shipped a light-client
-   implementation (`les/`); v1.1.x does not — the flag still parses, but the
-   node refuses to start with "light mode has been deprecated". If any
-   launcher or unit file passes `--syncmode light`, change it to `full` (or
-   `snap`) before restarting.
+5. **★ Metadium networks run full sync only — every other `--syncmode`
+   refuses to start.** `light` is gone from the tree (0.10.x shipped `les/`;
+   v1.1.x does not), and `snap`/`fast` are deliberately rejected on Metadium
+   mainnet/testnet because the snap state-healing fixes are not backported to
+   this base (state-corruption risk). If any launcher or unit file passes a
+   `--syncmode` other than `full`, change it before restarting. For fast
+   new-node bring-up, bootstrap from a published chain snapshot instead
+   (`docs/sync-policy-and-snapshot-bootstrap.md`).
 6. **`gmet.sh stop` semantics changed.** It now exits non-zero when the node
    did not actually stop (previously it could report success without stopping
    anything), and gained `.rc` tunables: `STOP_TIMEOUT` (seconds to wait for
@@ -154,10 +157,10 @@ before — but review the following **before** restarting on the new binary.
    cap — set it explicitly if your tooling sends high-fee transactions.
 9. **Direct-CLI launchers**: the flag surface is upstream go-ethereum
    v1.13.14. If you maintain a custom launch script or systemd unit instead
-   of `gmet.sh`, dry-run it against the new binary (`gmet --help`); valid
-   `--syncmode` values are `full` and `snap` (`light` refuses to start, see
-   item 5). systemd unit templates are provided at
-   `metadium/scripts/gmet.service` (plus a sealer override).
+   of `gmet.sh`, dry-run it against the new binary (`gmet --help`); the only
+   `--syncmode` that starts on Metadium networks is `full` (item 5). systemd
+   unit templates are provided at `metadium/scripts/gmet.service` (plus a
+   sealer override).
 10. **`metadium/metclient` library users**: compile-time signature changes —
     `SendValue`'s `amount` went `int` → `*big.Int`, and `_gasPrice` went
     `int` → `int64` in both `SendValue` and `Deploy` (`gas` is unchanged).
@@ -182,7 +185,7 @@ stock layout). Every knob, with its default:
 | `HTTP_ADDR` / `WS_ADDR` | `127.0.0.1` | RPC / WS bind address. Set `0.0.0.0` (or a specific interface) only on nodes that must serve other machines. |
 | `TESTNET` | unset | `1` → `--metadium-testnet`. Anything else is ignored. |
 | `DISCOVER` | unset (on) | `0` → `--nodiscover`. Leave discovery on for ordinary full nodes; mainnet/testnet bootnodes are compiled into the binary, so no `BOOT_NODES` is needed. |
-| `SYNC_MODE` | unset (**archive**) | `full` → pruned full node (recommended for exchange/API nodes, ~600GB-class). **Unset means `--syncmode full --gcmode archive`** — a multi-TB archive node; only choose that if you need historical `debug_traceTransaction`. |
+| `SYNC_MODE` | unset (**archive**) | `full` → pruned full node (recommended for exchange/API nodes, ~600GB-class). **Unset means `--syncmode full --gcmode archive`** — a multi-TB archive node; only choose that if you need historical `debug_traceTransaction`. Any other value refuses to start on Metadium networks (full sync only, see the upgrade checklist). |
 | `BOOT_NODES` | unset | Extra `--bootnodes` enodes (rarely needed, see above). |
 | `GMET_OPTS` | unset | Extra flags appended verbatim to the command line. |
 | `STOP_TIMEOUT` | `200` | Seconds `gmet.sh stop` waits for graceful shutdown before escalating. |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,65 @@ cd tests/private-net-poa
 ./stop.sh     # Stop (data preserved)
 ```
 
+## Upgrading from 0.10.x
+
+v1.1.x rebases the tree onto go-ethereum v1.13.14 and changes several
+operational defaults. An in-place upgrade (`gmet.sh stop` → extract tarball →
+`gmet.sh start`) preserves the datadir, `geth/nodekey` and `.rc` exactly as
+before — but review the following **before** restarting on the new binary.
+
+### Upgrade checklist
+
+1. **Upgrade before the activation block** — mainnet 117,764,000. The block
+   height is authoritative; wall-clock estimates are approximate. Nodes on
+   older binaries follow a diverging chain from that block on.
+2. **Use the engine-matched tarball.** The DB engine is decided at build time.
+   Check the node's chaindata before extracting: `.sst` files → rocksdb
+   tarball, `.ldb` files → leveldb tarball. A mismatched binary cannot open
+   the database.
+3. **★ RPC/WS bind default changed** (`gmet.sh`): `--http.addr`/`--ws.addr`
+   now default to **`127.0.0.1`** (was `0.0.0.0`). A node that serves RPC/WS
+   to other machines — exchange wallet backends included — must add to its
+   per-node `.rc` **before** restarting:
+
+   ```bash
+   HTTP_ADDR=0.0.0.0    # or a specific interface address
+   WS_ADDR=0.0.0.0
+   ```
+
+   Without these, the upgraded node silently stops serving external clients
+   while looking healthy in every other way.
+4. **`gmet.sh stop` semantics changed.** It now exits non-zero when the node
+   did not actually stop (previously it could report success without stopping
+   anything), and gained `.rc` tunables: `STOP_TIMEOUT` (seconds to wait for
+   graceful shutdown before escalating), `STOP_FORCE` (`0` = never SIGKILL,
+   exit non-zero instead), `LOCK_TIMEOUT`. Automation that wraps `stop` must
+   check the exit code rather than assume success. Never `kill -9` a node —
+   RocksDB especially.
+5. **Testnet operators: skip 1.1.0, go straight to 1.1.1.** The 1.1.0 testnet
+   build carries a chain-config regression that rewinds a 0.10.x node to
+   block 5,622,999 (~80M-block resync) on first start. 1.1.1 is safe from
+   both 0.10.x and 1.1.0 starting states. Run testnet nodes with
+   `--metadium-testnet` (or `TESTNET=1` in `.rc` when using `gmet.sh`).
+6. **RPC fee cap**: `gmet.sh` now passes `--rpc.txfeecap 0`, preserving the
+   0.10.x behaviour of no cap on `eth_sendTransaction` fees. Operators who
+   launch `gmet` directly without this flag get upstream's default 1-ether
+   cap — set it explicitly if your tooling sends high-fee transactions.
+7. **Direct-CLI launchers**: the flag surface is upstream go-ethereum
+   v1.13.14. If you maintain a custom launch script or systemd unit instead
+   of `gmet.sh`, dry-run it against the new binary (`gmet --help`); valid
+   `--syncmode` values are `full`, `snap` and `light`. systemd unit templates
+   are provided at `metadium/scripts/gmet.service` (plus a sealer override).
+8. **`metadium/metclient` library users**: `SendValue` and `Deploy` signatures
+   changed (`amount`/`gas` are no longer platform-sized ints). External tools
+   linking the package fail loudly at compile time; update the call sites.
+
+Transaction-behaviour note: the pool again admits transactions up to 256KB
+(0.10.x parity; the intermediate 1.1.0 line rejected above 128KB). Until the
+whole network is upgraded, nodes still on old binaries do not propagate
+128–256KB transactions, so propagation of large contract deployments is
+path-dependent during a rolling upgrade.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
v1.1.x runs differently from 0.10.x in ways that bite an in-place upgrade, and none of it was in the README — operators (exchanges included) would have discovered the RPC bind change as a production outage. This adds an "Upgrading from 0.10.x" section: one checklist ordered by blast radius.

Covered, each verified against the actual `gmet.sh`/binary behaviour on both lines:

1. Activation-block deadline (height authoritative)
2. Engine-matched tarball selection (`.sst`/`.ldb` check)
3. **RPC/WS bind default `0.0.0.0` → `127.0.0.1`** with the exact `.rc` lines to restore external serving (the #58-review upgrade note, now in the README too)
4. `gmet.sh stop` exit-code semantics + `STOP_TIMEOUT`/`STOP_FORCE`/`LOCK_TIMEOUT`
5. Testnet: skip 1.1.0 (stored-config rewind), `--metadium-testnet`/`TESTNET=1`
6. `--rpc.txfeecap 0` (gmet.sh parity vs upstream 1-ether default for direct launchers)
7. Direct-CLI flag surface = upstream v1.13.14, valid `--syncmode` values, systemd templates
8. `metclient` compile-time API break
9. 256KB pool ceiling propagation note during rolling upgrade

This is the source text for the exchange upgrade guide going out with the release notice, so the two documents can't drift apart.

Docs-only; no code. Happy to fold in wording fixes with the #68 final round.

---

**Second commit** (`1ae64c106`): a **Node Configuration Reference** — the upgrade section says what changed; this says how to configure a node from scratch, sufficient for a third-party operator (exchange) to set run options without asking us:

- Every `gmet.sh` `.rc` knob with its default — including the trap that an **unset `SYNC_MODE` means archive mode** (multi-TB) rather than a pruned full node
- A worked exchange/API node `.rc` profile + the equivalent direct `gmet` invocation
- The deploy/upgrade cycle with the what-survives-the-tarball note

Merge-order note: the `TESTNET` row documents the post-#68 behaviour (non-`"1"` values ignored) — #68 should merge before this.
