### PR TITLE
tests, docs: bigtx & feepayer-evict e2e + m1.1.1 verification report

### DIFF
--- a/docs/camellia-test-report-m1.1.1.md
+++ b/docs/camellia-test-report-m1.1.1.md
@@ -1,0 +1,106 @@
+# Camellia Fork Test Report — m1.1.1 Release Verification
+
+**Date:** 2026-08-11 ~ 2026-08-12
+**Binary under test:** `a91d1b323` (master tip, m1.1.1) and `21c1997e6` (PR #77 candidate = `a91d1b323` + blobpool PoA finality fix)
+**Author:** Jeffrey Song
+
+This report re-validates every functional axis of the original Camellia test
+report (`camellia-test-report.md`, 2026-04-08) against the release-line
+binary, and extends coverage to axes the original did not have: the restored
+256KB txpool ceiling (#64), pool-side TRS enforcement (#67), fee-delegation
+eviction (#67), governance-driven multi-BP rotation, mixed-version fork
+divergence, and the blobpool PoA finality fix (#76/#77).
+
+## 1. Environments
+
+| Environment | Purpose |
+|---|---|
+| 3-node PoA private net (Docker, chainId 1337, Camellia @ block 100, genesis gasLimit pinned to the production 105,000,000) | All functional suites |
+| 2-node mixed-version net (release binary + production `0.10.2-stable/ce4a95e93`) | Fork-boundary divergence |
+| Production followers (46/47/mykeepin, 5 services) + official testnet 5 nodes | Live deployment, soak, lockstep |
+| Fresh full syncs: testnet (embedded genesis) and mainnet (embedded genesis) | #68 embedded-genesis validation, in progress at time of writing |
+
+## 2. Regression Suites (all on the #77 candidate binary)
+
+| Suite | Result |
+|---|---|
+| `camellia-test.sh` (EIP transitions, block 99 vs 100) | **PASS 14 / FAIL 0 / SKIP 3** (skips environmental, unchanged from v1) |
+| `camellia-contract-e2e` (solc 0.8.28 cancun: PUSH0/MCOPY/TSTORE) | ALL PASS |
+| `blob-tx-e2e` (EIP-4844 lifecycle + sidecar) | ALL PASS |
+| `mixed-tx-e2e` (Type 2 + Type 22 + Type 3 in one flow) | ALL PASS |
+| `rpc-test-full.sh` (Execution API surface) | **64 PASS / 0 FAIL / 0 WARN / 3 SKIP** |
+| `bigtx-e2e` (new, see §3) | ALL PASS |
+
+## 3. New Coverage
+
+### 3.1 256KB txpool ceiling (`tests/private-net-poa/bigtx-e2e`, #64)
+- 262,248-byte tx rejected: `oversized data: 256.10 KiB, limit 262144`
+- 254,056-byte max-code deployment admitted, **propagated to peer pools
+  pre-mining** (pending=true observed on both non-miner nodes), mined with
+  status 1; deployed code reads back at exactly 253,952 bytes
+- gasUsed **52,045,896** against the production block gas limit
+  **105,000,000** — roughly 2x headroom
+
+### 3.2 Fee-delegation eviction (`tests/private-net-poa/feepayer-evict-e2e`, #67)
+A queued Type-22 tx whose fee payer is drained to zero after admission is
+evicted by the promote/demote sweep within seconds. 3/3 PASS.
+
+### 3.3 Governance Phase 2 — multi-BP rotation
+`deploy.sh` on a fresh chain: Registry at the deployer's nonce-0 CREATE
+address, etcd initialized first attempt, node2/node3 registered, and all
+three sealers observed rotating block production (15-block sample: 3/7/5).
+
+> Operational note learned the hard way: registry discovery scans the genesis
+> coinbase's CREATE addresses for nonces 0–9, so governance must be deployed
+> before that account sends other transactions.
+
+### 3.4 TRS pool-side enforcement (#67)
+- `addToTRSList(victim)` alone does **not** activate enforcement — a node
+  enforces only after its governance address calls `TRSList.subscribe()`
+  (per-node opt-in, matching 0.10.x semantics)
+- Once subscribed: transactions **from** and **to** the restricted address
+  are both rejected at admission with `included in the TRSList`
+- Follow-up for the mainnet runbook: verify BP subscription state after the
+  rolling upgrade; an unsubscribed node silently skips enforcement
+
+### 3.5 Sync-mode policy (docs/#69 claim, verified on the binary)
+`--syncmode snap` and `--syncmode light` fail fast with the documented
+full-only message; `fast` is rejected by the flag parser.
+
+### 3.6 Mixed-version fork divergence (production 0.10.2 binary)
+A real `0.10.2-stable/ce4a95e93` node (taken from the mainnet fleet) peered
+with a release-binary miner on a fresh Camellia@100 chain:
+- pre-fork: peers and syncs normally (0 → 99)
+- at activation: imports **exactly through block 99 and stops** — no crash,
+  no BAD BLOCK; peer count drops to 0 (fork-id divergence) and the node
+  idles logging `Looking for peers`
+This is the expected behavior for any operator who has not upgraded when
+mainnet reaches 117,764,000.
+
+### 3.7 Blobpool PoA finality (#76 → #77)
+Before the fix, every Camellia-active node logged `Nil finalized block cannot
+evict old blobs` once per block (live on testnet after the 1.1.1 rollout;
+7,189 lines in one follower's log) and included blob sidecars never left the
+limbo store. With the #77 candidate binary: zero occurrences across all three
+nodes (including with pre-existing limbo entries on disk), fresh blob e2e
+unaffected, and 64-plus blocks of post-eviction silence.
+
+## 4. Live Deployments (a91d1b323)
+
+| Fleet | Result |
+|---|---|
+| Followers: 46 (LevelDB), 47 (RocksDB), mykeepin (archive) — 5 services | Graceful swaps 0–7s, fork banners correct, lockstep with official networks, zero errors over soak |
+| Official testnet: bp1/bp2/bp3/api01/exp01 | Rolling deploy, one node at a time; etcd leader handoff observed (`moving leader to meta1`); sealer rotation intact; block production uninterrupted |
+
+Fresh full syncs from embedded genesis (the #68 path) reproduce the official
+genesis hashes on both networks (testnet `0x10c1b0a5…`, mainnet
+`0xf1b2a543…`) and are progressing past the historical trouble spots at the
+time of writing.
+
+## 5. Verdict
+
+Every axis of the April report passes on the release binary, and the new
+axes (256KB ceiling, TRS enforcement, fee-payer eviction, governance
+rotation, mixed-version divergence, blobpool finality) pass as well. The one
+code change this round of testing produced is PR #77; everything else
+verified clean.

--- a/tests/private-net-poa/bigtx-e2e/main.go
+++ b/tests/private-net-poa/bigtx-e2e/main.go
@@ -1,0 +1,188 @@
+// bigtx-e2e: verifies the restored 256KB txpool ceiling end-to-end on a live
+// PoA network mirroring production block gas limit (105M).
+//
+//  1. NEGATIVE: a creation tx whose RLP size exceeds params.MaxTransactionSize
+//     (262,144) must be rejected by the pool with "oversized data".
+//  2. POSITIVE: a creation tx depositing a max-size contract
+//     (params.MaxCodeSize = 253,952 runtime bytes, ~254KB tx) must be
+//     accepted, propagated to the other nodes' pools, mined with status 1,
+//     and the deployed code must read back at exactly 253,952 bytes.
+//
+// Usage: go run . [rpc1] [rpc2] [rpc3]   (defaults: localhost:8545/8546/8547)
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const hardhatKey0 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+func die(format string, a ...any) {
+	fmt.Printf("FAIL: "+format+"\n", a...)
+	os.Exit(1)
+}
+
+// initcodeFor returns initcode that deposits `runtimeLen` bytes of runtime
+// code: 13-byte CODECOPY prologue followed by the payload.
+func initcodeFor(runtimeLen int) []byte {
+	if runtimeLen > 0xFFFFFF {
+		panic("runtimeLen too large for PUSH3")
+	}
+	pro := []byte{
+		0x62, byte(runtimeLen >> 16), byte(runtimeLen >> 8), byte(runtimeLen), // PUSH3 len
+		0x80,       // DUP1
+		0x60, 0x0d, // PUSH1 13 (payload offset)
+		0x60, 0x00, // PUSH1 0  (mem dest)
+		0x39,       // CODECOPY
+		0x60, 0x00, // PUSH1 0
+		0xf3, // RETURN
+	}
+	return append(pro, make([]byte, runtimeLen)...)
+}
+
+func signedCreation(key *ecdsa.PrivateKey, chainID *big.Int, nonce uint64, gasPrice *big.Int, gas uint64, initcode []byte) *types.Transaction {
+	tx := types.NewContractCreation(nonce, big.NewInt(0), gas, gasPrice, initcode)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	if err != nil {
+		die("sign: %v", err)
+	}
+	return signed
+}
+
+func main() {
+	urls := []string{"http://localhost:8545", "http://localhost:8546", "http://localhost:8547"}
+	for i, a := range os.Args[1:] {
+		if i < 3 {
+			urls[i] = a
+		}
+	}
+	ctx := context.Background()
+
+	key, err := crypto.HexToECDSA(hardhatKey0)
+	if err != nil {
+		die("key: %v", err)
+	}
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	var clients []*ethclient.Client
+	for _, u := range urls {
+		c, err := ethclient.Dial(u)
+		if err != nil {
+			die("dial %s: %v", u, err)
+		}
+		clients = append(clients, c)
+	}
+	c1 := clients[0]
+
+	chainID, err := c1.ChainID(ctx)
+	if err != nil {
+		die("chainID: %v", err)
+	}
+	head, err := c1.HeaderByNumber(ctx, nil)
+	if err != nil {
+		die("head: %v", err)
+	}
+	bal, _ := c1.BalanceAt(ctx, from, nil)
+	gasPrice, err := c1.SuggestGasPrice(ctx)
+	if err != nil {
+		die("gasPrice: %v", err)
+	}
+	fmt.Printf("chainID=%v head=%v gasLimit=%d camellia@100 sender=%s balance=%s gasPrice=%s\n",
+		chainID, head.Number, head.GasLimit, from.Hex(), bal.String(), gasPrice.String())
+	fmt.Printf("params: MaxCodeSize=%d MaxTransactionSize=%d\n", params.MaxCodeSize, params.MaxTransactionSize)
+
+	nonce, err := c1.PendingNonceAt(ctx, from)
+	if err != nil {
+		die("nonce: %v", err)
+	}
+
+	// ---- 1. NEGATIVE: tx RLP > 262,144 must be rejected ----
+	over := signedCreation(key, chainID, nonce, gasPrice, 60_000_000, initcodeFor(params.MaxTransactionSize))
+	oRaw, _ := rlp.EncodeToBytes(over)
+	err = c1.SendTransaction(ctx, over)
+	if err == nil {
+		die("oversized tx (%d bytes RLP) was ACCEPTED — ceiling not enforced", len(oRaw))
+	}
+	if !strings.Contains(err.Error(), "oversized") {
+		die("oversized tx rejected with unexpected error: %v", err)
+	}
+	fmt.Printf("PASS 1/4: oversized tx (RLP %d > %d) rejected: %v\n", len(oRaw), params.MaxTransactionSize, err)
+
+	// ---- 2. POSITIVE: max-size contract deployment ----
+	initcode := initcodeFor(params.MaxCodeSize)
+	big1 := signedCreation(key, chainID, nonce, gasPrice, 60_000_000, initcode)
+	bRaw, _ := rlp.EncodeToBytes(big1)
+	if len(bRaw) <= 131072 {
+		die("test tx unexpectedly small (%d bytes) — not exercising the 128KB regression", len(bRaw))
+	}
+	if len(bRaw) > params.MaxTransactionSize {
+		die("test tx too big (%d bytes) — constructor overhead math wrong", len(bRaw))
+	}
+	if err := c1.SendTransaction(ctx, big1); err != nil {
+		die("max-size deployment tx (RLP %d bytes) rejected by pool: %v", len(bRaw), err)
+	}
+	fmt.Printf("PASS 2/4: %d-byte tx (>128KB legacy limit, <=256KB) accepted by node1 pool, hash=%s\n", len(bRaw), big1.Hash().Hex())
+
+	// ---- 3. PROPAGATION: other nodes must see the tx ----
+	seen := map[int]bool{}
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) && (!seen[1] || !seen[2]) {
+		for i := 1; i <= 2; i++ {
+			if seen[i] {
+				continue
+			}
+			if _, pending, err := clients[i].TransactionByHash(ctx, big1.Hash()); err == nil {
+				seen[i] = true
+				fmt.Printf("PASS 3/4: tx visible on node%d (pending=%v)\n", i+1, pending)
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if !seen[1] || !seen[2] {
+		die("tx did not propagate to all nodes within 60s (node2=%v node3=%v)", seen[1], seen[2])
+	}
+
+	// ---- 4. INCLUSION + code readback ----
+	var rcpt *types.Receipt
+	deadline = time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		rcpt, err = c1.TransactionReceipt(ctx, big1.Hash())
+		if err == nil {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if rcpt == nil {
+		die("tx not mined within 120s")
+	}
+	if rcpt.Status != 1 {
+		die("tx mined but reverted (status=0), gasUsed=%d", rcpt.GasUsed)
+	}
+	blk, err := c1.BlockByNumber(ctx, rcpt.BlockNumber)
+	if err != nil {
+		die("block: %v", err)
+	}
+	code, err := c1.CodeAt(ctx, rcpt.ContractAddress, nil)
+	if err != nil {
+		die("codeAt: %v", err)
+	}
+	if len(code) != params.MaxCodeSize {
+		die("deployed code %d bytes, want %d", len(code), params.MaxCodeSize)
+	}
+	fmt.Printf("PASS 4/4: mined in block %v (status=1) gasUsed=%d blockGasLimit=%d — deployed code %d bytes at %s\n",
+		rcpt.BlockNumber, rcpt.GasUsed, blk.GasLimit(), len(code), rcpt.ContractAddress.Hex())
+	fmt.Printf("ALL PASS — 256KB pool ceiling verified end-to-end (accept, propagate, include, %d-byte code deposit under %d gas limit)\n",
+		len(code), blk.GasLimit())
+}

--- a/tests/private-net-poa/feepayer-evict-e2e/main.go
+++ b/tests/private-net-poa/feepayer-evict-e2e/main.go
@@ -1,0 +1,135 @@
+// feepayer-evict-e2e: verifies the #67 sweep evicts a pooled fee-delegated tx
+// whose fee payer has been drained after admission.
+//
+// Sequence: fund a fresh fee payer -> admit a type-22 tx with a nonce gap (so
+// it parks in the queue instead of mining) -> drain the fee payer to zero ->
+// the promote/demote sweep must drop the delegated tx within a few blocks.
+//
+// Usage: go run . [rpc-url]   (default http://localhost:8545)
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+const senderKeyHex = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+func die(f string, a ...any) { fmt.Printf("FAIL: "+f+"\n", a...); os.Exit(1) }
+
+func waitMined(ctx context.Context, c *ethclient.Client, h common.Hash, secs int) *types.Receipt {
+	for i := 0; i < secs; i++ {
+		if r, err := c.TransactionReceipt(ctx, h); err == nil {
+			return r
+		}
+		time.Sleep(time.Second)
+	}
+	die("tx %s not mined in %ds", h.Hex(), secs)
+	return nil
+}
+
+func main() {
+	url := "http://localhost:8545"
+	if len(os.Args) > 1 {
+		url = os.Args[1]
+	}
+	ctx := context.Background()
+	c, err := ethclient.Dial(url)
+	if err != nil {
+		die("dial: %v", err)
+	}
+	chainID, _ := c.ChainID(ctx)
+	sender, _ := crypto.HexToECDSA(senderKeyHex)
+	senderAddr := crypto.PubkeyToAddress(sender.PublicKey)
+
+	// Fresh fee payer, funded just enough to pass admission.
+	fpKey, _ := crypto.GenerateKey()
+	fpAddr := crypto.PubkeyToAddress(fpKey.PublicKey)
+	gasPrice, _ := c.SuggestGasPrice(ctx)
+	fund := new(big.Int).Mul(gasPrice, big.NewInt(200_000)) // covers delegated tx cost cap + drain tx
+
+	nonce, _ := c.PendingNonceAt(ctx, senderAddr)
+	fundTx, _ := types.SignTx(types.NewTransaction(nonce, fpAddr, fund, 21000, gasPrice, nil),
+		types.LatestSignerForChainID(chainID), sender)
+	if err := c.SendTransaction(ctx, fundTx); err != nil {
+		die("fund feePayer: %v", err)
+	}
+	waitMined(ctx, c, fundTx.Hash(), 30)
+	fmt.Printf("funded feePayer %s with %s wei\n", fpAddr.Hex(), fund)
+
+	// Type-22 delegated tx with a nonce GAP (pending+1) so it parks queued.
+	nonce, _ = c.PendingNonceAt(ctx, senderAddr)
+	gapNonce := nonce + 1
+	tip := big.NewInt(1_000_000_000)
+	inner := &types.DynamicFeeTx{
+		ChainID: chainID, Nonce: gapNonce, GasTipCap: tip, GasFeeCap: gasPrice,
+		Gas: 21000, To: &senderAddr, Value: big.NewInt(0),
+	}
+	senderSigned, err := types.SignTx(types.NewTx(inner), types.NewLondonSigner(chainID), sender)
+	if err != nil {
+		die("sender sign: %v", err)
+	}
+	v, r, s := senderSigned.RawSignatureValues()
+	fd := &types.FeeDelegateDynamicFeeTx{
+		SenderTx: types.DynamicFeeTx{
+			ChainID: chainID, Nonce: gapNonce, GasTipCap: tip, GasFeeCap: gasPrice,
+			Gas: 21000, To: &senderAddr, Value: big.NewInt(0),
+			V: v, R: r, S: s,
+		},
+		FeePayer: &fpAddr,
+		FV:       new(big.Int), FR: new(big.Int), FS: new(big.Int),
+	}
+	fdTx, err := types.SignTx(types.NewTx(fd), types.NewFeeDelegateSigner(chainID), fpKey)
+	if err != nil {
+		die("feePayer sign: %v", err)
+	}
+	if err := c.SendTransaction(ctx, fdTx); err != nil {
+		die("delegated tx rejected at admission (feePayer funded, should be accepted): %v", err)
+	}
+	fmt.Printf("PASS 1/3: delegated tx admitted (queued, nonce gap) hash=%s\n", fdTx.Hash().Hex())
+
+	if _, pending, err := c.TransactionByHash(ctx, fdTx.Hash()); err != nil || !pending {
+		die("delegated tx not visible in pool after admission (err=%v pending=%v)", err, pending)
+	}
+
+	// Drain the fee payer to zero.
+	fpBal, _ := c.BalanceAt(ctx, fpAddr, nil)
+	drainGas := new(big.Int).Mul(gasPrice, big.NewInt(21000))
+	drainVal := new(big.Int).Sub(fpBal, drainGas)
+	if drainVal.Sign() <= 0 {
+		die("feePayer balance too small to drain: %s", fpBal)
+	}
+	fpNonce, _ := c.PendingNonceAt(ctx, fpAddr)
+	drainTx, _ := types.SignTx(types.NewTransaction(fpNonce, senderAddr, drainVal, 21000, gasPrice, nil),
+		types.LatestSignerForChainID(chainID), fpKey)
+	if err := c.SendTransaction(ctx, drainTx); err != nil {
+		die("drain tx: %v", err)
+	}
+	waitMined(ctx, c, drainTx.Hash(), 30)
+	fpBal, _ = c.BalanceAt(ctx, fpAddr, nil)
+	fmt.Printf("PASS 2/3: feePayer drained (balance now %s wei)\n", fpBal)
+
+	// The sweep should now drop the queued delegated tx within a few blocks.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		_, _, err := c.TransactionByHash(ctx, fdTx.Hash())
+		if err == ethereum.NotFound {
+			fmt.Println("PASS 3/3: drained-feePayer delegated tx evicted from the pool")
+			fmt.Println("ALL PASS")
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	fmt.Println("RESULT: tx still pooled after 60s — eviction did not trigger on reset sweep " +
+		"(document whether it defers to the 3h ticker; not an automatic FAIL, but needs a ruling)")
+	os.Exit(2)
+}


### PR DESCRIPTION
Test assets and the verification record from the m1.1.1 release testing, so they ride the same dev→master promotion as #77.

**`tests/private-net-poa/bigtx-e2e`** — end-to-end pin of the restored 256KB txpool ceiling (#64): oversized rejection at the exact boundary, max-code deployment admission, pool-level propagation, inclusion under the production 105M gas limit, and code readback at exactly `MaxCodeSize`.

**`tests/private-net-poa/feepayer-evict-e2e`** — live pin of the #67 sweep: a queued Type-22 tx whose fee payer is drained after admission is evicted rather than lingering unmineable. (Ran 3/3 on the private net.)

**`docs/camellia-test-report-m1.1.1.md`** — the full verification record for this release: all six April-report suites re-run green on the #77 candidate binary, plus the new axes — TRS per-node `subscribe()` semantics (with a mainnet-runbook follow-up), governance Phase-2 rotation, sync-mode policy, mixed-version fork divergence measured against a production 0.10.2 binary (stops at block 99, no crash, peers drop — the exchange-notice evidence), and the #76/#77 blobpool verification.

No production code changes — tests and docs only. Both e2e programs use the well-known Hardhat dev key that `setup.sh` already embeds.