### PR TITLE
docs: say what was measured about the m1.1.1 assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ before — but review the following **before** restarting on the new binary.
    start. The fix landed *after* the version string moved to 1.1.1, so
    "reports 1.1.1-stable" does not prove a build is safe — use the official
    m1.1.2 release asset (its exact commit hash is published in the release
-   notes). **Do not use the m1.1.1 assets**: they were built on Ubuntu 24.04
-   and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04 at all.
+   notes). **Do not use the m1.1.1 assets**: they were built against glibc
+   2.39 and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04.
    Self-builders can check their commit contains the fix with
    `git merge-base --is-ancestor e2c0d7413 <your-commit>` (exit 0 = fixed).
    Order matters on the remediation too: run testnet
@@ -234,7 +234,7 @@ before — but review the following **before** restarting on the new binary.
 
 Transaction-behaviour note: the pool admits transactions of code plus
 constructor data up to 256KB total, restoring 0.10.x parity — 0.10.x has
-carried the same 256KB ceiling since 2018, so a mixed 0.10.x + 1.1.1 fleet
+carried the same 256KB ceiling since 2018, so a mixed 0.10.x + 1.1.x fleet
 behaves uniformly. Only the intermediate **1.1.0** line rejected above
 128KB: propagation of 128–256KB transactions is path-dependent only while
 1.1.0 nodes are present (relevant on testnet; the mainnet fleet upgrades


### PR DESCRIPTION
Three lines in README, both from @cp-khs's approval of #83. Docs only, no code.

**1. Item 7 claimed something that was inferred, not measured.** It said the m1.1.1 assets "were built on Ubuntu 24.04". Where they were built is a guess — `Dockerfile.metadium` was pinned to noble at that commit too, so the container route produces the same binary and there is no way to tell them apart from the artifact. What was measured is the glibc they were built against and the `GLIBC_2.38` they require, and that is also the part an operator can act on.

```
-   they were built on Ubuntu 24.04 and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04 at all.
+   they were built against glibc 2.39 and require `GLIBC_2.38`, so they do not start on 20.04 or 22.04.
```

**2. The mixed-fleet sentence named one patch release.** After m1.1.2 the fleet is `0.10.x + 1.1.2`, so `1.1.1` there goes stale on this release rather than a later one. The statement is about the line, not the patch.

```
-   so a mixed 0.10.x + 1.1.1 fleet behaves uniformly
+   so a mixed 0.10.x + 1.1.x fleet behaves uniformly
```

@cp-khs marked the first one "cosmetic, and only worth touching if you're editing that block anyway". Raising it now because #88 is the last point where README reaches master before m1.1.2 is cut, and item 7 is the section the exchange guide is written from — the same reason the m1.1.1 → m1.1.2 correction in it mattered.

Opened as a PR rather than pushed to `dev` directly. #88 picks this up automatically once it lands.
