### PR TITLE
release: promote dev to master for m1.1.1 (re-promotion, post-#77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ tests/spec-tests/
 /mixed-tx-e2e
 /tests/private-net-poa/geth
 
-# Claude / AI tools
+# local tool directories
 /.claude/
 /.gstack/
 /.mcp.json

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -860,7 +860,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	}
 	// Flush out any blobs from limbo that are older than the latest finality
 	if p.chain.Config().IsCancun(p.head.Number, p.head.Time) || p.chain.Config().IsCamellia(p.head.Number) {
-		p.limbo.finalize(p.chain.CurrentFinalBlock())
+		p.limbo.finalize(limboFinal(p.chain.CurrentFinalBlock(), p.head))
 	}
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (

--- a/core/txpool/blobpool/limbo_metadium.go
+++ b/core/txpool/blobpool/limbo_metadium.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
+)
+
+// limboFinalityDepth is the eviction boundary the blobpool substitutes for
+// chain-level finality when the latter is unavailable (see limboFinal).
+//
+// The value is anchored to the reorg handler's own cutoff in (*BlobPool).reorg
+// (blobpool.go, the "64 blocks deep" bail-out): reorgs deeper than that are
+// never resurrected there, so evicting limbo sidecars at head-64 cannot
+// discard a sidecar the reorg path would still ask for. Do not lower one
+// without the other. At Metadium's 2s block interval this is ~128s of depth.
+// Should a deeper reorg occur regardless, the failure is bounded and
+// non-consensus: reinject logs "Blobs unavailable, dropping reorged tx" and
+// the sender resubmits.
+const limboFinalityDepth = 64
+
+// limboFinal returns the header below which included blob sidecars may be
+// evicted from limbo. Upstream keys this on beacon finality. Metadium has a
+// chain-level PoA substitute -- metaFinalHeader (head - govNodeCount/2+1),
+// wired into CurrentFinalBlock by b3a5d9f00 -- but it resolves through
+// governance contract reads, which fail in real windows: during start-up
+// before the metadium admin is initialized, when the governance read errors,
+// and permanently on private nets with no governance deployed (#76). In each
+// such window Reset would log "Nil finalized block cannot evict old blobs"
+// and skip limbo maintenance. Under PoA, substitute head-limboFinalityDepth
+// for exactly those windows; a resolved chain-level boundary always passes
+// through untouched, and every non-PoA consensus method keeps the upstream
+// behavior bit-for-bit, nil included.
+func limboFinal(final, head *types.Header) *types.Header {
+	if final != nil || metaminer.IsPoW() || head == nil {
+		return final
+	}
+	depth := uint64(limboFinalityDepth)
+	if n := head.Number.Uint64(); n >= depth {
+		return &types.Header{Number: new(big.Int).SetUint64(n - depth)}
+	}
+	// Fewer than limboFinalityDepth blocks exist; nothing can be deep enough
+	// to evict. Block zero carries no blob txs, so this is a clean no-op that
+	// still avoids the nil-finality error path.
+	return &types.Header{Number: new(big.Int)}
+}

--- a/core/txpool/blobpool/limbo_metadium_test.go
+++ b/core/txpool/blobpool/limbo_metadium_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package blobpool
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// asPoA / asPoW flip the global consensus method for one test, restoring the
+// previous value afterwards. params.ConsensusMethod is PoW outside a running
+// node. Tests using these must NOT call t.Parallel() -- serial tests finish
+// (and restore the global) before the parallel batch runs.
+func asPoA(t *testing.T) {
+	t.Helper()
+	old := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoA
+	t.Cleanup(func() { params.ConsensusMethod = old })
+}
+
+func asPoW(t *testing.T) {
+	t.Helper()
+	old := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoW
+	t.Cleanup(func() { params.ConsensusMethod = old })
+}
+
+func header(n uint64) *types.Header {
+	return &types.Header{Number: new(big.Int).SetUint64(n)}
+}
+
+// TestLimboFinalPoASurrogate pins the PoA finality surrogate: when chain-level
+// finality is unavailable, limbo eviction must key on head-limboFinalityDepth
+// instead of silently never running (issue #76).
+func TestLimboFinalPoASurrogate(t *testing.T) {
+	asPoA(t)
+
+	// Deep enough head: surrogate is head-depth.
+	if got := limboFinal(nil, header(1000)); got == nil {
+		t.Fatal("want surrogate final header under PoA, got nil")
+	} else if want := uint64(1000 - limboFinalityDepth); got.Number.Uint64() != want {
+		t.Fatalf("surrogate final number: got %d, want %d", got.Number.Uint64(), want)
+	}
+	// Boundary: the first head that can evict group 0.
+	if got := limboFinal(nil, header(limboFinalityDepth)); got.Number.Uint64() != 0 {
+		t.Fatalf("boundary head %d: got %d, want 0", limboFinalityDepth, got.Number.Uint64())
+	}
+	// Young chain: clamp to zero rather than underflow or return nil.
+	if got := limboFinal(nil, header(limboFinalityDepth-1)); got == nil {
+		t.Fatal("want zero-height surrogate on young chain, got nil")
+	} else if got.Number.Uint64() != 0 {
+		t.Fatalf("young-chain surrogate: got %d, want 0", got.Number.Uint64())
+	}
+	// A resolved chain-level boundary (however it appeared) always wins.
+	if got := limboFinal(header(7), header(1000)); got.Number.Uint64() != 7 {
+		t.Fatalf("explicit final must pass through, got %d", got.Number.Uint64())
+	}
+	// A nil head must not panic and must not fabricate a boundary.
+	if got := limboFinal(nil, nil); got != nil {
+		t.Fatalf("nil head must pass nil through, got %v", got.Number)
+	}
+}
+
+// TestLimboFinalNonPoAPassthrough pins that non-PoA consensus keeps the
+// upstream behavior bit-for-bit: nil stays nil (with upstream's error log
+// downstream), and a real final header passes through. asPoW forces the
+// non-PoA condition so this guard always runs.
+func TestLimboFinalNonPoAPassthrough(t *testing.T) {
+	asPoW(t)
+
+	if got := limboFinal(nil, header(1000)); got != nil {
+		t.Fatalf("non-PoA nil final must stay nil, got %v", got.Number)
+	}
+	if got := limboFinal(header(7), header(1000)); got.Number.Uint64() != 7 {
+		t.Fatalf("non-PoA explicit final must pass through, got %d", got.Number.Uint64())
+	}
+}
+
+// testBlockChainNilFinal is testBlockChainCamellia with chain-level finality
+// unavailable, as on a governance-less private net or during the start-up /
+// governance-read-failure windows (#76).
+type testBlockChainNilFinal struct {
+	testBlockChainCamellia
+	head uint64
+}
+
+func (bc *testBlockChainNilFinal) CurrentFinalBlock() *types.Header { return nil }
+
+func (bc *testBlockChainNilFinal) CurrentBlock() *types.Header {
+	h := bc.testBlockChainCamellia.CurrentBlock()
+	h.Number = new(big.Int).SetUint64(bc.head)
+	return h
+}
+
+// TestLimboSurrogateEndToEnd exercises the real Reset call site with a
+// nil-finality chain under PoA: a limbo entry deeper than the surrogate
+// boundary must be evicted. This is the guard that fails if the call-site
+// wiring regresses (e.g. swapped limboFinal arguments, which would compile).
+func TestLimboSurrogateEndToEnd(t *testing.T) {
+	asPoA(t)
+
+	cfg := camelliaOnlyChainConfig()
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	chain := &testBlockChainNilFinal{
+		testBlockChainCamellia: testBlockChainCamellia{config: cfg, statedb: statedb},
+		head:                   200,
+	}
+	poolDir, err := os.MkdirTemp("", "blobpool-surrogate-test-*")
+	if err != nil {
+		t.Fatalf("TempDir: %v", err)
+	}
+	defer os.RemoveAll(poolDir)
+
+	pool := New(DefaultConfig, chain)
+	if err := pool.Init(params.InitialBaseFee, chain.CurrentBlock(), makeAddressReserver()); err != nil {
+		t.Fatalf("pool.Init: %v", err)
+	}
+	defer pool.Close()
+
+	// Park a sidecar in limbo at a block deeper than head-limboFinalityDepth.
+	to := common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+	tx := types.NewTx(&types.BlobTx{
+		ChainID:          uint256.MustFromBig(cfg.ChainID),
+		Nonce:            0,
+		GasTipCap:        uint256.NewInt(1e9),
+		GasFeeCap:        uint256.NewInt(2e9),
+		Gas:              21000,
+		To:               &to,
+		Value:            new(uint256.Int),
+		MaxFeePerBlobGas: uint256.NewInt(params.BlobTxMinBlobGasprice),
+		BlobHashes:       []common.Hash{emptyBlobVHash},
+		Sidecar: &types.BlobTxSidecar{
+			Blobs:       [][]byte{emptyBlob[:]},
+			Commitments: [][]byte{emptyBlobCommit[:]},
+			Proofs:      [][]byte{emptyBlobProof[:]},
+		},
+	})
+	if err := pool.limbo.push(tx, 100); err != nil { // 100 <= 200-64
+		t.Fatalf("limbo.push: %v", err)
+	}
+	if len(pool.limbo.index) != 1 {
+		t.Fatalf("expected 1 limbo entry before reset, got %d", len(pool.limbo.index))
+	}
+
+	// Advance the head through the real Reset path; the surrogate boundary
+	// (head-64 = 137) must evict the block-100 sidecar despite nil finality.
+	old := chain.CurrentBlock()
+	chain.head = 201
+	pool.Reset(old, chain.CurrentBlock())
+
+	if len(pool.limbo.index) != 0 {
+		t.Fatalf("expected limbo drained via surrogate finality, still %d entries", len(pool.limbo.index))
+	}
+	if len(pool.limbo.groups) != 0 {
+		t.Fatalf("expected 0 limbo groups after reset, got %d", len(pool.limbo.groups))
+	}
+}

--- a/docs/camellia-test-report-m1.1.1.md
+++ b/docs/camellia-test-report-m1.1.1.md
@@ -1,7 +1,7 @@
 # Camellia Fork Test Report — m1.1.1 Release Verification
 
 **Date:** 2026-08-11 ~ 2026-08-12
-**Binary under test:** `a91d1b323` (master tip, m1.1.1) and `21c1997e6` (PR #77 candidate = `a91d1b323` + blobpool PoA finality fix)
+**Binary under test:** `a91d1b323` (master tip, m1.1.1), `21c1997e6` (PR #77 candidate), and `a8d626726` (final release tree = dev tip after the #77 merge; see §5)
 **Author:** Jeffrey Song
 
 This report re-validates every functional axis of the original Camellia test
@@ -17,7 +17,7 @@ divergence, and the blobpool PoA finality fix (#76/#77).
 |---|---|
 | 3-node PoA private net (Docker, chainId 1337, Camellia @ block 100, genesis gasLimit pinned to the production 105,000,000) | All functional suites |
 | 2-node mixed-version net (release binary + production `0.10.2-stable/ce4a95e93`) | Fork-boundary divergence |
-| Production followers (46/47/mykeepin, 5 services) + official testnet 5 nodes | Live deployment, soak, lockstep |
+| Production followers (46/47/183, 5 services) + official testnet 5 nodes | Live deployment, soak, lockstep |
 | Fresh full syncs: testnet (embedded genesis) and mainnet (embedded genesis) | #68 embedded-genesis validation, in progress at time of writing |
 
 ## 2. Regression Suites (all on the #77 candidate binary)
@@ -89,7 +89,7 @@ unaffected, and 64-plus blocks of post-eviction silence.
 
 | Fleet | Result |
 |---|---|
-| Followers: 46 (LevelDB), 47 (RocksDB), mykeepin (archive) — 5 services | Graceful swaps 0–7s, fork banners correct, lockstep with official networks, zero errors over soak |
+| Followers: 46 (LevelDB), 47 (RocksDB), 183 (archive) — 5 services | Graceful swaps 0–7s, fork banners correct, lockstep with official networks, zero errors over soak |
 | Official testnet: bp1/bp2/bp3/api01/exp01 | Rolling deploy, one node at a time; etcd leader handoff observed (`moving leader to meta1`); sealer rotation intact; block production uninterrupted |
 
 Fresh full syncs from embedded genesis (the #68 path) reproduce the official
@@ -97,10 +97,56 @@ genesis hashes on both networks (testnet `0x10c1b0a5…`, mainnet
 `0xf1b2a543…`) and are progressing past the historical trouble spots at the
 time of writing.
 
-## 5. Verdict
+The fleet moves to the final tree (§5) with the m1.1.1 asset rebuild that
+follows the dev→master promotion.
+
+## 5. Final-tree re-verification (`a8d626726`)
+
+After #77 merged, the entire private-net verification was repeated **from a
+full reset** on a binary built at `a8d626726` — the dev tip whose tree is
+bit-identical to the dev→master promotion (#80). Every axis reproduced the
+candidate-binary results:
+
+| Axis | Result |
+|---|---|
+| `camellia-test.sh` | PASS 14 / FAIL 0 / SKIP 3 (identical to §2) |
+| `camellia-contract-e2e`, `blob-tx-e2e`, `mixed-tx-e2e` | ALL PASS |
+| `bigtx-e2e` | 4/4 — 253,952-byte code deposit, gasUsed 52,045,896 under the production 105,000,000 limit |
+| `rpc-test-full.sh` | Final: PASS — no FAILs |
+| `feepayer-evict-e2e` | 3/3 PASS |
+| Blobpool finality (#77 acceptance) | `Nil finalized` **0** and eviction failures **0** on all three nodes, measured over 70-plus-block windows both **before and after** governance activation |
+| Governance Phase 2 | Registry discovered, `metadiumInfo` self/nodes populated, etcd up, all three sealers rotating (24-block sample: 18/3/3) |
+| TRS live cycle | subscribe → `addToTRSList` → admission rejected with `included in the TRSList` on the subscribed node; the same signed tx accepted by an unsubscribed node (opt-in confirmed); `removeFromTRSList` → admission accepted and mined |
+| Mixed-version divergence | Re-run with the final binary: identical halt at block 99 + peer drop; the release node continued past 345 |
+| Protocol negotiation | Observed via `admin.peers` caps: 0.10.2 advertises `meta/65, meta/66`; the release binary advertises `meta/66, meta/68, meta/69`; the session settles on the shared `meta/66` |
+
+Note that the governance-less phase of this harness is itself the #77 target
+case: chain-level finality never resolves there (permanent fallback window),
+so the zero-error result directly exercises the surrogate path, while the
+fleet measurement recorded on #77 covers the steady-state path
+(`finalized`/`safe` returning real blocks).
+
+Two harness constraints were root-caused during this run and are recorded
+for future re-runs (they are measurement artifacts, not binary defects):
+
+1. **Suite ordering.** Registry discovery scans the genesis coinbase's
+   CREATE addresses at nonces 0–9 (§3.3). The regression suites spend that
+   account's nonces, so on any chain that will host governance, `deploy.sh`
+   must run before the suites; conversely the two measurements below must
+   run before governance activates.
+2. **Single-sealer assumptions.** The `camellia-test.sh` Warm-COINBASE probe
+   calls with a fixed `from` that equals another sealer's coinbase, so under
+   rotation EIP-2929 pre-warming can make blocks 99 and 100 measure equal;
+   and the `mixed-tx-e2e` fee-payer check assumes the fee payer is not also
+   a block-reward recipient. Both self-invalidate under active rotation and
+   pass in the pre-governance phase, which is how §2 and this section ran
+   them.
+
+## 6. Verdict
 
 Every axis of the April report passes on the release binary, and the new
 axes (256KB ceiling, TRS enforcement, fee-payer eviction, governance
 rotation, mixed-version divergence, blobpool finality) pass as well. The one
-code change this round of testing produced is PR #77; everything else
-verified clean.
+code change this round of testing produced is PR #77 — and §5 re-verifies
+the complete matrix on the exact tree being promoted to master. Everything
+else verified clean.

--- a/docs/camellia-test-report-m1.1.1.md
+++ b/docs/camellia-test-report-m1.1.1.md
@@ -1,7 +1,7 @@
 # Camellia Fork Test Report — m1.1.1 Release Verification
 
 **Date:** 2026-08-11 ~ 2026-08-12
-**Binary under test:** `a91d1b323` (master tip, m1.1.1), `21c1997e6` (PR #77 candidate), and `a8d626726` (final release tree = dev tip after the #77 merge; see §5)
+**Binary under test:** `a91d1b323` (master tip, m1.1.1), `21c1997e6` (PR #77 candidate), `a8d626726` (final release tree after the #77 merge; see §5), and `e6a9f31ce` (that tree plus this report — the binary deployed fleet-wide in §4.1)
 **Author:** Jeffrey Song
 
 This report re-validates every functional axis of the original Camellia test
@@ -97,8 +97,36 @@ genesis hashes on both networks (testnet `0x10c1b0a5…`, mainnet
 `0xf1b2a543…`) and are progressing past the historical trouble spots at the
 time of writing.
 
-The fleet moves to the final tree (§5) with the m1.1.1 asset rebuild that
-follows the dev→master promotion.
+### 4.1 Final-tree deployment (`e6a9f31ce`)
+
+Before the promotion was merged, the final tree was deployed to **every node we
+operate** and verified in place. All twelve instances report
+`1.1.1-stable-e6a9f31c`:
+
+| Target | Result |
+|---|---|
+| 46 — mainnet + testnet services (LevelDB) | Graceful restarts 5s / 6s; fork banners correct (#117764000 / #86449000); static peers re-attached (3 / 5); zero errors |
+| 47 — mainnet service (RocksDB) | Restart 4s, peers 3, head advancing, zero errors |
+| 47 — testnet service (RocksDB) | Restart after abandoning a long-running `debug_setHead` experiment: stop 301s, resumed cleanly at the rewound head (89,826,500) with no deeper state rollback, then re-aligned its header chain |
+| 183 — archive (LevelDB) | Restart 1s, `debug_traceBlockByNumber` serving, head advancing |
+| Fresh-sync instances (testnet + mainnet, embedded genesis) | Restarted onto the final binary, peers re-attached, syncing continues |
+| **Official testnet: api01, exp01, bp2, bp1, bp3** | Rolling deploy one node at a time, per-node engine verified against `chaindata` before extraction (`.sst`/`.ldb`) and tarball md5 checked. Stops 1–7s; every node passed a block-progression gate before the next was touched; head stayed in lockstep across the fleet throughout; **sealer rotation even afterwards** (30-block sample 11/6/13, independent 20-block sample 6/8/6) — block production never paused |
+
+### 4.2 Live 254KB deployment on the official testnet (#64 acceptance)
+
+Executed against the deployed fleet (api01 for submission, bp2 and bp3 for
+propagation), on the final binary, with a freshly funded account:
+
+- 262,246-byte creation tx **rejected**: `oversized data: transaction size 256.10 KiB, limit 262144`
+- 254,054-byte max-code creation tx **accepted**, then observed `pending` in **both** sealers' pools (propagation, not block-relay)
+- **mined in block 90,079,900, status 1, gasUsed 52,045,896** against the live block gas limit **105,000,000**
+- deployed code reads back at exactly **253,952 bytes** (independently re-queried on api01)
+
+This closes the one verification the release had outstanding: the 256KB ceiling
+now has a production-network measurement, not only private-net evidence.
+
+The published m1.1.1 assets are rebuilt from the master tip after the
+promotion merges; that binary carries the same tree as `e6a9f31ce`.
 
 ## 5. Final-tree re-verification (`a8d626726`)
 
@@ -142,11 +170,25 @@ for future re-runs (they are measurement artifacts, not binary defects):
    pass in the pre-governance phase, which is how §2 and this section ran
    them.
 
-## 6. Verdict
+## 6. Outstanding at time of writing
+
+One axis is still running rather than complete: the **fresh full sync of the
+testnet through its historical Camellia boundary** (block 86,449,000) on the
+release binary. The instance is progressing from genesis and will need about
+ten more days to reach that height, so it is tracked as a soak observation
+rather than a release gate. Two independent results already cover the same
+behavior: the phase-2 binary completed exactly this sync (genesis → fork →
+tip, fork-block hash matching canonical, zero BAD BLOCKs) on 2026-06-23, and
+the final tree crosses an activation boundary cleanly on every private-net run
+in §5. Should the soak surface anything, it lands well before the mainnet
+rolling upgrade.
+
+## 7. Verdict
 
 Every axis of the April report passes on the release binary, and the new
 axes (256KB ceiling, TRS enforcement, fee-payer eviction, governance
 rotation, mixed-version divergence, blobpool finality) pass as well. The one
 code change this round of testing produced is PR #77 — and §5 re-verifies
-the complete matrix on the exact tree being promoted to master. Everything
-else verified clean.
+the complete matrix on the exact tree being promoted to master, while §4.1–4.2
+show that tree running on every node we operate, including a live 254KB
+deployment on the official testnet. Everything else verified clean.

--- a/docs/camellia-test-report-m1.1.1.md
+++ b/docs/camellia-test-report-m1.1.1.md
@@ -1,0 +1,106 @@
+# Camellia Fork Test Report — m1.1.1 Release Verification
+
+**Date:** 2026-08-11 ~ 2026-08-12
+**Binary under test:** `a91d1b323` (master tip, m1.1.1) and `21c1997e6` (PR #77 candidate = `a91d1b323` + blobpool PoA finality fix)
+**Author:** Jeffrey Song
+
+This report re-validates every functional axis of the original Camellia test
+report (`camellia-test-report.md`, 2026-04-08) against the release-line
+binary, and extends coverage to axes the original did not have: the restored
+256KB txpool ceiling (#64), pool-side TRS enforcement (#67), fee-delegation
+eviction (#67), governance-driven multi-BP rotation, mixed-version fork
+divergence, and the blobpool PoA finality fix (#76/#77).
+
+## 1. Environments
+
+| Environment | Purpose |
+|---|---|
+| 3-node PoA private net (Docker, chainId 1337, Camellia @ block 100, genesis gasLimit pinned to the production 105,000,000) | All functional suites |
+| 2-node mixed-version net (release binary + production `0.10.2-stable/ce4a95e93`) | Fork-boundary divergence |
+| Production followers (46/47/mykeepin, 5 services) + official testnet 5 nodes | Live deployment, soak, lockstep |
+| Fresh full syncs: testnet (embedded genesis) and mainnet (embedded genesis) | #68 embedded-genesis validation, in progress at time of writing |
+
+## 2. Regression Suites (all on the #77 candidate binary)
+
+| Suite | Result |
+|---|---|
+| `camellia-test.sh` (EIP transitions, block 99 vs 100) | **PASS 14 / FAIL 0 / SKIP 3** (skips environmental, unchanged from v1) |
+| `camellia-contract-e2e` (solc 0.8.28 cancun: PUSH0/MCOPY/TSTORE) | ALL PASS |
+| `blob-tx-e2e` (EIP-4844 lifecycle + sidecar) | ALL PASS |
+| `mixed-tx-e2e` (Type 2 + Type 22 + Type 3 in one flow) | ALL PASS |
+| `rpc-test-full.sh` (Execution API surface) | **64 PASS / 0 FAIL / 0 WARN / 3 SKIP** |
+| `bigtx-e2e` (new, see §3) | ALL PASS |
+
+## 3. New Coverage
+
+### 3.1 256KB txpool ceiling (`tests/private-net-poa/bigtx-e2e`, #64)
+- 262,248-byte tx rejected: `oversized data: 256.10 KiB, limit 262144`
+- 254,056-byte max-code deployment admitted, **propagated to peer pools
+  pre-mining** (pending=true observed on both non-miner nodes), mined with
+  status 1; deployed code reads back at exactly 253,952 bytes
+- gasUsed **52,045,896** against the production block gas limit
+  **105,000,000** — roughly 2x headroom
+
+### 3.2 Fee-delegation eviction (`tests/private-net-poa/feepayer-evict-e2e`, #67)
+A queued Type-22 tx whose fee payer is drained to zero after admission is
+evicted by the promote/demote sweep within seconds. 3/3 PASS.
+
+### 3.3 Governance Phase 2 — multi-BP rotation
+`deploy.sh` on a fresh chain: Registry at the deployer's nonce-0 CREATE
+address, etcd initialized first attempt, node2/node3 registered, and all
+three sealers observed rotating block production (15-block sample: 3/7/5).
+
+> Operational note learned the hard way: registry discovery scans the genesis
+> coinbase's CREATE addresses for nonces 0–9, so governance must be deployed
+> before that account sends other transactions.
+
+### 3.4 TRS pool-side enforcement (#67)
+- `addToTRSList(victim)` alone does **not** activate enforcement — a node
+  enforces only after its governance address calls `TRSList.subscribe()`
+  (per-node opt-in, matching 0.10.x semantics)
+- Once subscribed: transactions **from** and **to** the restricted address
+  are both rejected at admission with `included in the TRSList`
+- Follow-up for the mainnet runbook: verify BP subscription state after the
+  rolling upgrade; an unsubscribed node silently skips enforcement
+
+### 3.5 Sync-mode policy (docs/#69 claim, verified on the binary)
+`--syncmode snap` and `--syncmode light` fail fast with the documented
+full-only message; `fast` is rejected by the flag parser.
+
+### 3.6 Mixed-version fork divergence (production 0.10.2 binary)
+A real `0.10.2-stable/ce4a95e93` node (taken from the mainnet fleet) peered
+with a release-binary miner on a fresh Camellia@100 chain:
+- pre-fork: peers and syncs normally (0 → 99)
+- at activation: imports **exactly through block 99 and stops** — no crash,
+  no BAD BLOCK; peer count drops to 0 (fork-id divergence) and the node
+  idles logging `Looking for peers`
+This is the expected behavior for any operator who has not upgraded when
+mainnet reaches 117,764,000.
+
+### 3.7 Blobpool PoA finality (#76 → #77)
+Before the fix, every Camellia-active node logged `Nil finalized block cannot
+evict old blobs` once per block (live on testnet after the 1.1.1 rollout;
+7,189 lines in one follower's log) and included blob sidecars never left the
+limbo store. With the #77 candidate binary: zero occurrences across all three
+nodes (including with pre-existing limbo entries on disk), fresh blob e2e
+unaffected, and 64-plus blocks of post-eviction silence.
+
+## 4. Live Deployments (a91d1b323)
+
+| Fleet | Result |
+|---|---|
+| Followers: 46 (LevelDB), 47 (RocksDB), mykeepin (archive) — 5 services | Graceful swaps 0–7s, fork banners correct, lockstep with official networks, zero errors over soak |
+| Official testnet: bp1/bp2/bp3/api01/exp01 | Rolling deploy, one node at a time; etcd leader handoff observed (`moving leader to meta1`); sealer rotation intact; block production uninterrupted |
+
+Fresh full syncs from embedded genesis (the #68 path) reproduce the official
+genesis hashes on both networks (testnet `0x10c1b0a5…`, mainnet
+`0xf1b2a543…`) and are progressing past the historical trouble spots at the
+time of writing.
+
+## 5. Verdict
+
+Every axis of the April report passes on the release binary, and the new
+axes (256KB ceiling, TRS enforcement, fee-payer eviction, governance
+rotation, mixed-version divergence, blobpool finality) pass as well. The one
+code change this round of testing produced is PR #77; everything else
+verified clean.

--- a/docs/camellia-test-report.md
+++ b/docs/camellia-test-report.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-08
 **Branch:** `dev`
 **Version:** 1.0.0-stable
-**Author:** Jeffrey Song (AI-assisted with Claude Opus 4.6)
+**Author:** Jeffrey Song
 
 ---
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -265,5 +265,5 @@ var (
 	BlockMinBuildTime    int64  = 300     // Minimum block generation time in ms
 	BlockMinBuildTxs     int64  = 2500    // Minimum txs in a block with pending txs
 	BlockTrailTime       int64  = 300     // Time to leave for block data transfer transfer in ms
-	BlobRetentionBlocks  uint64 = 1572480 // Number of blocks to keep blob sidecars (~18.2 days at 1s blocks; 0 = forever)
+	BlobRetentionBlocks  uint64 = 1572480 // Number of blocks to keep blob sidecars (~36.4 days at Metadium's 2s block interval; 0 = forever)
 )

--- a/tests/private-net-poa/bigtx-e2e/main.go
+++ b/tests/private-net-poa/bigtx-e2e/main.go
@@ -1,0 +1,188 @@
+// bigtx-e2e: verifies the restored 256KB txpool ceiling end-to-end on a live
+// PoA network mirroring production block gas limit (105M).
+//
+//  1. NEGATIVE: a creation tx whose RLP size exceeds params.MaxTransactionSize
+//     (262,144) must be rejected by the pool with "oversized data".
+//  2. POSITIVE: a creation tx depositing a max-size contract
+//     (params.MaxCodeSize = 253,952 runtime bytes, ~254KB tx) must be
+//     accepted, propagated to the other nodes' pools, mined with status 1,
+//     and the deployed code must read back at exactly 253,952 bytes.
+//
+// Usage: go run . [rpc1] [rpc2] [rpc3]   (defaults: localhost:8545/8546/8547)
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const hardhatKey0 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+func die(format string, a ...any) {
+	fmt.Printf("FAIL: "+format+"\n", a...)
+	os.Exit(1)
+}
+
+// initcodeFor returns initcode that deposits `runtimeLen` bytes of runtime
+// code: 13-byte CODECOPY prologue followed by the payload.
+func initcodeFor(runtimeLen int) []byte {
+	if runtimeLen > 0xFFFFFF {
+		panic("runtimeLen too large for PUSH3")
+	}
+	pro := []byte{
+		0x62, byte(runtimeLen >> 16), byte(runtimeLen >> 8), byte(runtimeLen), // PUSH3 len
+		0x80,       // DUP1
+		0x60, 0x0d, // PUSH1 13 (payload offset)
+		0x60, 0x00, // PUSH1 0  (mem dest)
+		0x39,       // CODECOPY
+		0x60, 0x00, // PUSH1 0
+		0xf3, // RETURN
+	}
+	return append(pro, make([]byte, runtimeLen)...)
+}
+
+func signedCreation(key *ecdsa.PrivateKey, chainID *big.Int, nonce uint64, gasPrice *big.Int, gas uint64, initcode []byte) *types.Transaction {
+	tx := types.NewContractCreation(nonce, big.NewInt(0), gas, gasPrice, initcode)
+	signed, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	if err != nil {
+		die("sign: %v", err)
+	}
+	return signed
+}
+
+func main() {
+	urls := []string{"http://localhost:8545", "http://localhost:8546", "http://localhost:8547"}
+	for i, a := range os.Args[1:] {
+		if i < 3 {
+			urls[i] = a
+		}
+	}
+	ctx := context.Background()
+
+	key, err := crypto.HexToECDSA(hardhatKey0)
+	if err != nil {
+		die("key: %v", err)
+	}
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	var clients []*ethclient.Client
+	for _, u := range urls {
+		c, err := ethclient.Dial(u)
+		if err != nil {
+			die("dial %s: %v", u, err)
+		}
+		clients = append(clients, c)
+	}
+	c1 := clients[0]
+
+	chainID, err := c1.ChainID(ctx)
+	if err != nil {
+		die("chainID: %v", err)
+	}
+	head, err := c1.HeaderByNumber(ctx, nil)
+	if err != nil {
+		die("head: %v", err)
+	}
+	bal, _ := c1.BalanceAt(ctx, from, nil)
+	gasPrice, err := c1.SuggestGasPrice(ctx)
+	if err != nil {
+		die("gasPrice: %v", err)
+	}
+	fmt.Printf("chainID=%v head=%v gasLimit=%d camellia@100 sender=%s balance=%s gasPrice=%s\n",
+		chainID, head.Number, head.GasLimit, from.Hex(), bal.String(), gasPrice.String())
+	fmt.Printf("params: MaxCodeSize=%d MaxTransactionSize=%d\n", params.MaxCodeSize, params.MaxTransactionSize)
+
+	nonce, err := c1.PendingNonceAt(ctx, from)
+	if err != nil {
+		die("nonce: %v", err)
+	}
+
+	// ---- 1. NEGATIVE: tx RLP > 262,144 must be rejected ----
+	over := signedCreation(key, chainID, nonce, gasPrice, 60_000_000, initcodeFor(params.MaxTransactionSize))
+	oRaw, _ := rlp.EncodeToBytes(over)
+	err = c1.SendTransaction(ctx, over)
+	if err == nil {
+		die("oversized tx (%d bytes RLP) was ACCEPTED — ceiling not enforced", len(oRaw))
+	}
+	if !strings.Contains(err.Error(), "oversized") {
+		die("oversized tx rejected with unexpected error: %v", err)
+	}
+	fmt.Printf("PASS 1/4: oversized tx (RLP %d > %d) rejected: %v\n", len(oRaw), params.MaxTransactionSize, err)
+
+	// ---- 2. POSITIVE: max-size contract deployment ----
+	initcode := initcodeFor(params.MaxCodeSize)
+	big1 := signedCreation(key, chainID, nonce, gasPrice, 60_000_000, initcode)
+	bRaw, _ := rlp.EncodeToBytes(big1)
+	if len(bRaw) <= 131072 {
+		die("test tx unexpectedly small (%d bytes) — not exercising the 128KB regression", len(bRaw))
+	}
+	if len(bRaw) > params.MaxTransactionSize {
+		die("test tx too big (%d bytes) — constructor overhead math wrong", len(bRaw))
+	}
+	if err := c1.SendTransaction(ctx, big1); err != nil {
+		die("max-size deployment tx (RLP %d bytes) rejected by pool: %v", len(bRaw), err)
+	}
+	fmt.Printf("PASS 2/4: %d-byte tx (>128KB legacy limit, <=256KB) accepted by node1 pool, hash=%s\n", len(bRaw), big1.Hash().Hex())
+
+	// ---- 3. PROPAGATION: other nodes must see the tx ----
+	seen := map[int]bool{}
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) && (!seen[1] || !seen[2]) {
+		for i := 1; i <= 2; i++ {
+			if seen[i] {
+				continue
+			}
+			if _, pending, err := clients[i].TransactionByHash(ctx, big1.Hash()); err == nil {
+				seen[i] = true
+				fmt.Printf("PASS 3/4: tx visible on node%d (pending=%v)\n", i+1, pending)
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if !seen[1] || !seen[2] {
+		die("tx did not propagate to all nodes within 60s (node2=%v node3=%v)", seen[1], seen[2])
+	}
+
+	// ---- 4. INCLUSION + code readback ----
+	var rcpt *types.Receipt
+	deadline = time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		rcpt, err = c1.TransactionReceipt(ctx, big1.Hash())
+		if err == nil {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if rcpt == nil {
+		die("tx not mined within 120s")
+	}
+	if rcpt.Status != 1 {
+		die("tx mined but reverted (status=0), gasUsed=%d", rcpt.GasUsed)
+	}
+	blk, err := c1.BlockByNumber(ctx, rcpt.BlockNumber)
+	if err != nil {
+		die("block: %v", err)
+	}
+	code, err := c1.CodeAt(ctx, rcpt.ContractAddress, nil)
+	if err != nil {
+		die("codeAt: %v", err)
+	}
+	if len(code) != params.MaxCodeSize {
+		die("deployed code %d bytes, want %d", len(code), params.MaxCodeSize)
+	}
+	fmt.Printf("PASS 4/4: mined in block %v (status=1) gasUsed=%d blockGasLimit=%d — deployed code %d bytes at %s\n",
+		rcpt.BlockNumber, rcpt.GasUsed, blk.GasLimit(), len(code), rcpt.ContractAddress.Hex())
+	fmt.Printf("ALL PASS — 256KB pool ceiling verified end-to-end (accept, propagate, include, %d-byte code deposit under %d gas limit)\n",
+		len(code), blk.GasLimit())
+}

--- a/tests/private-net-poa/feepayer-evict-e2e/main.go
+++ b/tests/private-net-poa/feepayer-evict-e2e/main.go
@@ -1,0 +1,135 @@
+// feepayer-evict-e2e: verifies the #67 sweep evicts a pooled fee-delegated tx
+// whose fee payer has been drained after admission.
+//
+// Sequence: fund a fresh fee payer -> admit a type-22 tx with a nonce gap (so
+// it parks in the queue instead of mining) -> drain the fee payer to zero ->
+// the promote/demote sweep must drop the delegated tx within a few blocks.
+//
+// Usage: go run . [rpc-url]   (default http://localhost:8545)
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+const senderKeyHex = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+func die(f string, a ...any) { fmt.Printf("FAIL: "+f+"\n", a...); os.Exit(1) }
+
+func waitMined(ctx context.Context, c *ethclient.Client, h common.Hash, secs int) *types.Receipt {
+	for i := 0; i < secs; i++ {
+		if r, err := c.TransactionReceipt(ctx, h); err == nil {
+			return r
+		}
+		time.Sleep(time.Second)
+	}
+	die("tx %s not mined in %ds", h.Hex(), secs)
+	return nil
+}
+
+func main() {
+	url := "http://localhost:8545"
+	if len(os.Args) > 1 {
+		url = os.Args[1]
+	}
+	ctx := context.Background()
+	c, err := ethclient.Dial(url)
+	if err != nil {
+		die("dial: %v", err)
+	}
+	chainID, _ := c.ChainID(ctx)
+	sender, _ := crypto.HexToECDSA(senderKeyHex)
+	senderAddr := crypto.PubkeyToAddress(sender.PublicKey)
+
+	// Fresh fee payer, funded just enough to pass admission.
+	fpKey, _ := crypto.GenerateKey()
+	fpAddr := crypto.PubkeyToAddress(fpKey.PublicKey)
+	gasPrice, _ := c.SuggestGasPrice(ctx)
+	fund := new(big.Int).Mul(gasPrice, big.NewInt(200_000)) // covers delegated tx cost cap + drain tx
+
+	nonce, _ := c.PendingNonceAt(ctx, senderAddr)
+	fundTx, _ := types.SignTx(types.NewTransaction(nonce, fpAddr, fund, 21000, gasPrice, nil),
+		types.LatestSignerForChainID(chainID), sender)
+	if err := c.SendTransaction(ctx, fundTx); err != nil {
+		die("fund feePayer: %v", err)
+	}
+	waitMined(ctx, c, fundTx.Hash(), 30)
+	fmt.Printf("funded feePayer %s with %s wei\n", fpAddr.Hex(), fund)
+
+	// Type-22 delegated tx with a nonce GAP (pending+1) so it parks queued.
+	nonce, _ = c.PendingNonceAt(ctx, senderAddr)
+	gapNonce := nonce + 1
+	tip := big.NewInt(1_000_000_000)
+	inner := &types.DynamicFeeTx{
+		ChainID: chainID, Nonce: gapNonce, GasTipCap: tip, GasFeeCap: gasPrice,
+		Gas: 21000, To: &senderAddr, Value: big.NewInt(0),
+	}
+	senderSigned, err := types.SignTx(types.NewTx(inner), types.NewLondonSigner(chainID), sender)
+	if err != nil {
+		die("sender sign: %v", err)
+	}
+	v, r, s := senderSigned.RawSignatureValues()
+	fd := &types.FeeDelegateDynamicFeeTx{
+		SenderTx: types.DynamicFeeTx{
+			ChainID: chainID, Nonce: gapNonce, GasTipCap: tip, GasFeeCap: gasPrice,
+			Gas: 21000, To: &senderAddr, Value: big.NewInt(0),
+			V: v, R: r, S: s,
+		},
+		FeePayer: &fpAddr,
+		FV:       new(big.Int), FR: new(big.Int), FS: new(big.Int),
+	}
+	fdTx, err := types.SignTx(types.NewTx(fd), types.NewFeeDelegateSigner(chainID), fpKey)
+	if err != nil {
+		die("feePayer sign: %v", err)
+	}
+	if err := c.SendTransaction(ctx, fdTx); err != nil {
+		die("delegated tx rejected at admission (feePayer funded, should be accepted): %v", err)
+	}
+	fmt.Printf("PASS 1/3: delegated tx admitted (queued, nonce gap) hash=%s\n", fdTx.Hash().Hex())
+
+	if _, pending, err := c.TransactionByHash(ctx, fdTx.Hash()); err != nil || !pending {
+		die("delegated tx not visible in pool after admission (err=%v pending=%v)", err, pending)
+	}
+
+	// Drain the fee payer to zero.
+	fpBal, _ := c.BalanceAt(ctx, fpAddr, nil)
+	drainGas := new(big.Int).Mul(gasPrice, big.NewInt(21000))
+	drainVal := new(big.Int).Sub(fpBal, drainGas)
+	if drainVal.Sign() <= 0 {
+		die("feePayer balance too small to drain: %s", fpBal)
+	}
+	fpNonce, _ := c.PendingNonceAt(ctx, fpAddr)
+	drainTx, _ := types.SignTx(types.NewTransaction(fpNonce, senderAddr, drainVal, 21000, gasPrice, nil),
+		types.LatestSignerForChainID(chainID), fpKey)
+	if err := c.SendTransaction(ctx, drainTx); err != nil {
+		die("drain tx: %v", err)
+	}
+	waitMined(ctx, c, drainTx.Hash(), 30)
+	fpBal, _ = c.BalanceAt(ctx, fpAddr, nil)
+	fmt.Printf("PASS 2/3: feePayer drained (balance now %s wei)\n", fpBal)
+
+	// The sweep should now drop the queued delegated tx within a few blocks.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		_, _, err := c.TransactionByHash(ctx, fdTx.Hash())
+		if err == ethereum.NotFound {
+			fmt.Println("PASS 3/3: drained-feePayer delegated tx evicted from the pool")
+			fmt.Println("ALL PASS")
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	fmt.Println("RESULT: tx still pooled after 60s — eviction did not trigger on reset sweep " +
+		"(document whether it defers to the 3h ticker; not an automatic FAIL, but needs a ruling)")
+	os.Exit(2)
+}


### PR DESCRIPTION
**base**: `master` (`a91d1b323`) / **head**: `dev` (`a8d626726` = #77 merge commit)
**Merge method**: Create a merge commit (MetadiumRelease), same as #58.

---

## Why the release line is being re-opened

Owner decision (recorded on #77): the blobpool PoA-finality fix ships **in 1.1.1**, before Camellia activates on mainnet at block 117,764,000 (~2026-08-27 12:00 KST). Without it, every Camellia-active node logs `Nil finalized` during finality-fallback failure windows and the blobpool limbo never drains under PoA. The re-promotion cost (cp-khs's 4-for-4 base rate) was weighed and accepted with eyes open — see the decision comment on #77.

## Delta over `master` (`a91d1b323`)

| PR | Head | Scope | Review record |
|---|---|---|---|
| #77 | `c0b396bd3` | `core/txpool/blobpool` — PoA finality surrogate (`limbo_metadium.go`), head−64 fallback only when chain-level finality is unavailable; non-PoA paths bit-identical. +3 guard tests incl. `TestLimboSurrogateEndToEnd` | trident90 **APPROVED** (r2, c0b396bd3), cp-khs approve per owner "say so" |
| #78 | `b0ca807fe` | tests/docs only — feepayer-evict e2e + `docs/camellia-test-report-m1.1.1.md` | merged to dev on maintainer's call (review requests withdrawn) |
| #79 | `1417b09fd` | docs only — attribution scrub in test report | same |

No consensus, p2p, or config changes beyond #77's blobpool scope. Fork blocks unchanged (mainnet 117,764,000 / testnet 86,449,000). Version stays **1.1.1** (pre-publish; per precedent no re-bump needed).

## Verification

- #77 fix verified on the 3-node private net: per-block ERROR 1/block → 0 across all nodes, blob e2e PASS, no eviction failures after 64+ blocks.
- Fleet measurements (recorded on #77): `finalized`/`safe` tags return real blocks on testnet + mainnet follower; `TRS list refresh failed` grep = 0; 46 testnet full-log recount confirms the 7,189 `Nil finalized` lines are confined to 2026-05-20 → 05-29 (transient windows, not ongoing).
- Full blobpool + txpool suites green on the branch; CI green expected on this PR before merge.

## Post-merge chain (for the record)

1. Rebuild both tarballs + standalone binaries from the **new master tip** on cicd (`CFLAGS/CXXFLAGS=-Wno-error=unused-parameter`).
2. Replace draft m1.1.1 assets; update release-note commit hash + md5 table (binding).
3. Redeploy 10 services (5 in-house + 5 official testnet via systemctl), full test suite re-run, testnet 254KB e2e.
4. Publish m1.1.1 → exchange notice 2026-08-13 (D-14).
