### PR TITLE
accounts/keystore, eth/catalyst: backport the upstream fixes for the two CI test flakes

### DIFF
--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -326,6 +326,11 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 	// Create a temporary keystore to test with
 	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-updatedkeyfilecontents-test-%d-%d", os.Getpid(), rand.Int()))
+
+	// Create the directory
+	os.MkdirAll(dir, 0700)
+	defer os.RemoveAll(dir)
+
 	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
 
 	list := ks.Accounts()
@@ -335,9 +340,7 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 	if !waitWatcherStart(ks) {
 		t.Fatal("keystore watcher didn't start in time")
 	}
-	// Create the directory and copy a key file into it.
-	os.MkdirAll(dir, 0700)
-	defer os.RemoveAll(dir)
+	// Copy a key file into it
 	file := filepath.Join(dir, "aaa")
 
 	// Place one of our testfiles in there

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -68,17 +68,26 @@ func waitWatcherStart(ks *KeyStore) bool {
 
 func waitForAccounts(wantAccounts []accounts.Account, ks *KeyStore) error {
 	var list []accounts.Account
+	haveAccounts := false
+	haveChange := false
 	for t0 := time.Now(); time.Since(t0) < 5*time.Second; time.Sleep(100 * time.Millisecond) {
-		list = ks.Accounts()
-		if reflect.DeepEqual(list, wantAccounts) {
-			// ks should have also received change notifications
+		if !haveAccounts {
+			list = ks.Accounts()
+			haveAccounts = reflect.DeepEqual(list, wantAccounts)
+		}
+		if !haveChange {
 			select {
 			case <-ks.changes:
+				haveChange = true
 			default:
-				return errors.New("wasn't notified of new accounts")
 			}
+		}
+		if haveAccounts && haveChange {
 			return nil
 		}
+	}
+	if haveAccounts {
+		return errors.New("wasn't notified of new accounts")
 	}
 	return fmt.Errorf("\ngot  %v\nwant %v", list, wantAccounts)
 }

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -264,9 +264,12 @@ func (c *SimulatedBeacon) Rollback() {
 
 // Fork sets the head to the provided hash.
 func (c *SimulatedBeacon) Fork(parentHash common.Hash) error {
+	// Ensure no pending transactions.
+	c.eth.TxPool().Sync()
 	if len(c.eth.TxPool().Pending(txpool.PendingFilter{})) != 0 {
 		return errors.New("pending block dirty")
 	}
+
 	parent := c.eth.BlockChain().GetBlockByHash(parentHash)
 	if parent == nil {
 		return errors.New("parent not found")


### PR DESCRIPTION
Closes #73 together with #92: that PR fixes the TRS races added to the issue later; this one takes the issue's original two items the fundamental way — backporting the upstream stabilizations instead of quarantining the tests. **Review-only like the others; merging waits until after the 2026-08-27 fork.** Third in the queue behind #91 and #92, and it overlaps no file with them or with anything else waiting.

Three upstream commits, cherry-picked with `-x` (original authorship preserved):

- **accounts: fix TestUpdateKeyfileContents (upstream #29867)** — creates the keystore directory before `NewKeyStore`, so the watcher starts on its first attempt and `waitWatcherStart` gates what it was written to gate.
- **accounts/keystore: fix flaky TestUpdatedKeyfileContents (upstream #34084)** — `waitForAccounts` required the account-list match and the change notification to be observable in the same poll instant; it now waits until both have been observed within the same timeout window.
- **eth/catalyst: ensure TxPool is synced in Fork (upstream #29876)** — `SimulatedBeacon.Fork` could run before the pool finished reorganizing, which is the `TestForkResendTx` failure. This is the one non-test change in the set, and the component is the `--dev`-mode simulated beacon: nothing on the node's mainnet/testnet path executes it.

The trigger for doing this now: `TestUpdatedKeyfileContents` fired again on the 8/19 scheduled dev-cron, on unchanged dev — the fifth occurrence tracked in #73, each one costing a manual rerun exactly when review attention matters.

## Verification

- `go test ./accounts/keystore/ -run TestUpdatedKeyfileContents -count=100` — pass (upstream #34084's own validation recipe)
- `go test ./accounts/keystore/ -count=3` — pass
- `go test ./ethclient/simulated/ -run TestForkResendTx -count=20` — pass
- `go test ./ethclient/simulated/ ./eth/catalyst/` — pass; `go vet` clean on all three packages
