### PR TITLE
build: produce release artifacts that run on the whole fleet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fo
 - Backend: Go 1.21+
 - DB: LevelDB (default) / RocksDB (`-tags rocksdb`)
 - Consensus: Metadium PoA (ethash placeholder, custom sealing)
-- Version: 1.1.1-stable
+- Version: 1.1.2-stable
 
 ## Directory Structure
 - `cmd/geth/` -- main binary entrypoint
@@ -24,6 +24,10 @@ Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fo
 - `docs/` -- Camellia fork documentation and test reports
 
 ## Build
+Development only -- these link against the host and produce **non-portable**
+binaries. Anything published or deployed goes through `make gmet-linux`, which
+builds in the release container and runs `make release-check`. See README
+"Release artifacts".
 - LevelDB: `CGO_ENABLED=0 go build -o gmet ./cmd/geth`
 - RocksDB: `CGO_ENABLED=1 CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd" go build -tags rocksdb -o gmet ./cmd/geth`
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,11 @@
 # Dockerfile.build - Build Linux binaries (rocksdb + leveldb variants)
+#
+# ⚠ DEVELOPMENT ONLY — NOT FOR RELEASE ARTIFACTS.
+# This image is noble (glibc 2.39) and links the shared libstdc++, so what it
+# produces requires GLIBC_2.38 and does not start on the 20.04/22.04 nodes in
+# the fleet. That is the exact defect that made the m1.1.1 assets unusable.
+# Release artifacts are built with `make gmet-linux` (Dockerfile.metadium),
+# which pins the fleet's oldest glibc and is gated by `make release-check`.
 # Usage (local ARM64 Mac → arm64 image):
 #   docker build -f Dockerfile.build --output dist .
 #

--- a/Dockerfile.metadium
+++ b/Dockerfile.metadium
@@ -1,15 +1,29 @@
 # builder image
+#
+# The base image fixes the oldest glibc/libstdc++ the release binaries can run
+# against: a binary built here runs on that release and every newer one, but not
+# the other way round. Ubuntu 20.04 (focal) is the oldest distribution still in
+# the deployment fleet, so release artifacts must be produced from this image
+# rather than from whatever the build host happens to run.
+#
+# focal ships gcc 9 and carries gcc 10 in its archive; neither can build the
+# vendored RocksDB, which uses `using enum` (C++20, implemented from GCC 11).
+# The toolchain PPA provides gcc 11 while keeping focal's glibc 2.31.
 
-FROM ubuntu:noble as base
+FROM ubuntu:focal as base
 
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update -q -y && apt-get upgrade -q -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata software-properties-common
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update -q -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential gcc-11 g++-11 ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git
+
+ENV CC=gcc-11
+ENV CXX=g++-11
 
 # golang
-ARG GO_VERSION=1.22.4
+ARG GO_VERSION=1.22.5
 
 RUN curl -sL -o /tmp/go.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \

--- a/Dockerfile.rocksdb-amd64
+++ b/Dockerfile.rocksdb-amd64
@@ -1,3 +1,8 @@
+# ⚠ DEVELOPMENT ONLY — NOT FOR RELEASE ARTIFACTS.
+# bullseye with a shared libstdc++: the result inherits this image's glibc and
+# GLIBCXX floors rather than the fleet's. Release artifacts are built with
+# `make gmet-linux` (Dockerfile.metadium) and gated by `make release-check`.
+
 FROM golang:1.21-bullseye AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 else
 	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -lstdc++ $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 endif
 	@echo "Done building."
@@ -64,7 +64,7 @@ ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 else
 	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -lstdc++ $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # don't need to bother with make.
 
 .PHONY: geth evm all test test-short lint fmt clean devtools help rocksdb
-.PHONY: gmet gmet-linux metadium logrot dbbench
+.PHONY: gmet gmet-linux metadium logrot dbbench release-check
 
 GOBIN = ./build/bin
 GO ?= latest
@@ -24,9 +24,40 @@ ifneq ($(shell uname), Linux)
   USE_ROCKSDB = NO
 endif
 
+# STATIC_STDCPP
+# - "YES": link libstdc++ from its archive and libgcc statically, so the binary
+#   carries no GLIBCXX/CXXABI requirement and does not inherit the build host's
+#   floor. Release artifacts need this; gmet-linux sets it. Requires the static
+#   libstdc++ (libstdc++-N-dev on Debian/Ubuntu, libstdc++-static on RHEL).
+# - undefined | anything else: link the shared libstdc++, which is what a plain
+#   development box has. -static-libgcc is paired with the static libstdc++ so
+#   the unwinder matches; do not drop one without the other.
+ifeq ($(STATIC_STDCPP), YES)
+STDCPP_LDFLAGS = -l:libstdc++.a -static-libgcc
+else
+STDCPP_LDFLAGS = -lstdc++
+endif
+
+# gmet-linux always compiles inside a Linux container, so the host's uname must
+# not pick the engine for it. Default to RocksDB there and honour USE_ROCKSDB
+# only when it was given explicitly on the command line.
+ifeq ($(origin USE_ROCKSDB), command line)
+GMET_LINUX_USE_ROCKSDB = $(USE_ROCKSDB)
+else
+GMET_LINUX_USE_ROCKSDB = YES
+endif
+
+# Highest glibc symbol version release artifacts may reference. Set by the
+# oldest distribution in the deployment fleet (Ubuntu 20.04 = 2.31).
+MAX_GLIBC ?= 2.31
+
 ifneq ($(USE_ROCKSDB), NO)
 ROCKSDB_DIR=$(shell pwd)/rocksdb
 ROCKSDB_TAG=-tags rocksdb
+# Recursively expanded on purpose: make_config.mk only exists once the rocksdb
+# target has run.
+ROCKSDB_CGO_CFLAGS = -I$(ROCKSDB_DIR)/include
+ROCKSDB_CGO_LDFLAGS = -L$(ROCKSDB_DIR) -lrocksdb -lm $(STDCPP_LDFLAGS) $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)
 endif
 
 metadium: gmet logrot
@@ -44,8 +75,8 @@ gmet: rocksdb metadium/governance_abi.go metadium/governance_legacy_abi.go
 ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 else
-	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+	CGO_CFLAGS="$(ROCKSDB_CGO_CFLAGS)" \
+		CGO_LDFLAGS="$(ROCKSDB_CGO_LDFLAGS)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 endif
 	@echo "Done building."
@@ -63,8 +94,8 @@ dbbench: rocksdb
 ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 else
-	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+	CGO_CFLAGS="$(ROCKSDB_CGO_CFLAGS)" \
+		CGO_LDFLAGS="$(ROCKSDB_CGO_LDFLAGS)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 endif
 
@@ -116,18 +147,46 @@ devtools:
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'
 
 gmet-linux:
-	@docker --version > /dev/null 2>&1;				\
-	if [ ! $$? = 0 ]; then						\
-		echo "Docker not found.";				\
-	else								\
-		docker build -t meta/builder:local			\
-			-f Dockerfile.metadium . &&			\
-		docker run -e HOME=/tmp --rm -v $(shell pwd):/data	\
-			-u $(shell id -u):$(shell id -g)                \
-			-w /data meta/builder:local			\
-			"git config --global --add safe.directory /data;\
-			 make USE_ROCKSDB=$(USE_ROCKSDB)";		\
+	@if ! docker --version > /dev/null 2>&1; then			\
+		echo "Docker not found. gmet-linux is the only supported"	\
+		     "way to build release artifacts; see README." >&2;	\
+		exit 1;							\
 	fi
+	docker build -t meta/builder:local -f Dockerfile.metadium .
+	docker run -e HOME=/tmp --rm -v $(shell pwd):/data		\
+		-u $(shell id -u):$(shell id -g)			\
+		-w /data meta/builder:local				\
+		"git config --global --add safe.directory /data;	\
+		 make USE_ROCKSDB=$(GMET_LINUX_USE_ROCKSDB) STATIC_STDCPP=YES"
+	@$(MAKE) --no-print-directory release-check
+
+# Refuse artifacts that cannot run on the oldest distribution in the fleet.
+# Checks every ELF in $(GOBIN), not just gmet: the bundle also ships logrot,
+# which is built with cgo and carries a glibc floor of its own.
+release-check:
+	@command -v objdump > /dev/null 2>&1 || { echo "release-check: objdump not found" >&2; exit 1; }
+	@fail=0;							\
+	for f in $(GOBIN)/*; do						\
+		[ -f "$$f" ] || continue;				\
+		head -c 4 "$$f" | grep -q 'ELF' || continue;		\
+		glibc=`objdump -T "$$f" 2>/dev/null | sed -n 's/.*GLIBC_\([0-9][0-9.]*\).*/\1/p' | sort -V | tail -1`; \
+		gxx=`objdump -T "$$f" 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+' | sort -V | tail -1`; \
+		cxxabi=`objdump -T "$$f" 2>/dev/null | grep -oE 'CXXABI_[0-9.]+' | sort -V | tail -1`; \
+		echo "  $$f: GLIBC=$${glibc:-none} GLIBCXX=$${gxx:-none} CXXABI=$${cxxabi:-none}"; \
+		if [ -n "$$glibc" ] && [ "`printf '%s\n%s\n' "$$glibc" "$(MAX_GLIBC)" | sort -V | tail -1`" != "$(MAX_GLIBC)" ]; then \
+			echo "    FAIL: needs GLIBC_$$glibc > $(MAX_GLIBC)" >&2; fail=1; \
+		fi;							\
+		if [ -n "$$gxx" ] || [ -n "$$cxxabi" ]; then		\
+			echo "    FAIL: links libstdc++ dynamically (build with STATIC_STDCPP=YES)" >&2; fail=1; \
+		fi;							\
+		objdump -p "$$f" 2>/dev/null | awk '/NEEDED/ {printf "    NEEDED %s\n", $$2}'; \
+	done;								\
+	if [ $$fail != 0 ]; then					\
+		echo "release-check: FAILED — do not publish these artifacts" >&2; \
+		exit 1;							\
+	fi;								\
+	echo "release-check: OK (ceiling GLIBC_$(MAX_GLIBC))"
+	@echo "  NEEDED entries above must be present on target hosts (snappy, lz4, zstd, jemalloc)."
 
 ifneq ($(USE_ROCKSDB), YES)
 rocksdb:

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ before — but review the following **before** restarting on the new binary.
    a graceful shutdown when `STOP_FORCE=0` is set. Automation must check the
    exit code *and* set `STOP_FORCE=0`, sizing its own timeout above
    `STOP_TIMEOUT`. Never `kill -9` a node — RocksDB especially.
-7. **Testnet operators: skip 1.1.0, go straight to the m1.1.1 release
+7. **Testnet operators: skip 1.1.0, go straight to the m1.1.2 release
    build.** The 1.1.0 testnet build carries a chain-config regression that
    rewinds a 0.10.x node to block 5,622,999 (~80M-block resync) on first
    start. The fix landed *after* the version string moved to 1.1.1, so

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Metadium blockchain node implementation, forked from [go-ethereum](https://githu
 
 Metadium is a Proof-of-Authority (PoA) blockchain with on-chain governance. It uses a custom consensus layer built on top of go-ethereum's ethash engine, with block signing via node keys and reward distribution through governance smart contracts.
 
-**Current version:** 1.1.1-stable (Camellia fork)
+**Current version:** 1.1.2-stable (Camellia fork)
 
 ## Camellia Fork
 
@@ -46,8 +46,9 @@ See [docs/camellia-test-report.md](docs/camellia-test-report.md) for full test r
 
 Prerequisites: Go 1.21+, C compiler (for RocksDB builds).
 
-The canonical builds are the Makefile targets — they are what CI validates
-and what the release tarballs ship:
+These are the Makefile targets CI validates. They build against whatever the
+host provides, which is what you want for development — but **not** for
+anything you publish or deploy; see [Release artifacts](#release-artifacts).
 
 ```bash
 make gmet                    # gmet binary (RocksDB; USE_ROCKSDB=NO for LevelDB)
@@ -64,26 +65,34 @@ make gmet-linux                     # RocksDB
 make gmet-linux USE_ROCKSDB=NO      # LevelDB
 ```
 
-`make gmet-linux` builds `Dockerfile.metadium` and compiles inside it. That
-image pins the oldest glibc the artifacts have to run against (Ubuntu 20.04);
-building on the host instead bakes in the host's glibc, and the result will not
-start on any older distribution:
+`make gmet-linux` builds `Dockerfile.metadium` and compiles inside it. Two
+properties come from that image and nothing else guarantees them:
 
-```
-gmet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
-```
+- its base pins the oldest glibc the artifacts have to run against (Ubuntu
+  20.04). Building on the host bakes in the host's glibc instead, and the
+  result does not start anywhere older:
+  `gmet: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found`
+- it sets `STATIC_STDCPP=YES`, which links libstdc++ from its archive so the
+  binary carries no `GLIBCXX`/`CXXABI` requirement either. Host builds keep the
+  shared libstdc++ so a plain development box still links.
 
-Check an artifact before publishing it — neither command should print a version
-newer than the oldest distribution you support, and the second should print
-nothing at all:
+`gmet-linux` runs `make release-check` on the result and fails the build if an
+artifact would not run on the fleet. Run it standalone against anything you are
+about to publish:
 
 ```bash
-objdump -T build/bin/gmet | grep -oE 'GLIBC_[0-9.]+'                 | sort -Vu | tail -1
-objdump -T build/bin/gmet | grep -oE 'GLIBCXX_[0-9.]+|CXXABI_[0-9.]+' | sort -Vu | tail -1
+make release-check                  # ceiling from MAX_GLIBC (default 2.31)
 ```
 
-Direct `go build` works for development (`./cmd/gmet` and `./cmd/geth` are
-the same entrypoint; the Makefile uses `./cmd/gmet`):
+It covers every ELF in `build/bin` — `logrot` ships in the same bundle and has
+its own glibc floor — and prints each artifact's `NEEDED` list. Those shared
+libraries (snappy, lz4, zstd, jemalloc) must exist on the target host; the
+symbol-version checks passing does not by itself make an artifact runnable on a
+freshly installed machine.
+
+Direct `go build` works for development — **these produce non-portable binaries
+and must not be published** (`./cmd/gmet` and `./cmd/geth` are the same
+entrypoint; the Makefile uses `./cmd/gmet`):
 
 ```bash
 CGO_ENABLED=0 go build -o gmet ./cmd/gmet                    # LevelDB
@@ -196,8 +205,10 @@ before — but review the following **before** restarting on the new binary.
    rewinds a 0.10.x node to block 5,622,999 (~80M-block resync) on first
    start. The fix landed *after* the version string moved to 1.1.1, so
    "reports 1.1.1-stable" does not prove a build is safe — use the official
-   m1.1.1 release asset (its exact commit hash is published in the release
-   notes). Self-builders can check their commit contains the fix with
+   m1.1.2 release asset (its exact commit hash is published in the release
+   notes). **Do not use the m1.1.1 assets**: they were built on Ubuntu 24.04
+   and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04 at all.
+   Self-builders can check their commit contains the fix with
    `git merge-base --is-ancestor e2c0d7413 <your-commit>` (exit 0 = fixed).
    Order matters on the remediation too: run testnet
    nodes with `--metadium-testnet` (or `TESTNET=1` in `.rc`) **only once on

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ make gmet                    # gmet binary (RocksDB; USE_ROCKSDB=NO for LevelDB)
 make metadium                # full deploy bundle: build/metadium.tar.gz (bin/ + conf/)
 ```
 
+### Release artifacts
+
+Artifacts that are published or deployed to nodes **must** be built through the
+container target, never on the build host directly:
+
+```bash
+make gmet-linux                     # RocksDB
+make gmet-linux USE_ROCKSDB=NO      # LevelDB
+```
+
+`make gmet-linux` builds `Dockerfile.metadium` and compiles inside it. That
+image pins the oldest glibc the artifacts have to run against (Ubuntu 20.04);
+building on the host instead bakes in the host's glibc, and the result will not
+start on any older distribution:
+
+```
+gmet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
+```
+
+Check an artifact before publishing it — neither command should print a version
+newer than the oldest distribution you support, and the second should print
+nothing at all:
+
+```bash
+objdump -T build/bin/gmet | grep -oE 'GLIBC_[0-9.]+'                 | sort -Vu | tail -1
+objdump -T build/bin/gmet | grep -oE 'GLIBCXX_[0-9.]+|CXXABI_[0-9.]+' | sort -Vu | tail -1
+```
+
 Direct `go build` works for development (`./cmd/gmet` and `./cmd/geth` are
 the same entrypoint; the Makefile uses `./cmd/gmet`):
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 1        // Minor version component of the current release
-	VersionPatch = 1        // Patch version component of the current release
+	VersionPatch = 2        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 

--- a/scripts/update-node.sh
+++ b/scripts/update-node.sh
@@ -59,6 +59,8 @@ if [[ $USE_ROCKSDB -eq 1 ]]; then
   done
   [[ -n "$ROCKSDB_LIB" ]] || err "librocksdb not found. Run apt install librocksdb-dev and retry."
 
+  # Host build: links this machine's libstdc++/glibc, so the binary is only
+  # guaranteed to run here. Release artifacts come from `make gmet-linux`.
   CGO_CFLAGS="-I/usr/include" \
   CGO_LDFLAGS="-L$ROCKSDB_LIB -lrocksdb -lsnappy -llz4 -lzstd -lm -lstdc++ -ldl" \
   go build -tags rocksdb -o "$BINARY_NAME" ./cmd/gmet


### PR DESCRIPTION
**Build-only change. No consensus, protocol, or node logic is touched** — the diff is `Dockerfile.metadium`, two `CGO_LDFLAGS` strings in `Makefile`, a `VersionPatch` bump, and README text.

## The problem

The published m1.1.1 artifacts only run on Ubuntu 24.04. Both require `GLIBC_2.38`; the RocksDB one additionally requires `GLIBCXX_3.4.32`.

Three mainnet nodes cannot run them at all:

| node | Ubuntu | glibc | engine |
|---|---|---|---|
| api1 | 22.04 | 2.35 | leveldb |
| api2 | 20.04 | 2.31 | rocksdb |
| fn2  | 20.04 | 2.31 | rocksdb |

```
$ ./gmet version
gmet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./gmet)
```

External operators are affected identically — anyone not on 24.04 cannot run the published release. This went unnoticed because all five testnet nodes happen to be on 24.04.

Root cause: the artifacts were built on the release host (Ubuntu 24.04) instead of through `make gmet-linux`, and `Dockerfile.metadium` had itself moved to `ubuntu:noble`. Either alone would have been enough to bake in a host glibc.

## The fix

**`Dockerfile.metadium` builds on focal**, the oldest release in the fleet. A binary built there runs on that release and every newer one; the reverse does not hold.

focal ships gcc 9 and archives gcc 10. Neither can compile the vendored RocksDB:

```
rocksdb/include/rocksdb/db.h:2276
  using enum SizeApproximationFlags;  // Require C++20 support

gcc 9:  error: unrecognized command line option '-std=c++20'; did you mean '-std=c++2a'?
gcc 10: error: expected nested-name-specifier before 'enum'
```

`using enum` is C++20 and is implemented from GCC 11, so the toolchain PPA supplies gcc 11 while focal's glibc 2.31 stays.

**libstdc++ is linked statically.** gcc 11's libstdc++ would otherwise reintroduce the same class of problem at `GLIBCXX_3.4.29`. Note that adding `-static-libstdc++` alone does nothing here — the explicit `-lstdc++` makes the linker resolve against the shared object first. Naming the archive is what drops the requirement:

```
-lrocksdb -lm -lstdc++                          ->  GLIBCXX_3.4.29 required
-lrocksdb -lm -l:libstdc++.a -static-libgcc     ->  no GLIBCXX requirement
```

`GO_VERSION` is pinned to the 1.22.5 the release was built with, and README documents that release artifacts go through `make gmet-linux` plus how to check an artifact before publishing it.

## Verification

`ebaeca7f4` rebuilt in the new image, then run on the nodes that reject the published artifacts:

| artifact | max GLIBC | GLIBCXX | run |
|---|---|---|---|
| rocksdb | 2.30 | none | fn2 (20.04) — OK |
| leveldb | 2.17 | none | api1 (22.04) — OK |

Both report `Git Commit ebaeca7f4` and `go1.22.5`, so this changes how the release is built, not what it contains.

Side-by-side on api1:

```
[this build]        Gmet  Version: 1.1.1-stable  Git Commit: ebaeca7f4...
[published m1.1.1]  gmet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

### Canary on a live mainnet node

fn2 (non-sealer, non-etcd, oldest binary in the fleet at 0.10.0) was upgraded in place with the rebuilt artifact. All six GO/NO-GO checks passed:

- graceful stop in 6s, no SIGKILL; total stop→swap→start 40s
- `Geth/v1.1.1-stable-ebaeca7f`, peers recovered to 3, `eth_syncing=false`, head advancing
- RocksDB opened normally — 3,946 `.sst` files still in use. Worth recording: the mainnet RocksDB nodes run **without** `--userocksdb`, and that still holds on 1.1.x, so the engine is decided by the build plus the existing chaindata
- no rewind — `Loaded most recent local block number=117,150,778`, no `Head state missing`
- `- Camellia Fork: #117764000` in the startup banner
- zero `BAD BLOCK` / `Fatal` / `invalid merkle root`

One unrelated notice surfaced and is worth flagging for operators upgrading from 0.10.x:

```
ERROR The static-nodes.json file is deprecated and ignored.
      Use P2P.StaticNodes in config.toml instead.
```

fn2 was unaffected (discovery enabled, public IP), but a node that depends on `static-nodes.json` loses those peers silently on 1.1.x.

## Version

`VersionPatch` 1 -> 2. Published artifacts should be immutable, so the corrected build ships as `m1.1.2` rather than replacing m1.1.1's assets; the m1.1.1 release notes can then point at it.

## Reproducing

```bash
git clone --branch fix/portable-release-build https://github.com/jsong1230/go-metadium.git
cd go-metadium && git submodule update --init -- rocksdb
make gmet-linux                     # rocksdb
make gmet-linux USE_ROCKSDB=NO      # leveldb

objdump -T build/bin/gmet | grep -oE 'GLIBC_[0-9.]+'                  | sort -Vu | tail -1
objdump -T build/bin/gmet | grep -oE 'GLIBCXX_[0-9.]+|CXXABI_[0-9.]+' | sort -Vu | tail -1
```

The second command should print nothing.
