### PR TITLE
cmd, metadium: stop letting log rotation take the node down

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ before — but review the following **before** restarting on the new binary.
    `--syncmode` that starts on Metadium networks is `full` (item 5). systemd
    unit templates are provided at `metadium/scripts/gmet.service` (plus a
    sealer override).
+   Two `--log` behaviour changes for such launchers: the flag's usage string
+   used to document the wrong argument order — the parsed one is
+   `<file-name>,<size>,<count>`, the same order as `logrot <file> <size>
+   <count>` — and a `--log` value that fails to parse, or asks for a
+   non-positive size or count, now stops the node at startup instead of
+   silently running without rotation (following the documented-but-wrong
+   order used to produce a 5-byte size and ten million generations). The
+   standalone `logrot` also exits 1 rather than 0 when invoked with the
+   wrong number of arguments, so supervisors notice a missing drainer.
 10. **`metadium/metclient` library users**: signature changes —
     `SendValue`'s `amount` went `int` → `*big.Int`, and `_gasPrice` went
     `int` → `int64` in both `SendValue` and `Deploy` (`gas` is unchanged).

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -280,14 +280,6 @@ func init() {
 	flags.AutoEnvVars(app.Flags, "GETH")
 
 	app.Before = func(ctx *cli.Context) error {
-		// Keep a broken log pipe from killing the node. gmet.sh runs us as
-		// `gmet 2>&1 | logrot ...`, and Go handles SIGPIPE on fd 1 and 2 with
-		// the default disposition: if the reader ever goes away, the process
-		// dies on its next log write, silently. Asking for the signal instead
-		// turns those writes into ordinary EPIPE errors, which the logger
-		// discards, so the node keeps producing blocks while blind.
-		ignoreSIGPIPE()
-
 		// setup rotating log if specified
 		if err := logrota(ctx); err != nil {
 			return err
@@ -381,6 +373,13 @@ func geth(ctx *cli.Context) error {
 	if args := ctx.Args().Slice(); len(args) > 0 {
 		return fmt.Errorf("invalid command: %q", args[0])
 	}
+
+	// Keep a broken log pipe from killing the node. gmet.sh runs us as
+	// `gmet 2>&1 | logrot ...`, and Go handles SIGPIPE on fd 1 and 2 with the
+	// default disposition: if the reader ever goes away, the process dies on
+	// its next log write, silently. Only the node ignores the signal —
+	// one-shot commands keep the default so their pipelines terminate.
+	ignoreSIGPIPE()
 
 	prepare(ctx)
 	stack, backend := makeFullNode(ctx)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -280,8 +280,18 @@ func init() {
 	flags.AutoEnvVars(app.Flags, "GETH")
 
 	app.Before = func(ctx *cli.Context) error {
+		// Keep a broken log pipe from killing the node. gmet.sh runs us as
+		// `gmet 2>&1 | logrot ...`, and Go handles SIGPIPE on fd 1 and 2 with
+		// the default disposition: if the reader ever goes away, the process
+		// dies on its next log write, silently. Asking for the signal instead
+		// turns those writes into ordinary EPIPE errors, which the logger
+		// discards, so the node keeps producing blocks while blind.
+		ignoreSIGPIPE()
+
 		// setup rotating log if specified
-		logrota(ctx)
+		if err := logrota(ctx); err != nil {
+			return err
+		}
 
 		maxprocs.Set() // Automatically set GOMAXPROCS to match Linux container CPU quota.
 		flags.MigrateGlobalFlags(ctx)

--- a/cmd/geth/metadiumcmd.go
+++ b/cmd/geth/metadiumcmd.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -602,15 +603,16 @@ func downloadGenesis(ctx *cli.Context) error {
 //
 // Go gives SIGPIPE on fd 1 and 2 the default disposition, so a node whose
 // stdout is a pipe dies the moment the reader exits — no panic, no log line,
-// nothing to find afterwards. Once the signal is delivered to a channel
-// instead, those writes fail with EPIPE and the node stays up.
+// nothing to find afterwards. Ignoring the signal turns those writes into
+// ordinary EPIPE errors, which the logger discards, so the node keeps
+// producing blocks while blind.
+//
+// It is installed only where the descriptors are expected to be pipes for the
+// life of the process: the node action itself (gmet.sh pipes it into logrot)
+// and the in-process --log path. One-shot commands keep the default so that
+// `gmet dump ... | head` still terminates when its reader does.
 func ignoreSIGPIPE() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, unix.SIGPIPE)
-	go func() {
-		for range c {
-		}
-	}()
+	signal.Ignore(unix.SIGPIPE)
 }
 
 // logrot frontend
@@ -624,7 +626,7 @@ func logrota(ctx *cli.Context) error {
 	}
 
 	var err error
-	logSize := 10 * 1024 * 1024
+	logSize := int64(10 * 1024 * 1024)
 	logCount := 5
 	logOpts := strings.Split(logflag, ",")
 	logFile := ""
@@ -659,32 +661,35 @@ func logrota(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	unix.Close(1) // stdout
-	unix.Close(2) // stderr
+	// Dup2 closes its target atomically; closing 1/2 first would open a
+	// window in which any concurrent open() could claim the descriptor.
 	unix.Dup2(int(w.Fd()), 1)
 	unix.Dup2(int(w.Fd()), 2)
+
+	// From here on the process's own stdout/stderr are backed by this pipe,
+	// so a dead drainer must cost EPIPE, not the process.
+	ignoreSIGPIPE()
 
 	// Diagnostics cannot go to stderr here: stderr is the pipe this goroutine
 	// is draining, so a broken log file would feed its own error reports back
 	// into itself. They go beside the log instead.
-	diag, err := os.OpenFile(logFile+".err", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
-	if err != nil {
-		diag = nil
+	var diagw io.Writer = io.Discard
+	if diag, derr := os.OpenFile(logFile+".err", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600); derr == nil {
+		diagw = diag
 	}
 
 	go func() {
-		if diag != nil {
-			defer diag.Close()
+		// Run returns only once the pipe is closed or its parameters were
+		// rejected — the latter cannot reach here, logSize/logCount are
+		// validated above before the descriptors were touched. Whatever the
+		// reason, leave it in the diagnostics rather than in the pipe.
+		if err := logrot.Run(r, logFile, logSize, logCount, diagw); err != nil {
+			fmt.Fprintf(diagw, "logrot: %s: rotation ended: %v (log output is being discarded)\n",
+				time.Now().Format("2006-01-02T15:04:05Z0700"), err)
 		}
-		var diagw io.Writer
-		if diag != nil {
-			diagw = diag
-		}
-		logrot.Run(r, logFile, logSize, logCount, diagw)
 
-		// Run only returns once the pipe is closed or a read fails. Nothing
-		// else drains this pipe, so keep it drained regardless: a full pipe
-		// would block the node forever on its next log write.
+		// Nothing else drains this pipe, so keep it drained regardless: a
+		// full pipe would block the node forever on its next log write.
 		io.Copy(io.Discard, r)
 	}()
 

--- a/cmd/geth/metadiumcmd.go
+++ b/cmd/geth/metadiumcmd.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -640,9 +641,14 @@ func logrota(ctx *cli.Context) error {
 		logCount = 1
 	}
 	if len(logOpts) >= 3 {
-		if logCount, err = logrot.ParseSize(logOpts[2]); err != nil {
-			return err
+		// A count, not a size: "5g" here would quietly ask for five billion
+		// generations, so no suffixes.
+		if logCount, err = strconv.Atoi(strings.TrimSpace(logOpts[2])); err != nil {
+			return fmt.Errorf("invalid log count %q: %v", logOpts[2], err)
 		}
+	}
+	if logSize <= 0 || logCount <= 0 {
+		return fmt.Errorf("log size and count must be positive, got %d and %d", logSize, logCount)
 	}
 
 	if dir := filepath.Dir(logFile); dir != "" && dir != "." {

--- a/cmd/geth/metadiumcmd.go
+++ b/cmd/geth/metadiumcmd.go
@@ -14,13 +14,12 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"golang.org/x/sys/unix"
 
-	"github.com/charlanxcc/logrot"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -28,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/metadium/logrot"
 	"github.com/ethereum/go-ethereum/metadium/metclient"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/urfave/cli/v2"
@@ -597,34 +597,19 @@ func downloadGenesis(ctx *cli.Context) error {
 	return nil
 }
 
-// borrowed from https://github.com/charlanxcc/logrot
-func parseSize(size string) (int, error) {
-	m := 1
-	size = strings.TrimSpace(size)
-	switch size[len(size)-1:] {
-	case "k":
-		fallthrough
-	case "K":
-		m = 1024
-		size = strings.TrimSpace(size[:len(size)-1])
-	case "m":
-		fallthrough
-	case "M":
-		m = 1024 * 1024
-		size = strings.TrimSpace(size[:len(size)-1])
-	case "g":
-		fallthrough
-	case "G":
-		m = 1024 * 1024 * 1024
-		size = strings.TrimSpace(size[:len(size)-1])
-	}
-
-	i, err := strconv.Atoi(size)
-	if err != nil {
-		return 0, err
-	} else {
-		return i * m, nil
-	}
+// ignoreSIGPIPE keeps a closed log pipe from taking the node down.
+//
+// Go gives SIGPIPE on fd 1 and 2 the default disposition, so a node whose
+// stdout is a pipe dies the moment the reader exits — no panic, no log line,
+// nothing to find afterwards. Once the signal is delivered to a channel
+// instead, those writes fail with EPIPE and the node stays up.
+func ignoreSIGPIPE() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, unix.SIGPIPE)
+	go func() {
+		for range c {
+		}
+	}()
 }
 
 // logrot frontend
@@ -649,13 +634,13 @@ func logrota(ctx *cli.Context) error {
 		logFile = strings.TrimSpace(logOpts[0])
 	}
 	if len(logOpts) >= 2 {
-		if logSize, err = parseSize(logOpts[1]); err != nil {
+		if logSize, err = logrot.ParseSize(logOpts[1]); err != nil {
 			return err
 		}
 		logCount = 1
 	}
 	if len(logOpts) >= 3 {
-		if logCount, err = parseSize(logOpts[2]); err != nil {
+		if logCount, err = logrot.ParseSize(logOpts[2]); err != nil {
 			return err
 		}
 	}
@@ -673,7 +658,29 @@ func logrota(ctx *cli.Context) error {
 	unix.Dup2(int(w.Fd()), 1)
 	unix.Dup2(int(w.Fd()), 2)
 
-	go logrot.LogRotate(r, logFile, logSize, logCount)
+	// Diagnostics cannot go to stderr here: stderr is the pipe this goroutine
+	// is draining, so a broken log file would feed its own error reports back
+	// into itself. They go beside the log instead.
+	diag, err := os.OpenFile(logFile+".err", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		diag = nil
+	}
+
+	go func() {
+		if diag != nil {
+			defer diag.Close()
+		}
+		var diagw io.Writer
+		if diag != nil {
+			diagw = diag
+		}
+		logrot.Run(r, logFile, logSize, logCount, diagw)
+
+		// Run only returns once the pipe is closed or a read fails. Nothing
+		// else drains this pipe, so keep it drained regardless: a full pipe
+		// would block the node forever on its next log write.
+		io.Copy(io.Discard, r)
+	}()
 
 	return nil
 }

--- a/cmd/logrot/main.go
+++ b/cmd/logrot/main.go
@@ -2,10 +2,39 @@
 
 package main
 
-import "github.com/charlanxcc/logrot"
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/metadium/logrot"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: logrot <file-name> <size> <count>\n")
+}
 
 func main() {
-	logrot.Main()
+	if len(os.Args) != 4 {
+		usage()
+		os.Exit(0)
+	}
+
+	filename := os.Args[1]
+	size, err1 := logrot.ParseSize(os.Args[2])
+	count, err2 := strconv.Atoi(os.Args[3])
+	if err1 != nil || err2 != nil || size <= 0 || count <= 0 {
+		usage()
+		os.Exit(1)
+	}
+
+	// Diagnostics go to stderr, which gmet.sh keeps in logs/logrot.err. They
+	// used to go to whichever terminal started the node, which meant that when
+	// rotation failed there was nothing left to explain it.
+	if err := logrot.Run(os.Stdin, filename, size, count, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "logrot: %s\n", err)
+		os.Exit(1)
+	}
 }
 
 /* EOF */

--- a/cmd/logrot/main.go
+++ b/cmd/logrot/main.go
@@ -15,15 +15,18 @@ func usage() {
 }
 
 func main() {
+	// Misuse must not exit 0: a supervisor that drops an argument would see
+	// success with no drainer running, and the node writing into the pipe
+	// would be discarding output from then on.
 	if len(os.Args) != 4 {
 		usage()
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	filename := os.Args[1]
 	size, err1 := logrot.ParseSize(os.Args[2])
 	count, err2 := strconv.Atoi(os.Args[3])
-	if err1 != nil || err2 != nil || size <= 0 || count <= 0 {
+	if err1 != nil || err2 != nil {
 		usage()
 		os.Exit(1)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -985,8 +985,8 @@ var (
 	}
 	LogFlag = &cli.StringFlag{
 		Name:  "log",
-		Usage: "Rotating log file: <file-name>,<count>,<size>",
-		Value: "log,5,10M",
+		Usage: "Rotating log file: <file-name>,<size>,<count>",
+		Value: "log,10M,5",
 	}
 	MaxTxsPerBlock = &cli.IntFlag{
 		Name:  "maxtxsperblock",

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.30.2
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/cespare/cp v0.1.0
-	github.com/charlanxcc/logrot v0.0.0-20180713171554-0c22fa310dfe
 	github.com/cloudflare/cloudflare-go v0.79.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593
 	github.com/consensys/gnark-crypto v0.12.1
@@ -78,7 +77,6 @@ require (
 	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.15.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
-	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,6 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/charlanxcc/logrot v0.0.0-20180713171554-0c22fa310dfe h1:b5zv4kOXaJpcryXQb/SfdvPIkneLpqJd6FIwV3HkYP4=
-github.com/charlanxcc/logrot v0.0.0-20180713171554-0c22fa310dfe/go.mod h1:cDOg0leM7XMSwrkXvVY7PFSTuYZlsILgvc4GnfVarkI=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -1178,8 +1176,6 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
-gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/metadium/logrot/logrot.go
+++ b/metadium/logrot/logrot.go
@@ -1,0 +1,239 @@
+// Package logrot writes a stream to a size-rotated log file.
+//
+// It replaces github.com/charlanxcc/logrot, which ended its process on every
+// error path. That made log rotation part of the node's availability: gmet.sh
+// runs the node as `gmet 2>&1 | logrot ...`, so when the reader exited the node
+// took SIGPIPE on fd 1/2 and — because Go handles SIGPIPE on those two
+// descriptors with the default disposition — died without printing anything.
+//
+// The rule here is therefore: keep draining the input until it ends, whatever
+// happens to the file. A write or rename failure degrades logging, reports
+// itself, and is retried; it never stops the reader and so never takes the
+// writer down with it.
+package logrot
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// readChunk is the read granularity. Input is copied through in chunks rather
+// than scanned line by line, so a log record of any length passes through
+// intact — the previous implementation's bufio.Scanner reported a record over
+// 64KB as end-of-input, which is indistinguishable from a closed pipe.
+const readChunk = 64 * 1024
+
+// retryInterval is how long the writer waits before reopening the log file
+// after an error. It bounds the damage of a permanent failure (a full disk, a
+// deleted directory) to one report per interval instead of one per record.
+const retryInterval = 30 * time.Second
+
+// ParseSize parses a byte count with an optional k/m/g suffix.
+func ParseSize(size string) (int, error) {
+	m := 1
+	size = strings.TrimSpace(size)
+	if size == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+
+	switch size[len(size)-1:] {
+	case "k", "K":
+		m = 1024
+		size = strings.TrimSpace(size[:len(size)-1])
+	case "m", "M":
+		m = 1024 * 1024
+		size = strings.TrimSpace(size[:len(size)-1])
+	case "g", "G":
+		m = 1024 * 1024 * 1024
+		size = strings.TrimSpace(size[:len(size)-1])
+	}
+
+	i, err := strconv.Atoi(size)
+	if err != nil {
+		return 0, err
+	}
+	return i * m, nil
+}
+
+// rotate renames filename to filename.1, shifting the existing generations up
+// and dropping filename.count. It is a no-op while the file is below size.
+func rotate(filename string, size, count int) error {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		// Nothing to rotate yet, or the file is unreadable; the writer will
+		// report the problem when it next opens it.
+		return nil
+	}
+	if fi.Size() < int64(size) {
+		return nil
+	}
+
+	for i := count; i >= 0; i-- {
+		if i == count {
+			os.Remove(fmt.Sprintf("%s.%d", filename, i))
+			continue
+		}
+
+		src := filename
+		if i != 0 {
+			src = fmt.Sprintf("%s.%d", filename, i)
+		}
+		if _, err := os.Stat(src); err != nil && os.IsNotExist(err) {
+			continue
+		}
+		if err := os.Rename(src, fmt.Sprintf("%s.%d", filename, i+1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writer appends to the log file and rotates it, keeping every failure to
+// itself.
+type writer struct {
+	filename string
+	size     int
+	count    int
+	diag     io.Writer
+
+	out      *os.File
+	off      int  // bytes in the current file
+	rotateAt int  // offset at which to attempt the next rotation
+	broken   bool // the file is unusable; output is being dropped
+	retry    time.Time
+	atBOL    bool // the last byte written was a newline
+}
+
+func (w *writer) reportf(format string, args ...interface{}) {
+	if w.diag == nil {
+		return
+	}
+	fmt.Fprintf(w.diag, "logrot: %s: %s\n",
+		time.Now().Format("2006-01-02T15:04:05Z0700"), fmt.Sprintf(format, args...))
+}
+
+// open makes the log file ready for appending. A failure marks the writer
+// broken and schedules a retry; it is never fatal.
+func (w *writer) open() bool {
+	if w.out != nil {
+		return true
+	}
+	if w.broken && time.Now().Before(w.retry) {
+		return false
+	}
+
+	out, err := os.OpenFile(w.filename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		w.fail("cannot open %s: %v", w.filename, err)
+		return false
+	}
+	off, err := out.Seek(0, io.SeekEnd)
+	if err != nil {
+		out.Close()
+		w.fail("cannot seek %s: %v", w.filename, err)
+		return false
+	}
+
+	if w.broken {
+		w.reportf("resumed writing to %s", w.filename)
+	}
+	w.out, w.off, w.broken = out, int(off), false
+	w.atBOL = true
+	return true
+}
+
+// fail records a failure and holds off further attempts for retryInterval.
+func (w *writer) fail(format string, args ...interface{}) {
+	if !w.broken {
+		w.reportf("%s (dropping output until it recovers)", fmt.Sprintf(format, args...))
+	}
+	w.broken = true
+	w.retry = time.Now().Add(retryInterval)
+}
+
+// write appends p, rotating once the file is over size. Output is dropped
+// while the file is unusable so that the reader can keep draining.
+func (w *writer) write(p []byte) {
+	if !w.open() {
+		return
+	}
+
+	n, err := w.out.Write(p)
+	if err != nil {
+		w.out.Close()
+		w.out = nil
+		w.fail("cannot write %s: %v", w.filename, err)
+		return
+	}
+	w.off += n
+	w.atBOL = p[len(p)-1] == '\n'
+
+	// Rotate on a record boundary only, so a record is never split across two
+	// files. A record longer than the rotation size therefore overshoots it,
+	// which is the same behaviour as before.
+	if w.off >= w.rotateAt && w.atBOL {
+		w.rotate()
+	}
+}
+
+func (w *writer) rotate() {
+	w.out.Close()
+	w.out = nil
+
+	if err := rotate(w.filename, w.size, w.count); err != nil {
+		// Keep appending to the current file: an oversized log is better than
+		// a stopped one. Hold off the next attempt for a full size, so a
+		// permanently failing rename reports once per size rather than once
+		// per record.
+		w.reportf("cannot rotate %s: %v (continuing in place)", w.filename, err)
+		w.rotateAt = w.off + w.size
+		return
+	}
+	w.rotateAt = w.size
+}
+
+func (w *writer) close() {
+	if w.out != nil {
+		w.out.Close()
+		w.out = nil
+	}
+}
+
+// Run copies r into filename, rotating it every size bytes and keeping count
+// generations. Diagnostics go to diag, which may be nil.
+//
+// Run returns only when r ends: while r is open it always keeps reading, so the
+// process writing into r never blocks on a full pipe and never sees it close.
+// An error is returned only for invalid parameters or a failed read.
+func Run(r io.Reader, filename string, size, count int, diag io.Writer) error {
+	if size <= 0 || count <= 0 {
+		return fmt.Errorf("invalid parameters: size=%d count=%d", size, count)
+	}
+
+	w := &writer{filename: filename, size: size, count: count, diag: diag}
+	defer w.close()
+
+	// Rotate once up front so a restart does not append to an already
+	// oversized file.
+	if err := rotate(filename, size, count); err != nil {
+		w.reportf("cannot rotate %s at startup: %v", filename, err)
+	}
+
+	buf := make([]byte, readChunk)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			w.write(buf[:n])
+		}
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/metadium/logrot/logrot.go
+++ b/metadium/logrot/logrot.go
@@ -10,11 +10,19 @@
 // happens to the file. A write or rename failure degrades logging, reports
 // itself, and is retried; it never stops the reader and so never takes the
 // writer down with it.
+//
+// The repo already vendors lumberjack for --log.rotate, but it cannot be used
+// here: it has no drain invariant (a write error propagates to the caller,
+// which on this path is the node's own log writer), it truncates rather than
+// retries on failure, and its backup naming (timestamped) breaks operators'
+// shippers that follow the numbered `.1`…`.N` scheme this replaces.
 package logrot
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -32,9 +40,11 @@ const readChunk = 64 * 1024
 // deleted directory) to one report per interval instead of one per record.
 const retryInterval = 30 * time.Second
 
-// ParseSize parses a byte count with an optional k/m/g suffix.
-func ParseSize(size string) (int, error) {
-	m := 1
+// ParseSize parses a positive byte count with an optional k/m/g suffix. The
+// result is an int64 whatever the platform: "2g" is a valid rotation size on a
+// 386 build, where int arithmetic would wrap it negative.
+func ParseSize(size string) (int64, error) {
+	var m int64 = 1
 	size = strings.TrimSpace(size)
 	if size == "" {
 		return 0, fmt.Errorf("empty size")
@@ -52,38 +62,49 @@ func ParseSize(size string) (int, error) {
 		size = strings.TrimSpace(size[:len(size)-1])
 	}
 
-	i, err := strconv.Atoi(size)
+	i, err := strconv.ParseInt(size, 10, 64)
 	if err != nil {
 		return 0, err
+	}
+	if i <= 0 || i > math.MaxInt64/m {
+		return 0, fmt.Errorf("size out of range: %q", size)
 	}
 	return i * m, nil
 }
 
 // rotate renames filename to filename.1, shifting the existing generations up
 // and dropping filename.count. It is a no-op while the file is below size.
-func rotate(filename string, size, count int) error {
+func rotate(filename string, size int64, count int) error {
 	fi, err := os.Stat(filename)
 	if err != nil {
 		// Nothing to rotate yet, or the file is unreadable; the writer will
 		// report the problem when it next opens it.
 		return nil
 	}
-	if fi.Size() < int64(size) {
+	if fi.Size() < size {
 		return nil
 	}
 
-	for i := count; i >= 0; i-- {
-		if i == count {
-			os.Remove(fmt.Sprintf("%s.%d", filename, i))
-			continue
+	// Find the highest existing generation walking up from 1, so the work
+	// scales with the files that exist rather than with count, which is
+	// configuration and can be absurd. Generations above a gap are stale
+	// (a previous shift did not reach them) and age out as later shifts
+	// rename over them.
+	top := 0
+	for i := 1; i <= count; i++ {
+		if _, err := os.Stat(fmt.Sprintf("%s.%d", filename, i)); err != nil {
+			break
 		}
-
+		top = i
+	}
+	if top == count {
+		os.Remove(fmt.Sprintf("%s.%d", filename, count))
+		top--
+	}
+	for i := top; i >= 0; i-- {
 		src := filename
 		if i != 0 {
 			src = fmt.Sprintf("%s.%d", filename, i)
-		}
-		if _, err := os.Stat(src); err != nil && os.IsNotExist(err) {
-			continue
 		}
 		if err := os.Rename(src, fmt.Sprintf("%s.%d", filename, i+1)); err != nil {
 			return err
@@ -96,16 +117,15 @@ func rotate(filename string, size, count int) error {
 // itself.
 type writer struct {
 	filename string
-	size     int
+	size     int64
 	count    int
 	diag     io.Writer
 
 	out      *os.File
-	off      int  // bytes in the current file
-	rotateAt int  // offset at which to attempt the next rotation
-	broken   bool // the file is unusable; output is being dropped
+	off      int64 // bytes in the current file
+	rotateAt int64 // offset at which to attempt the next rotation
+	broken   bool  // the file is unusable; output is being dropped
 	retry    time.Time
-	atBOL    bool // the last byte written was a newline
 }
 
 func (w *writer) reportf(format string, args ...interface{}) {
@@ -141,8 +161,10 @@ func (w *writer) open() bool {
 	if w.broken {
 		w.reportf("resumed writing to %s", w.filename)
 	}
-	w.out, w.off, w.broken = out, int(off), false
-	w.atBOL = true
+	w.out, w.off, w.broken = out, off, false
+	if w.rotateAt < w.size {
+		w.rotateAt = w.size
+	}
 	return true
 }
 
@@ -155,34 +177,60 @@ func (w *writer) fail(format string, args ...interface{}) {
 	w.retry = time.Now().Add(retryInterval)
 }
 
-// write appends p, rotating once the file is over size. Output is dropped
-// while the file is unusable so that the reader can keep draining.
-func (w *writer) write(p []byte) {
-	if !w.open() {
-		return
+// emit appends p to the file as it is. Output is dropped while the file is
+// unusable so that the reader can keep draining.
+func (w *writer) emit(p []byte) bool {
+	if len(p) == 0 {
+		return true
 	}
-
+	if !w.open() {
+		return false
+	}
 	n, err := w.out.Write(p)
 	if err != nil {
 		w.out.Close()
 		w.out = nil
 		w.fail("cannot write %s: %v", w.filename, err)
+		return false
+	}
+	w.off += int64(n)
+	return true
+}
+
+// write appends p, rotating once the file passes size.
+//
+// A chunk is not a record: under load the pipe coalesces many records into one
+// read. When a chunk would carry the file past the rotation point it is split
+// at its last newline — the head completes the current file on a record
+// boundary, the tail opens the next one — so the overshoot is bounded by one
+// read (readChunk) rather than by how long the reader stays saturated. A
+// stream with no record boundaries at all is cut mid-record once the overshoot
+// reaches a full extra size: an imprecise boundary beats an unbounded file.
+func (w *writer) write(p []byte) {
+	if w.off+int64(len(p)) >= w.rotateAt {
+		if ix := bytes.LastIndexByte(p, '\n'); ix >= 0 {
+			if !w.emit(p[:ix+1]) {
+				return
+			}
+			if w.off >= w.rotateAt {
+				w.rotate()
+			}
+			p = p[ix+1:]
+		}
+	}
+	if !w.emit(p) {
 		return
 	}
-	w.off += n
-	w.atBOL = p[len(p)-1] == '\n'
-
-	// Rotate on a record boundary only, so a record is never split across two
-	// files. A record longer than the rotation size therefore overshoots it,
-	// which is the same behaviour as before.
-	if w.off >= w.rotateAt && w.atBOL {
+	if w.off >= w.rotateAt+w.size {
 		w.rotate()
 	}
 }
 
 func (w *writer) rotate() {
-	w.out.Close()
-	w.out = nil
+	if w.out != nil {
+		w.out.Close()
+		w.out = nil
+	}
 
 	if err := rotate(w.filename, w.size, w.count); err != nil {
 		// Keep appending to the current file: an oversized log is better than
@@ -193,7 +241,8 @@ func (w *writer) rotate() {
 		w.rotateAt = w.off + w.size
 		return
 	}
-	w.rotateAt = w.size
+	// The current file was renamed away; the next emit starts a fresh one.
+	w.off, w.rotateAt = 0, w.size
 }
 
 func (w *writer) close() {
@@ -208,13 +257,14 @@ func (w *writer) close() {
 //
 // Run returns only when r ends: while r is open it always keeps reading, so the
 // process writing into r never blocks on a full pipe and never sees it close.
-// An error is returned only for invalid parameters or a failed read.
-func Run(r io.Reader, filename string, size, count int, diag io.Writer) error {
+// An error is returned only for invalid parameters or a persistent read
+// failure — a transient one is reported and retried.
+func Run(r io.Reader, filename string, size int64, count int, diag io.Writer) error {
 	if size <= 0 || count <= 0 {
 		return fmt.Errorf("invalid parameters: size=%d count=%d", size, count)
 	}
 
-	w := &writer{filename: filename, size: size, count: count, diag: diag}
+	w := &writer{filename: filename, size: size, count: count, diag: diag, rotateAt: size}
 	defer w.close()
 
 	// Rotate once up front so a restart does not append to an already
@@ -224,16 +274,24 @@ func Run(r io.Reader, filename string, size, count int, diag io.Writer) error {
 	}
 
 	buf := make([]byte, readChunk)
+	fails := 0
 	for {
 		n, err := r.Read(buf)
 		if n > 0 {
+			fails = 0
 			w.write(buf[:n])
 		}
 		if err != nil {
 			if err == io.EOF {
 				return nil
 			}
-			return err
+			// A read error on the pipe is close to impossible; retry rather
+			// than abandoning the drain over a transient one.
+			if fails++; fails >= 10 {
+				return err
+			}
+			w.reportf("cannot read input: %v (retrying)", err)
+			time.Sleep(time.Second)
 		}
 	}
 }

--- a/metadium/logrot/logrot_test.go
+++ b/metadium/logrot/logrot_test.go
@@ -1,0 +1,152 @@
+package logrot
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunPassesOversizedRecords is the regression test for the failure that
+// took a mainnet node down: the previous implementation scanned with a
+// bufio.Scanner, whose 64KB token limit made a longer record look like
+// end-of-input. The reader exited, and the node writing into the pipe died of
+// SIGPIPE without a message. A record of any length must pass through.
+func TestRunPassesOversizedRecords(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "log")
+
+	long := strings.Repeat("x", 256*1024)
+	in := fmt.Sprintf("before\n%s\nafter\n", long)
+
+	if err := Run(strings.NewReader(in), name, 1024*1024, 5, io.Discard); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != in {
+		t.Errorf("log does not match input: got %d bytes, want %d", len(got), len(in))
+	}
+}
+
+// TestRunDrainsWhenTheFileIsUnusable checks the property the node depends on:
+// however badly the file behaves, Run keeps reading to the end of the input and
+// reports success, so the writer on the other side of the pipe is never killed.
+func TestRunDrainsWhenTheFileIsUnusable(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "no-such-dir", "log")
+
+	in := strings.Repeat("a log line\n", 1000)
+	r := strings.NewReader(in)
+	var diag bytes.Buffer
+
+	if err := Run(r, name, 1024, 5, &diag); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.Len() != 0 {
+		t.Errorf("input not drained: %d bytes left", r.Len())
+	}
+	if diag.Len() == 0 {
+		t.Error("the failure was not reported")
+	}
+}
+
+// TestRunRotates covers the ordinary path: the log is rotated once it passes
+// size, and no more than count generations are kept.
+func TestRunRotates(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "log")
+
+	line := strings.Repeat("y", 99) + "\n"
+	if err := Run(strings.NewReader(strings.Repeat(line, 100)), name, 1000, 3, io.Discard); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(name + ".1"); err != nil {
+		t.Errorf("log.1 missing: %v", err)
+	}
+	if _, err := os.Stat(name + ".4"); err == nil {
+		t.Error("log.4 exists, but only 3 generations should be kept")
+	}
+}
+
+// TestRunSurvivesRotationFailure makes the rename fail permanently: log.1 is a
+// non-empty directory, which os.Remove cannot clear and os.Rename cannot
+// replace. Rotation is expendable; the reader is not.
+func TestRunSurvivesRotationFailure(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "log")
+
+	if err := os.Mkdir(name+".1", 0700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(name+".1", "keep"), []byte("x"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	line := strings.Repeat("z", 99) + "\n"
+	in := strings.Repeat(line, 100)
+	var diag bytes.Buffer
+
+	if err := Run(strings.NewReader(in), name, 1000, 1, &diag); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(diag.String(), "cannot rotate") {
+		t.Errorf("rotation failure not reported: %q", diag.String())
+	}
+
+	// Everything still landed in the log, just without rotation.
+	got, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(got) != len(in) {
+		t.Errorf("log has %d bytes, want %d", len(got), len(in))
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int
+		bad  bool
+	}{
+		{in: "10", want: 10},
+		{in: "10k", want: 10 * 1024},
+		{in: "10M", want: 10 * 1024 * 1024},
+		{in: " 2 g ", want: 2 * 1024 * 1024 * 1024},
+		{in: "", bad: true},
+		{in: "  ", bad: true},
+		{in: "k", bad: true},
+		{in: "ten", bad: true},
+	} {
+		got, err := ParseSize(tc.in)
+		if tc.bad {
+			if err == nil {
+				t.Errorf("ParseSize(%q) = %d, want an error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseSize(%q): %v", tc.in, err)
+		} else if got != tc.want {
+			t.Errorf("ParseSize(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRunRejectsInvalidParameters(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "log")
+	if err := Run(strings.NewReader(""), name, 0, 5, io.Discard); err == nil {
+		t.Error("size 0 accepted")
+	}
+	if err := Run(strings.NewReader(""), name, 1024, 0, io.Discard); err == nil {
+		t.Error("count 0 accepted")
+	}
+}

--- a/metadium/logrot/logrot_test.go
+++ b/metadium/logrot/logrot_test.go
@@ -114,17 +114,24 @@ func TestRunSurvivesRotationFailure(t *testing.T) {
 func TestParseSize(t *testing.T) {
 	for _, tc := range []struct {
 		in   string
-		want int
+		want int64
 		bad  bool
 	}{
 		{in: "10", want: 10},
 		{in: "10k", want: 10 * 1024},
 		{in: "10M", want: 10 * 1024 * 1024},
 		{in: " 2 g ", want: 2 * 1024 * 1024 * 1024},
+		// int64 on every platform: a 386 int would wrap these.
+		{in: "4g", want: 4 * 1024 * 1024 * 1024},
 		{in: "", bad: true},
 		{in: "  ", bad: true},
 		{in: "k", bad: true},
 		{in: "ten", bad: true},
+		// A size that parses but cannot rotate anything is an error, not a
+		// value for a later check to catch.
+		{in: "0", bad: true},
+		{in: "-10M", bad: true},
+		{in: "9999999999999999999g", bad: true},
 	} {
 		got, err := ParseSize(tc.in)
 		if tc.bad {
@@ -137,6 +144,73 @@ func TestParseSize(t *testing.T) {
 			t.Errorf("ParseSize(%q): %v", tc.in, err)
 		} else if got != tc.want {
 			t.Errorf("ParseSize(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestRunRotatesNearThresholdUnderCoalescedReads pins the rotation-accuracy
+// property: a saturated pipe hands Run full chunks whose last byte is rarely a
+// newline, and rotation must not wait for one that is. The chunk is split at
+// its last record boundary instead, so no generation overshoots the configured
+// size by more than one read, and every generation still ends on a record
+// boundary.
+func TestRunRotatesNearThresholdUnderCoalescedReads(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "log")
+
+	const size = 128 * 1024
+	line := strings.Repeat("v", 499) + "\n" // chunks end mid-record
+	in := strings.Repeat(line, 2*1024*1024/500)
+
+	if err := Run(strings.NewReader(in), name, size, 20, io.Discard); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	rotations := 0
+	for i := 1; ; i++ {
+		got, err := os.ReadFile(fmt.Sprintf("%s.%d", name, i))
+		if err != nil {
+			break
+		}
+		rotations++
+		if len(got) > size+readChunk {
+			t.Errorf("log.%d is %d bytes; the overshoot bound is size+readChunk = %d",
+				i, len(got), size+readChunk)
+		}
+		if got[len(got)-1] != '\n' {
+			t.Errorf("log.%d does not end on a record boundary", i)
+		}
+	}
+	if rotations < 2 {
+		t.Errorf("only %d rotations for %d bytes at size %d", rotations, len(in), size)
+	}
+}
+
+// TestRunCapsNewlineFreeStream pins the backstop for input with no record
+// boundaries at all: the file is cut mid-record once the overshoot reaches a
+// full extra size, instead of growing for the life of the process.
+func TestRunCapsNewlineFreeStream(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "log")
+
+	const size = 100 * 1024
+	in := strings.Repeat("x", 1024*1024)
+
+	if err := Run(strings.NewReader(in), name, size, 20, io.Discard); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(name + ".1"); err != nil {
+		t.Fatalf("a newline-free stream never rotated: %v", err)
+	}
+	for i := 1; ; i++ {
+		got, err := os.ReadFile(fmt.Sprintf("%s.%d", name, i))
+		if err != nil {
+			break
+		}
+		if len(got) > 2*size+readChunk {
+			t.Errorf("log.%d is %d bytes; the hard cap is 2*size+readChunk = %d",
+				i, len(got), 2*size+readChunk)
 		}
 	}
 }

--- a/metadium/scripts/gmet.sh
+++ b/metadium/scripts/gmet.sh
@@ -192,12 +192,15 @@ function start ()
     [ -d "$d/logs" ] || mkdir -p $d/logs
 
     cd $d
+    # logrot's own errors go to logs/logrot.err. They used to go to whatever
+    # terminal happened to start the node, so a rotation failure left nothing
+    # behind to explain itself.
     if [ ! "$2" = "inner" ]; then
 	$GMET --datadir ${PWD} --metrics $OPTS 2>&1 |   \
-	    ${d}/bin/logrot ${d}/logs/log 10M 5 &
+	    ${d}/bin/logrot ${d}/logs/log 10M 5 2>>${d}/logs/logrot.err &
     else
 	if [ -x "$d/bin/logrot" ]; then
-	    exec > >($d/bin/logrot $d/logs/log 10M 5)
+	    exec > >($d/bin/logrot $d/logs/log 10M 5 2>>${d}/logs/logrot.err)
 	    exec 2>&1
 	fi
 	exec $GMET --datadir ${PWD} --metrics $OPTS


### PR DESCRIPTION
Fixes #90 (items 1–3 of the suggested direction; the `--log` argument-order
mismatch and the smaller cleanups stay out of this change).

**This is not for the fork window.** The operations side asked that the fleet's
logging path not change before 2026-08-27, and I agree: the mechanism behind the
outage that surfaced this is still undetermined, and rewriting the log path on
mainnet 13 days before a fork creates more risk than it removes. Opening it now
so it can be reviewed while the context is fresh — merge and release are meant to
happen after the fork.

## What is wrong today

`metadium/scripts/gmet.sh` runs the node as `gmet 2>&1 | logrot ...`, so the
rotator sits on the node's availability path. `github.com/charlanxcc/logrot`
(unmaintained since 2018) ends its process on every error path, and one of those
paths needs no error at all:

- It reads with a `bufio.Scanner` and treats `Scan() == false` as end-of-input,
  never checking `in.Err()`. A record over `bufio.MaxScanTokenSize` (64 KB) is
  therefore indistinguishable from a closed pipe. `summarizeBadBlock` puts each
  receipt on a single line including a raw `[]*types.Log`, and this chain accepts
  254 KB transactions.
- A write error, or a failing rename during rotation, ends it the same way — and
  the reason goes to a stderr the gmet.sh pipeline discards, so nothing is left
  to explain it.
- Once the reader is gone, the node takes SIGPIPE on fd 1/2. Go leaves those two
  descriptors on the default disposition, so the process dies on its next log
  write, printing nothing at all.

The in-process `--log` path fails the other way: `logrota` discards the
goroutine's error and `main.go` discards `logrota`'s, so a rotator that stops
leaves nobody draining the pipe and the node blocks forever on its next write.

## What this changes

`metadium/logrot` replaces the dependency. Its one invariant is that it keeps
reading until the input ends, whatever the file does:

- records are copied through in chunks, so length no longer matters;
- write and rename failures are reported, retried on an interval, and otherwise
  tolerated — an oversized or missing log beats a stopped node;
- diagnostics go somewhere durable: stderr for the command, which gmet.sh now
  keeps in `logs/logrot.err`, and `<logfile>.err` for the in-process path, whose
  stderr is the very pipe it is draining.

Alongside it, `logrota` falls back to discarding if `Run` ever returns, its error
is checked, and the node asks for SIGPIPE instead of dying from it — a broken
pipe should cost logs, not the node.

`go mod tidy` drops the dependency, and `gopkg.in/urfave/cli.v1` with it; that
one was already unreferenced.

## Verification

Built and run on the CI builder (Go 1.22.5):

- `go test -race ./metadium/logrot/` passes; `go vet` and `gofmt` are clean
- `gmet` and `logrot` both build
- end to end through the real binary: a **262,144-byte single record** passes
  through intact and rotation keeps its 3 generations — the same input ends the
  old rotator at 64 KB

The tests cover the regression directly: an oversized record, an unwritable log
(the reader must still drain to EOF and report success), rotation and its
generation cap, a permanently failing rename, and the parameter parsing.

## Note on the issue text

One claim in #90 as filed does not hold: I read the log size at the time of the
outage as evidence of an oversized record, and measurements from the rest of the
fleet show that overshoot is the normal cut point. That inference is withdrawn in
[a comment on the issue](https://github.com/METADIUM/go-metadium/issues/90#issuecomment-5286958015).
The defects above are read off the source and do not depend on it.
