### PR TITLE
blobpool: drain limbo under PoA where beacon finality never exists

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -860,7 +860,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	}
 	// Flush out any blobs from limbo that are older than the latest finality
 	if p.chain.Config().IsCancun(p.head.Number, p.head.Time) || p.chain.Config().IsCamellia(p.head.Number) {
-		p.limbo.finalize(p.chain.CurrentFinalBlock())
+		p.limbo.finalize(limboFinal(p.chain.CurrentFinalBlock(), p.head))
 	}
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (

--- a/core/txpool/blobpool/limbo_metadium.go
+++ b/core/txpool/blobpool/limbo_metadium.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
+)
+
+// limboFinalityDepth is the eviction boundary the blobpool substitutes for
+// chain-level finality when the latter is unavailable (see limboFinal).
+//
+// The value is anchored to the reorg handler's own cutoff in (*BlobPool).reorg
+// (blobpool.go, the "64 blocks deep" bail-out): reorgs deeper than that are
+// never resurrected there, so evicting limbo sidecars at head-64 cannot
+// discard a sidecar the reorg path would still ask for. Do not lower one
+// without the other. At Metadium's 2s block interval this is ~128s of depth.
+// Should a deeper reorg occur regardless, the failure is bounded and
+// non-consensus: reinject logs "Blobs unavailable, dropping reorged tx" and
+// the sender resubmits.
+const limboFinalityDepth = 64
+
+// limboFinal returns the header below which included blob sidecars may be
+// evicted from limbo. Upstream keys this on beacon finality. Metadium has a
+// chain-level PoA substitute -- metaFinalHeader (head - govNodeCount/2+1),
+// wired into CurrentFinalBlock by b3a5d9f00 -- but it resolves through
+// governance contract reads, which fail in real windows: during start-up
+// before the metadium admin is initialized, when the governance read errors,
+// and permanently on private nets with no governance deployed (#76). In each
+// such window Reset would log "Nil finalized block cannot evict old blobs"
+// and skip limbo maintenance. Under PoA, substitute head-limboFinalityDepth
+// for exactly those windows; a resolved chain-level boundary always passes
+// through untouched, and every non-PoA consensus method keeps the upstream
+// behavior bit-for-bit, nil included.
+func limboFinal(final, head *types.Header) *types.Header {
+	if final != nil || metaminer.IsPoW() || head == nil {
+		return final
+	}
+	depth := uint64(limboFinalityDepth)
+	if n := head.Number.Uint64(); n >= depth {
+		return &types.Header{Number: new(big.Int).SetUint64(n - depth)}
+	}
+	// Fewer than limboFinalityDepth blocks exist; nothing can be deep enough
+	// to evict. Block zero carries no blob txs, so this is a clean no-op that
+	// still avoids the nil-finality error path.
+	return &types.Header{Number: new(big.Int)}
+}

--- a/core/txpool/blobpool/limbo_metadium_test.go
+++ b/core/txpool/blobpool/limbo_metadium_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// asPoA / asPoW flip the global consensus method for one test, restoring the
+// previous value afterwards. params.ConsensusMethod is PoW outside a running
+// node. Tests using these must NOT call t.Parallel() -- serial tests finish
+// (and restore the global) before the parallel batch runs.
+func asPoA(t *testing.T) {
+	t.Helper()
+	old := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoA
+	t.Cleanup(func() { params.ConsensusMethod = old })
+}
+
+func asPoW(t *testing.T) {
+	t.Helper()
+	old := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoW
+	t.Cleanup(func() { params.ConsensusMethod = old })
+}
+
+func header(n uint64) *types.Header {
+	return &types.Header{Number: new(big.Int).SetUint64(n)}
+}
+
+// TestLimboFinalPoASurrogate pins the PoA finality surrogate: when chain-level
+// finality is unavailable, limbo eviction must key on head-limboFinalityDepth
+// instead of silently never running (issue #76).
+func TestLimboFinalPoASurrogate(t *testing.T) {
+	asPoA(t)
+
+	// Deep enough head: surrogate is head-depth.
+	if got := limboFinal(nil, header(1000)); got == nil {
+		t.Fatal("want surrogate final header under PoA, got nil")
+	} else if want := uint64(1000 - limboFinalityDepth); got.Number.Uint64() != want {
+		t.Fatalf("surrogate final number: got %d, want %d", got.Number.Uint64(), want)
+	}
+	// Boundary: the first head that can evict group 0.
+	if got := limboFinal(nil, header(limboFinalityDepth)); got.Number.Uint64() != 0 {
+		t.Fatalf("boundary head %d: got %d, want 0", limboFinalityDepth, got.Number.Uint64())
+	}
+	// Young chain: clamp to zero rather than underflow or return nil.
+	if got := limboFinal(nil, header(limboFinalityDepth-1)); got == nil {
+		t.Fatal("want zero-height surrogate on young chain, got nil")
+	} else if got.Number.Uint64() != 0 {
+		t.Fatalf("young-chain surrogate: got %d, want 0", got.Number.Uint64())
+	}
+	// A resolved chain-level boundary (however it appeared) always wins.
+	if got := limboFinal(header(7), header(1000)); got.Number.Uint64() != 7 {
+		t.Fatalf("explicit final must pass through, got %d", got.Number.Uint64())
+	}
+	// A nil head must not panic and must not fabricate a boundary.
+	if got := limboFinal(nil, nil); got != nil {
+		t.Fatalf("nil head must pass nil through, got %v", got.Number)
+	}
+}
+
+// TestLimboFinalNonPoAPassthrough pins that non-PoA consensus keeps the
+// upstream behavior bit-for-bit: nil stays nil (with upstream's error log
+// downstream), and a real final header passes through. asPoW forces the
+// non-PoA condition so this guard always runs.
+func TestLimboFinalNonPoAPassthrough(t *testing.T) {
+	asPoW(t)
+
+	if got := limboFinal(nil, header(1000)); got != nil {
+		t.Fatalf("non-PoA nil final must stay nil, got %v", got.Number)
+	}
+	if got := limboFinal(header(7), header(1000)); got.Number.Uint64() != 7 {
+		t.Fatalf("non-PoA explicit final must pass through, got %d", got.Number.Uint64())
+	}
+}
+
+// testBlockChainNilFinal is testBlockChainCamellia with chain-level finality
+// unavailable, as on a governance-less private net or during the start-up /
+// governance-read-failure windows (#76).
+type testBlockChainNilFinal struct {
+	testBlockChainCamellia
+	head uint64
+}
+
+func (bc *testBlockChainNilFinal) CurrentFinalBlock() *types.Header { return nil }
+
+func (bc *testBlockChainNilFinal) CurrentBlock() *types.Header {
+	h := bc.testBlockChainCamellia.CurrentBlock()
+	h.Number = new(big.Int).SetUint64(bc.head)
+	return h
+}
+
+// TestLimboSurrogateEndToEnd exercises the real Reset call site with a
+// nil-finality chain under PoA: a limbo entry deeper than the surrogate
+// boundary must be evicted. This is the guard that fails if the call-site
+// wiring regresses (e.g. swapped limboFinal arguments, which would compile).
+func TestLimboSurrogateEndToEnd(t *testing.T) {
+	asPoA(t)
+
+	cfg := camelliaOnlyChainConfig()
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	chain := &testBlockChainNilFinal{
+		testBlockChainCamellia: testBlockChainCamellia{config: cfg, statedb: statedb},
+		head:                   200,
+	}
+	poolDir, err := os.MkdirTemp("", "blobpool-surrogate-test-*")
+	if err != nil {
+		t.Fatalf("TempDir: %v", err)
+	}
+	defer os.RemoveAll(poolDir)
+
+	pool := New(DefaultConfig, chain)
+	if err := pool.Init(params.InitialBaseFee, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+		t.Fatalf("pool.Init: %v", err)
+	}
+	defer pool.Close()
+
+	// Park a sidecar in limbo at a block deeper than head-limboFinalityDepth.
+	to := common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+	tx := types.NewTx(&types.BlobTx{
+		ChainID:          uint256.MustFromBig(cfg.ChainID),
+		Nonce:            0,
+		GasTipCap:        uint256.NewInt(1e9),
+		GasFeeCap:        uint256.NewInt(2e9),
+		Gas:              21000,
+		To:               &to,
+		Value:            new(uint256.Int),
+		MaxFeePerBlobGas: uint256.NewInt(params.BlobTxMinBlobGasprice),
+		BlobHashes:       []common.Hash{emptyBlobVHash},
+		Sidecar: &types.BlobTxSidecar{
+			Blobs:       [][]byte{emptyBlob[:]},
+			Commitments: [][]byte{emptyBlobCommit[:]},
+			Proofs:      [][]byte{emptyBlobProof[:]},
+		},
+	})
+	if err := pool.limbo.push(tx, 100); err != nil { // 100 <= 200-64
+		t.Fatalf("limbo.push: %v", err)
+	}
+	if len(pool.limbo.index) != 1 {
+		t.Fatalf("expected 1 limbo entry before reset, got %d", len(pool.limbo.index))
+	}
+
+	// Advance the head through the real Reset path; the surrogate boundary
+	// (head-64 = 137) must evict the block-100 sidecar despite nil finality.
+	old := chain.CurrentBlock()
+	chain.head = 201
+	pool.Reset(old, chain.CurrentBlock())
+
+	if len(pool.limbo.index) != 0 {
+		t.Fatalf("expected limbo drained via surrogate finality, still %d entries", len(pool.limbo.index))
+	}
+	if len(pool.limbo.groups) != 0 {
+		t.Fatalf("expected 0 limbo groups after reset, got %d", len(pool.limbo.groups))
+	}
+}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -265,5 +265,5 @@ var (
 	BlockMinBuildTime    int64  = 300     // Minimum block generation time in ms
 	BlockMinBuildTxs     int64  = 2500    // Minimum txs in a block with pending txs
 	BlockTrailTime       int64  = 300     // Time to leave for block data transfer transfer in ms
-	BlobRetentionBlocks  uint64 = 1572480 // Number of blocks to keep blob sidecars (~18.2 days at 1s blocks; 0 = forever)
+	BlobRetentionBlocks  uint64 = 1572480 // Number of blocks to keep blob sidecars (~36.4 days at Metadium's 2s block interval; 0 = forever)
 )


### PR DESCRIPTION
Fixes #76.

## Problem (diagnosis corrected per both reviews)

Upstream keys limbo eviction on beacon finality. Metadium **does** have a chain-level PoA substitute — `metaFinalHeader()` (head − govNodeCount/2+1), wired into `CurrentFinalBlock()` by `b3a5d9f00` — and fleet measurements confirm it works in steady state: `eth_getBlockByNumber("finalized")`/`("safe")` return real blocks on both live networks, and trident90's proposed co-occurrence marker (`TRS list refresh failed`) is absent from full-log scans.

But that substitute resolves through **governance contract reads, which fail in real windows**: during start-up before the metadium admin initializes, when a governance read errors, and permanently on private nets with no governance deployed. Since limbo maintenance was enabled for Camellia (`f3e50b41`, April — not #67, which never touched this line), every such window logs `Nil finalized block cannot evict old blobs` and skips eviction:

- **Testnet (live)**: sporadic — 7,189 lines over ~83 days on an *unrotated* 25.5GB follower log ≈ ~86/day, concentrated in restart/warm-up windows
- **Governance-less private nets**: once per block, permanently (where this was found)
- **Mainnet**: nothing until the 117,764,000 activation on **2026-08-27** (the gate is `IsCancun || IsCamellia`, both false there today); after activation, the same sporadic windows as testnet

The limbo-drain half is unchanged: sidecars parked during failed-finality windows outstay their usefulness (bounded by the 2.5GB datacap, needs actual blob usage).

## Fix

`limboFinal(final, head)` in a fork-owned `limbo_metadium.go`: substitute **head−64** for exactly the failed-finality windows, gated on `!metaminer.IsPoW()` (matching the sibling Metadium paths in this package, and covering ETCD/PBFT). A resolved chain-level boundary always passes through untouched; every non-PoA method keeps upstream behavior bit-for-bit, nil included; nil heads guarded. The 64 is anchored to the reorg handler's own resurrection cutoff, so eviction can never outrun a reorg the pool would still service — and a deeper reorg is bounded and non-consensus (reinject drops with "Blobs unavailable", sender resubmits). Also corrects the `BlobRetentionBlocks` comment (36.4 days at 2s blocks, not 18.2).

## Verification

- `TestLimboFinalPoASurrogate` — surrogate math, the `n == 64` eviction-boundary block, young-chain clamp, explicit-final precedence, nil-head guard
- `TestLimboFinalNonPoAPassthrough` — forced via `asPoW` so it always runs
- **`TestLimboSurrogateEndToEnd`** — the real `Reset` call site with a nil-finality PoA mock: a parked sidecar deeper than head−64 must drain (this is the guard that fails if the call-site wiring regresses, e.g. swapped arguments)
- Full `./core/txpool/...` suite green; `gofmt`/`go vet` clean
- Empirically on the 3-node private net where the bug was found: error rate went from 1/block to 0 across all three nodes with pre-existing limbo entries on disk, fresh blob e2e unaffected

## Why 1.1.1 (owner decision, revised)

The release owner weighed cp-khs's ship-then-1.1.2 recommendation against a second exchange-facing release before 8/27 and decided one corrected review round now is the cheaper path. Branch is rebased onto current dev (`fb47df9f6`); trident90's inline items are all incorporated (predicate, nil-head guard, constant anchoring, all three test gaps, comment/commit-message diagnosis). The `min(final, head-64)` clamp and the lock-held governance read hoist are deferred as follow-ups per the review's own framing.
