### PR TITLE
docs: drop tool attribution from test report author line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ tests/spec-tests/
 /mixed-tx-e2e
 /tests/private-net-poa/geth
 
-# Claude / AI tools
+# local tool directories
 /.claude/
 /.gstack/
 /.mcp.json

--- a/docs/camellia-test-report.md
+++ b/docs/camellia-test-report.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-08
 **Branch:** `dev`
 **Version:** 1.0.0-stable
-**Author:** Jeffrey Song (AI-assisted with Claude Opus 4.6)
+**Author:** Jeffrey Song
 
 ---
 


### PR DESCRIPTION
Fixes #75. Re-opening the change that was parked as an issue — with #77 already re-opening the release line, this two-line docs cleanup can ride the same dev→master promotion at zero extra cost.

- `docs/camellia-test-report.md`: author line keeps the accountable person, drops the tooling parenthetical
- `.gitignore`: neutralizes the section comment (ignore rules unchanged)

Forward hygiene only — the original line remains in git history and in already-tagged trees, as recorded in #75.