### PR TITLE
docs: drop tool attribution from test report author line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ tests/spec-tests/
 /mixed-tx-e2e
 /tests/private-net-poa/geth
 
-# Claude / AI tools
+# local tool directories
 /.claude/
 /.gstack/
 /.mcp.json

--- a/docs/camellia-test-report.md
+++ b/docs/camellia-test-report.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-08
 **Branch:** `dev`
 **Version:** 1.0.0-stable
-**Author:** Jeffrey Song (AI-assisted with Claude Opus 4.6)
+**Author:** Jeffrey Song
 
 ---
 


### PR DESCRIPTION
Removes the tool-attribution parenthetical from the author line of `docs/camellia-test-report.md` and neutralizes the related `.gitignore` section comment. Two lines, docs/comment only — no code or content changes.

The author field should name the person accountable for the report; drafting tools are not part of that record.