### PR TITLE
docs: fleet deployment + live 254KB testnet result for the m1.1.1 report

### DIFF
--- a/docs/camellia-test-report-m1.1.1.md
+++ b/docs/camellia-test-report-m1.1.1.md
@@ -1,7 +1,7 @@
 # Camellia Fork Test Report — m1.1.1 Release Verification
 
 **Date:** 2026-08-11 ~ 2026-08-12
-**Binary under test:** `a91d1b323` (master tip, m1.1.1), `21c1997e6` (PR #77 candidate), and `a8d626726` (final release tree = dev tip after the #77 merge; see §5)
+**Binary under test:** `a91d1b323` (master tip, m1.1.1), `21c1997e6` (PR #77 candidate), `a8d626726` (final release tree after the #77 merge; see §5), and `e6a9f31ce` (that tree plus this report — the binary deployed fleet-wide in §4.1)
 **Author:** Jeffrey Song
 
 This report re-validates every functional axis of the original Camellia test
@@ -97,8 +97,36 @@ genesis hashes on both networks (testnet `0x10c1b0a5…`, mainnet
 `0xf1b2a543…`) and are progressing past the historical trouble spots at the
 time of writing.
 
-The fleet moves to the final tree (§5) with the m1.1.1 asset rebuild that
-follows the dev→master promotion.
+### 4.1 Final-tree deployment (`e6a9f31ce`)
+
+Before the promotion was merged, the final tree was deployed to **every node we
+operate** and verified in place. All twelve instances report
+`1.1.1-stable-e6a9f31c`:
+
+| Target | Result |
+|---|---|
+| 46 — mainnet + testnet services (LevelDB) | Graceful restarts 5s / 6s; fork banners correct (#117764000 / #86449000); static peers re-attached (3 / 5); zero errors |
+| 47 — mainnet service (RocksDB) | Restart 4s, peers 3, head advancing, zero errors |
+| 47 — testnet service (RocksDB) | Restart after abandoning a long-running `debug_setHead` experiment: stop 301s, resumed cleanly at the rewound head (89,826,500) with no deeper state rollback, then re-aligned its header chain |
+| 183 — archive (LevelDB) | Restart 1s, `debug_traceBlockByNumber` serving, head advancing |
+| Fresh-sync instances (testnet + mainnet, embedded genesis) | Restarted onto the final binary, peers re-attached, syncing continues |
+| **Official testnet: api01, exp01, bp2, bp1, bp3** | Rolling deploy one node at a time, per-node engine verified against `chaindata` before extraction (`.sst`/`.ldb`) and tarball md5 checked. Stops 1–7s; every node passed a block-progression gate before the next was touched; head stayed in lockstep across the fleet throughout; **sealer rotation even afterwards** (30-block sample 11/6/13, independent 20-block sample 6/8/6) — block production never paused |
+
+### 4.2 Live 254KB deployment on the official testnet (#64 acceptance)
+
+Executed against the deployed fleet (api01 for submission, bp2 and bp3 for
+propagation), on the final binary, with a freshly funded account:
+
+- 262,246-byte creation tx **rejected**: `oversized data: transaction size 256.10 KiB, limit 262144`
+- 254,054-byte max-code creation tx **accepted**, then observed `pending` in **both** sealers' pools (propagation, not block-relay)
+- **mined in block 90,079,900, status 1, gasUsed 52,045,896** against the live block gas limit **105,000,000**
+- deployed code reads back at exactly **253,952 bytes** (independently re-queried on api01)
+
+This closes the one verification the release had outstanding: the 256KB ceiling
+now has a production-network measurement, not only private-net evidence.
+
+The published m1.1.1 assets are rebuilt from the master tip after the
+promotion merges; that binary carries the same tree as `e6a9f31ce`.
 
 ## 5. Final-tree re-verification (`a8d626726`)
 
@@ -142,11 +170,25 @@ for future re-runs (they are measurement artifacts, not binary defects):
    pass in the pre-governance phase, which is how §2 and this section ran
    them.
 
-## 6. Verdict
+## 6. Outstanding at time of writing
+
+One axis is still running rather than complete: the **fresh full sync of the
+testnet through its historical Camellia boundary** (block 86,449,000) on the
+release binary. The instance is progressing from genesis and will need about
+ten more days to reach that height, so it is tracked as a soak observation
+rather than a release gate. Two independent results already cover the same
+behavior: the phase-2 binary completed exactly this sync (genesis → fork →
+tip, fork-block hash matching canonical, zero BAD BLOCKs) on 2026-06-23, and
+the final tree crosses an activation boundary cleanly on every private-net run
+in §5. Should the soak surface anything, it lands well before the mainnet
+rolling upgrade.
+
+## 7. Verdict
 
 Every axis of the April report passes on the release binary, and the new
 axes (256KB ceiling, TRS enforcement, fee-payer eviction, governance
 rotation, mixed-version divergence, blobpool finality) pass as well. The one
 code change this round of testing produced is PR #77 — and §5 re-verifies
-the complete matrix on the exact tree being promoted to master. Everything
-else verified clean.
+the complete matrix on the exact tree being promoted to master, while §4.1–4.2
+show that tree running on every node we operate, including a live 254KB
+deployment on the official testnet. Everything else verified clean.


### PR DESCRIPTION
Docs-only, final piece before the #80 promotion merges.

- **§4.1** — the final tree (`e6a9f31ce`) deployed to all twelve instances we operate, including the official testnet rolled one node at a time with per-node engine verification against `chaindata`, tarball md5 checks, and a block-progression gate between nodes. Head stayed in lockstep and sealer rotation is even afterwards (30-block sample 11/6/13, independent 20-block sample 6/8/6).
- **§4.2** — the **254KB deployment measured on the official testnet**, which is the verification @cp-khs asked for in #64: 262,246-byte tx rejected as oversized, 254,054-byte max-code tx accepted and observed `pending` in both sealers' pools, mined in block 90,079,900 with status 1 and gasUsed **52,045,896** against the live **105,000,000** limit, deployed code reading back at exactly 253,952 bytes.
- **§6** — the one axis still running (fresh testnet sync through the historical Camellia boundary, ~10 more days) recorded as a soak observation, with the 2026-06-23 phase-2 completion and the private-net boundary crossings that cover it.

No code touched.