### PR TITLE
release: promote dev to master for m1.1.2 (portable release artifacts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fo
 - Backend: Go 1.21+
 - DB: LevelDB (default) / RocksDB (`-tags rocksdb`)
 - Consensus: Metadium PoA (ethash placeholder, custom sealing)
-- Version: 1.1.1-stable
+- Version: 1.1.2-stable
 
 ## Directory Structure
 - `cmd/geth/` -- main binary entrypoint
@@ -24,6 +24,10 @@ Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fo
 - `docs/` -- Camellia fork documentation and test reports
 
 ## Build
+Development only -- these link against the host and produce **non-portable**
+binaries. Anything published or deployed goes through `make gmet-linux`, which
+builds in the release container and runs `make release-check`. See README
+"Release artifacts".
 - LevelDB: `CGO_ENABLED=0 go build -o gmet ./cmd/geth`
 - RocksDB: `CGO_ENABLED=1 CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd" go build -tags rocksdb -o gmet ./cmd/geth`
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,11 @@
 # Dockerfile.build - Build Linux binaries (rocksdb + leveldb variants)
+#
+# ⚠ DEVELOPMENT ONLY — NOT FOR RELEASE ARTIFACTS.
+# This image is noble (glibc 2.39) and links the shared libstdc++, so what it
+# produces requires GLIBC_2.38 and does not start on the 20.04/22.04 nodes in
+# the fleet. That is the exact defect that made the m1.1.1 assets unusable.
+# Release artifacts are built with `make gmet-linux` (Dockerfile.metadium),
+# which pins the fleet's oldest glibc and is gated by `make release-check`.
 # Usage (local ARM64 Mac → arm64 image):
 #   docker build -f Dockerfile.build --output dist .
 #

--- a/Dockerfile.metadium
+++ b/Dockerfile.metadium
@@ -1,15 +1,29 @@
 # builder image
+#
+# The base image fixes the oldest glibc/libstdc++ the release binaries can run
+# against: a binary built here runs on that release and every newer one, but not
+# the other way round. Ubuntu 20.04 (focal) is the oldest distribution still in
+# the deployment fleet, so release artifacts must be produced from this image
+# rather than from whatever the build host happens to run.
+#
+# focal ships gcc 9 and carries gcc 10 in its archive; neither can build the
+# vendored RocksDB, which uses `using enum` (C++20, implemented from GCC 11).
+# The toolchain PPA provides gcc 11 while keeping focal's glibc 2.31.
 
-FROM ubuntu:noble as base
+FROM ubuntu:focal as base
 
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update -q -y && apt-get upgrade -q -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata software-properties-common
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update -q -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential gcc-11 g++-11 ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git
+
+ENV CC=gcc-11
+ENV CXX=g++-11
 
 # golang
-ARG GO_VERSION=1.22.4
+ARG GO_VERSION=1.22.5
 
 RUN curl -sL -o /tmp/go.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \

--- a/Dockerfile.rocksdb-amd64
+++ b/Dockerfile.rocksdb-amd64
@@ -1,3 +1,8 @@
+# ⚠ DEVELOPMENT ONLY — NOT FOR RELEASE ARTIFACTS.
+# bullseye with a shared libstdc++: the result inherits this image's glibc and
+# GLIBCXX floors rather than the fleet's. Release artifacts are built with
+# `make gmet-linux` (Dockerfile.metadium) and gated by `make release-check`.
+
 FROM golang:1.21-bullseye AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 else
 	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -lstdc++ $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 endif
 	@echo "Done building."
@@ -64,7 +64,7 @@ ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 else
 	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -lstdc++ $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # don't need to bother with make.
 
 .PHONY: geth evm all test test-short lint fmt clean devtools help rocksdb
-.PHONY: gmet gmet-linux metadium logrot dbbench
+.PHONY: gmet gmet-linux metadium logrot dbbench release-check
 
 GOBIN = ./build/bin
 GO ?= latest
@@ -24,9 +24,40 @@ ifneq ($(shell uname), Linux)
   USE_ROCKSDB = NO
 endif
 
+# STATIC_STDCPP
+# - "YES": link libstdc++ from its archive and libgcc statically, so the binary
+#   carries no GLIBCXX/CXXABI requirement and does not inherit the build host's
+#   floor. Release artifacts need this; gmet-linux sets it. Requires the static
+#   libstdc++ (libstdc++-N-dev on Debian/Ubuntu, libstdc++-static on RHEL).
+# - undefined | anything else: link the shared libstdc++, which is what a plain
+#   development box has. -static-libgcc is paired with the static libstdc++ so
+#   the unwinder matches; do not drop one without the other.
+ifeq ($(STATIC_STDCPP), YES)
+STDCPP_LDFLAGS = -l:libstdc++.a -static-libgcc
+else
+STDCPP_LDFLAGS = -lstdc++
+endif
+
+# gmet-linux always compiles inside a Linux container, so the host's uname must
+# not pick the engine for it. Default to RocksDB there and honour USE_ROCKSDB
+# only when it was given explicitly on the command line.
+ifeq ($(origin USE_ROCKSDB), command line)
+GMET_LINUX_USE_ROCKSDB = $(USE_ROCKSDB)
+else
+GMET_LINUX_USE_ROCKSDB = YES
+endif
+
+# Highest glibc symbol version release artifacts may reference. Set by the
+# oldest distribution in the deployment fleet (Ubuntu 20.04 = 2.31).
+MAX_GLIBC ?= 2.31
+
 ifneq ($(USE_ROCKSDB), NO)
 ROCKSDB_DIR=$(shell pwd)/rocksdb
 ROCKSDB_TAG=-tags rocksdb
+# Recursively expanded on purpose: make_config.mk only exists once the rocksdb
+# target has run.
+ROCKSDB_CGO_CFLAGS = -I$(ROCKSDB_DIR)/include
+ROCKSDB_CGO_LDFLAGS = -L$(ROCKSDB_DIR) -lrocksdb -lm $(STDCPP_LDFLAGS) $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)
 endif
 
 metadium: gmet logrot
@@ -44,8 +75,8 @@ gmet: rocksdb metadium/governance_abi.go metadium/governance_legacy_abi.go
 ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 else
-	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+	CGO_CFLAGS="$(ROCKSDB_CGO_CFLAGS)" \
+		CGO_LDFLAGS="$(ROCKSDB_CGO_LDFLAGS)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/gmet
 endif
 	@echo "Done building."
@@ -63,8 +94,8 @@ dbbench: rocksdb
 ifeq ($(USE_ROCKSDB), NO)
 	$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 else
-	CGO_CFLAGS=-I$(ROCKSDB_DIR)/include \
-		CGO_LDFLAGS="-L$(ROCKSDB_DIR) -lrocksdb -lm -l:libstdc++.a -static-libgcc $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)" \
+	CGO_CFLAGS="$(ROCKSDB_CGO_CFLAGS)" \
+		CGO_LDFLAGS="$(ROCKSDB_CGO_LDFLAGS)" \
 		$(GORUN) build/ci.go install $(ROCKSDB_TAG) ./cmd/dbbench
 endif
 
@@ -116,18 +147,46 @@ devtools:
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'
 
 gmet-linux:
-	@docker --version > /dev/null 2>&1;				\
-	if [ ! $$? = 0 ]; then						\
-		echo "Docker not found.";				\
-	else								\
-		docker build -t meta/builder:local			\
-			-f Dockerfile.metadium . &&			\
-		docker run -e HOME=/tmp --rm -v $(shell pwd):/data	\
-			-u $(shell id -u):$(shell id -g)                \
-			-w /data meta/builder:local			\
-			"git config --global --add safe.directory /data;\
-			 make USE_ROCKSDB=$(USE_ROCKSDB)";		\
+	@if ! docker --version > /dev/null 2>&1; then			\
+		echo "Docker not found. gmet-linux is the only supported"	\
+		     "way to build release artifacts; see README." >&2;	\
+		exit 1;							\
 	fi
+	docker build -t meta/builder:local -f Dockerfile.metadium .
+	docker run -e HOME=/tmp --rm -v $(shell pwd):/data		\
+		-u $(shell id -u):$(shell id -g)			\
+		-w /data meta/builder:local				\
+		"git config --global --add safe.directory /data;	\
+		 make USE_ROCKSDB=$(GMET_LINUX_USE_ROCKSDB) STATIC_STDCPP=YES"
+	@$(MAKE) --no-print-directory release-check
+
+# Refuse artifacts that cannot run on the oldest distribution in the fleet.
+# Checks every ELF in $(GOBIN), not just gmet: the bundle also ships logrot,
+# which is built with cgo and carries a glibc floor of its own.
+release-check:
+	@command -v objdump > /dev/null 2>&1 || { echo "release-check: objdump not found" >&2; exit 1; }
+	@fail=0;							\
+	for f in $(GOBIN)/*; do						\
+		[ -f "$$f" ] || continue;				\
+		head -c 4 "$$f" | grep -q 'ELF' || continue;		\
+		glibc=`objdump -T "$$f" 2>/dev/null | sed -n 's/.*GLIBC_\([0-9][0-9.]*\).*/\1/p' | sort -V | tail -1`; \
+		gxx=`objdump -T "$$f" 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+' | sort -V | tail -1`; \
+		cxxabi=`objdump -T "$$f" 2>/dev/null | grep -oE 'CXXABI_[0-9.]+' | sort -V | tail -1`; \
+		echo "  $$f: GLIBC=$${glibc:-none} GLIBCXX=$${gxx:-none} CXXABI=$${cxxabi:-none}"; \
+		if [ -n "$$glibc" ] && [ "`printf '%s\n%s\n' "$$glibc" "$(MAX_GLIBC)" | sort -V | tail -1`" != "$(MAX_GLIBC)" ]; then \
+			echo "    FAIL: needs GLIBC_$$glibc > $(MAX_GLIBC)" >&2; fail=1; \
+		fi;							\
+		if [ -n "$$gxx" ] || [ -n "$$cxxabi" ]; then		\
+			echo "    FAIL: links libstdc++ dynamically (build with STATIC_STDCPP=YES)" >&2; fail=1; \
+		fi;							\
+		objdump -p "$$f" 2>/dev/null | awk '/NEEDED/ {printf "    NEEDED %s\n", $$2}'; \
+	done;								\
+	if [ $$fail != 0 ]; then					\
+		echo "release-check: FAILED — do not publish these artifacts" >&2; \
+		exit 1;							\
+	fi;								\
+	echo "release-check: OK (ceiling GLIBC_$(MAX_GLIBC))"
+	@echo "  NEEDED entries above must be present on target hosts (snappy, lz4, zstd, jemalloc)."
 
 ifneq ($(USE_ROCKSDB), YES)
 rocksdb:

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ before — but review the following **before** restarting on the new binary.
    a graceful shutdown when `STOP_FORCE=0` is set. Automation must check the
    exit code *and* set `STOP_FORCE=0`, sizing its own timeout above
    `STOP_TIMEOUT`. Never `kill -9` a node — RocksDB especially.
-7. **Testnet operators: skip 1.1.0, go straight to the m1.1.1 release
+7. **Testnet operators: skip 1.1.0, go straight to the m1.1.2 release
    build.** The 1.1.0 testnet build carries a chain-config regression that
    rewinds a 0.10.x node to block 5,622,999 (~80M-block resync) on first
    start. The fix landed *after* the version string moved to 1.1.1, so

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ before — but review the following **before** restarting on the new binary.
    start. The fix landed *after* the version string moved to 1.1.1, so
    "reports 1.1.1-stable" does not prove a build is safe — use the official
    m1.1.2 release asset (its exact commit hash is published in the release
-   notes). **Do not use the m1.1.1 assets**: they were built on Ubuntu 24.04
-   and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04 at all.
+   notes). **Do not use the m1.1.1 assets**: they were built against glibc
+   2.39 and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04.
    Self-builders can check their commit contains the fix with
    `git merge-base --is-ancestor e2c0d7413 <your-commit>` (exit 0 = fixed).
    Order matters on the remediation too: run testnet
@@ -234,7 +234,7 @@ before — but review the following **before** restarting on the new binary.
 
 Transaction-behaviour note: the pool admits transactions of code plus
 constructor data up to 256KB total, restoring 0.10.x parity — 0.10.x has
-carried the same 256KB ceiling since 2018, so a mixed 0.10.x + 1.1.1 fleet
+carried the same 256KB ceiling since 2018, so a mixed 0.10.x + 1.1.x fleet
 behaves uniformly. Only the intermediate **1.1.0** line rejected above
 128KB: propagation of 128–256KB transactions is path-dependent only while
 1.1.0 nodes are present (relevant on testnet; the mainnet fleet upgrades

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Metadium blockchain node implementation, forked from [go-ethereum](https://githu
 
 Metadium is a Proof-of-Authority (PoA) blockchain with on-chain governance. It uses a custom consensus layer built on top of go-ethereum's ethash engine, with block signing via node keys and reward distribution through governance smart contracts.
 
-**Current version:** 1.1.1-stable (Camellia fork)
+**Current version:** 1.1.2-stable (Camellia fork)
 
 ## Camellia Fork
 
@@ -46,8 +46,9 @@ See [docs/camellia-test-report.md](docs/camellia-test-report.md) for full test r
 
 Prerequisites: Go 1.21+, C compiler (for RocksDB builds).
 
-The canonical builds are the Makefile targets — they are what CI validates
-and what the release tarballs ship:
+These are the Makefile targets CI validates. They build against whatever the
+host provides, which is what you want for development — but **not** for
+anything you publish or deploy; see [Release artifacts](#release-artifacts).
 
 ```bash
 make gmet                    # gmet binary (RocksDB; USE_ROCKSDB=NO for LevelDB)
@@ -64,26 +65,34 @@ make gmet-linux                     # RocksDB
 make gmet-linux USE_ROCKSDB=NO      # LevelDB
 ```
 
-`make gmet-linux` builds `Dockerfile.metadium` and compiles inside it. That
-image pins the oldest glibc the artifacts have to run against (Ubuntu 20.04);
-building on the host instead bakes in the host's glibc, and the result will not
-start on any older distribution:
+`make gmet-linux` builds `Dockerfile.metadium` and compiles inside it. Two
+properties come from that image and nothing else guarantees them:
 
-```
-gmet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
-```
+- its base pins the oldest glibc the artifacts have to run against (Ubuntu
+  20.04). Building on the host bakes in the host's glibc instead, and the
+  result does not start anywhere older:
+  `gmet: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found`
+- it sets `STATIC_STDCPP=YES`, which links libstdc++ from its archive so the
+  binary carries no `GLIBCXX`/`CXXABI` requirement either. Host builds keep the
+  shared libstdc++ so a plain development box still links.
 
-Check an artifact before publishing it — neither command should print a version
-newer than the oldest distribution you support, and the second should print
-nothing at all:
+`gmet-linux` runs `make release-check` on the result and fails the build if an
+artifact would not run on the fleet. Run it standalone against anything you are
+about to publish:
 
 ```bash
-objdump -T build/bin/gmet | grep -oE 'GLIBC_[0-9.]+'                 | sort -Vu | tail -1
-objdump -T build/bin/gmet | grep -oE 'GLIBCXX_[0-9.]+|CXXABI_[0-9.]+' | sort -Vu | tail -1
+make release-check                  # ceiling from MAX_GLIBC (default 2.31)
 ```
 
-Direct `go build` works for development (`./cmd/gmet` and `./cmd/geth` are
-the same entrypoint; the Makefile uses `./cmd/gmet`):
+It covers every ELF in `build/bin` — `logrot` ships in the same bundle and has
+its own glibc floor — and prints each artifact's `NEEDED` list. Those shared
+libraries (snappy, lz4, zstd, jemalloc) must exist on the target host; the
+symbol-version checks passing does not by itself make an artifact runnable on a
+freshly installed machine.
+
+Direct `go build` works for development — **these produce non-portable binaries
+and must not be published** (`./cmd/gmet` and `./cmd/geth` are the same
+entrypoint; the Makefile uses `./cmd/gmet`):
 
 ```bash
 CGO_ENABLED=0 go build -o gmet ./cmd/gmet                    # LevelDB
@@ -196,8 +205,10 @@ before — but review the following **before** restarting on the new binary.
    rewinds a 0.10.x node to block 5,622,999 (~80M-block resync) on first
    start. The fix landed *after* the version string moved to 1.1.1, so
    "reports 1.1.1-stable" does not prove a build is safe — use the official
-   m1.1.1 release asset (its exact commit hash is published in the release
-   notes). Self-builders can check their commit contains the fix with
+   m1.1.2 release asset (its exact commit hash is published in the release
+   notes). **Do not use the m1.1.1 assets**: they were built on Ubuntu 24.04
+   and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04 at all.
+   Self-builders can check their commit contains the fix with
    `git merge-base --is-ancestor e2c0d7413 <your-commit>` (exit 0 = fixed).
    Order matters on the remediation too: run testnet
    nodes with `--metadium-testnet` (or `TESTNET=1` in `.rc`) **only once on

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ make gmet                    # gmet binary (RocksDB; USE_ROCKSDB=NO for LevelDB)
 make metadium                # full deploy bundle: build/metadium.tar.gz (bin/ + conf/)
 ```
 
+### Release artifacts
+
+Artifacts that are published or deployed to nodes **must** be built through the
+container target, never on the build host directly:
+
+```bash
+make gmet-linux                     # RocksDB
+make gmet-linux USE_ROCKSDB=NO      # LevelDB
+```
+
+`make gmet-linux` builds `Dockerfile.metadium` and compiles inside it. That
+image pins the oldest glibc the artifacts have to run against (Ubuntu 20.04);
+building on the host instead bakes in the host's glibc, and the result will not
+start on any older distribution:
+
+```
+gmet: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
+```
+
+Check an artifact before publishing it — neither command should print a version
+newer than the oldest distribution you support, and the second should print
+nothing at all:
+
+```bash
+objdump -T build/bin/gmet | grep -oE 'GLIBC_[0-9.]+'                 | sort -Vu | tail -1
+objdump -T build/bin/gmet | grep -oE 'GLIBCXX_[0-9.]+|CXXABI_[0-9.]+' | sort -Vu | tail -1
+```
+
 Direct `go build` works for development (`./cmd/gmet` and `./cmd/geth` are
 the same entrypoint; the Makefile uses `./cmd/gmet`):
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 1        // Minor version component of the current release
-	VersionPatch = 1        // Patch version component of the current release
+	VersionPatch = 2        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 

--- a/scripts/update-node.sh
+++ b/scripts/update-node.sh
@@ -59,6 +59,8 @@ if [[ $USE_ROCKSDB -eq 1 ]]; then
   done
   [[ -n "$ROCKSDB_LIB" ]] || err "librocksdb not found. Run apt install librocksdb-dev and retry."
 
+  # Host build: links this machine's libstdc++/glibc, so the binary is only
+  # guaranteed to run here. Release artifacts come from `make gmet-linux`.
   CGO_CFLAGS="-I/usr/include" \
   CGO_LDFLAGS="-L$ROCKSDB_LIB -lrocksdb -lsnappy -llz4 -lzstd -lm -lstdc++ -ldl" \
   go build -tags rocksdb -o "$BINARY_NAME" ./cmd/gmet


### PR DESCRIPTION
Promotion of `dev` to `master` so m1.1.2 can be cut. Same shape as #80.

**This is the step that has to happen before the release, not after it.** `master` is still at `ebaeca7f4`, which carries `FROM ubuntu:noble` and `VersionPatch = 1` — building the release from `dev` instead would produce a tag and artifacts that disagree with the branch they claim to come from. @cp-khs flagged this twice on #83; recording it here so the sequencing is explicit.

## Contents

Four commits, all from #83 (merged to `dev` as `c911277c4`), reviewed and approved by @trident90 and @cp-khs:

| commit | |
|---|---|
| `f2d18f2c8` | build: produce release artifacts that run on the whole fleet |
| `a9f9c19f4` | build: scope the static link, and make the release check executable |
| `1132b2639` | docs: name m1.1.2 in the upgrade item's header too |
| `c911277c4` | merge commit |

Diff against `master` is 8 files, +161/−31: `Dockerfile.metadium`, `Makefile`, `README.md`, `CLAUDE.md`, `params/version.go`, `Dockerfile.build`, `Dockerfile.rocksdb-amd64`, `scripts/update-node.sh`. No consensus, protocol or node logic — `params/config.go` is untouched, so fork blocks are unchanged.

## Why

The published m1.1.1 artifacts only run on Ubuntu 24.04. Both require `GLIBC_2.38`; the RocksDB one also requires `GLIBCXX_3.4.32`. Three mainnet nodes cannot run them at all — api1 (22.04), api2 and fn2 (20.04) — and any external operator not on 24.04 is in the same position. `Dockerfile.metadium` had drifted to `ubuntu:noble`, so the container path produced the same artifact the build host did.

`m1.1.2` is the same source built correctly: focal base, gcc 11 from the toolchain PPA (RocksDB 10.9.1 uses `using enum`, which GCC 11 is the first to implement), and libstdc++ linked from its archive so no `GLIBCXX` requirement survives. `make release-check` now fails the build if an artifact would not run on the fleet, and `gmet-linux` runs it automatically.

## Verification

Built from a clean clone of the branch with nothing but the documented commands:

```
make gmet-linux                  → gmet   GLIBC=2.30  GLIBCXX=none  CXXABI=none
                                   logrot GLIBC=none  GLIBCXX=none  CXXABI=none
                                   release-check: OK (ceiling GLIBC_2.31)
make gmet-linux USE_ROCKSDB=NO   → gmet   GLIBC=2.17  GLIBCXX=none  CXXABI=none
                                   release-check: OK (ceiling GLIBC_2.31)
```

Both report `go1.22.5`. Run on the nodes that reject the published m1.1.1 artifacts: the RocksDB build starts on fn2 (20.04), the LevelDB build starts on api1 (22.04), and on api1 the published m1.1.1 binary fails with `GLIBC_2.38 not found` side by side with it.

Beyond the artifacts, the rebuilt binary was put on a live mainnet node — fn2, non-sealer, oldest binary in the fleet at 0.10.0 — as an in-place upgrade. All six GO/NO-GO checks passed: graceful stop in 6s, peers recovered, `eth_syncing=false`, head advancing, RocksDB opened normally without `--userocksdb` (3,946 `.sst` still in use), no rewind (`Loaded most recent local block`, no `Head state missing`), `- Camellia Fork: #117764000` in the banner, and zero `BAD BLOCK` / `Fatal` / `invalid merkle root`. It has been soaking since.

CI on #83 was green 3/3 at the merged head.

## After this

Tag `m1.1.2` on the promoted `master`, build the artifacts from that checkout — not from `dev` — publish, then redeploy the fleet ahead of the BP rolling upgrade, which has to start by 8/20 for the 8/27 fork.

The m1.1.1 release assets stay downloadable; they will be annotated when m1.1.2 goes up, since README item 7 now names m1.1.2 but a bookmark or a search result still lands on the old ones.

Non-blocking follow-ups from the #83 review are tracked in #84, #85, #86 and #87.
