### PR TITLE
eth/protocols/eth, crypto: gate responses on solicitation, and port the point-validation guards

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -176,6 +176,20 @@ func UnmarshalPubkey(pub []byte) (*ecdsa.PublicKey, error) {
 	// grew an UnmarshalCompressed method would otherwise silently stop being
 	// validated here. Upstream go-ethereum added it in "crypto: add IsOnCurve
 	// check" (159fb1a1d, CVE-2025-24883).
+	//
+	// The range half is spelled out rather than left to IsOnCurve, because the
+	// two build modes disagree about it: secp256k1.BitCurve.IsOnCurve rejects an
+	// unreduced coordinate, while btcec's KoblitzCurve converts to Jacobian
+	// coordinates first and so tests a coordinate at or above P as if it had
+	// been reduced. Upstream carries that check in a btCurve wrapper around
+	// btcec (895a8597c), which does not transplant here: this tree's S256()
+	// returns btcec.S256() directly, and wrapping it would change the curve
+	// identity that Sign and the key constructors compare against. Checking at
+	// the guard costs two comparisons and leaves both modes equivalent.
+	p := S256().Params().P
+	if x.Sign() < 0 || y.Sign() < 0 || x.Cmp(p) >= 0 || y.Cmp(p) >= 0 {
+		return nil, errInvalidPubkey
+	}
 	if !S256().IsOnCurve(x, y) {
 		return nil, errInvalidPubkey
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -169,6 +169,16 @@ func UnmarshalPubkey(pub []byte) (*ecdsa.PublicKey, error) {
 	if x == nil {
 		return nil, errInvalidPubkey
 	}
+	// elliptic.Unmarshal validates the point itself only for curves that do not
+	// implement its unmarshaler interface, and neither curve this tree resolves
+	// S256() to implements it, so the decode above does check. This makes the
+	// check explicit rather than inherited from that property: a curve type that
+	// grew an UnmarshalCompressed method would otherwise silently stop being
+	// validated here. Upstream go-ethereum added it in "crypto: add IsOnCurve
+	// check" (159fb1a1d, CVE-2025-24883).
+	if !S256().IsOnCurve(x, y) {
+		return nil, errInvalidPubkey
+	}
 	return &ecdsa.PublicKey{Curve: S256(), X: x, Y: y}, nil
 }
 

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -134,7 +134,19 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	// point is refused before GenerateShared is reached. This check covers the
 	// callers that build a PublicKey directly instead, and keeps the guarantee
 	// from depending on that property of the curve types.
-	if pub.X == nil || pub.Y == nil || !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+	//
+	// The range check is explicit for the same reason it is in
+	// crypto.UnmarshalPubkey: IsOnCurve rejects an unreduced coordinate on the
+	// cgo curve but not on btcec, which reduces before testing. Keeping it here
+	// makes the guard equivalent in both build modes.
+	if pub.X == nil || pub.Y == nil {
+		return nil, ErrInvalidPublicKey
+	}
+	if p := pub.Curve.Params().P; pub.X.Sign() < 0 || pub.Y.Sign() < 0 ||
+		pub.X.Cmp(p) >= 0 || pub.Y.Cmp(p) >= 0 {
+		return nil, ErrInvalidPublicKey
+	}
+	if !pub.Curve.IsOnCurve(pub.X, pub.Y) {
 		return nil, ErrInvalidPublicKey
 	}
 	if skLen+macLen > MaxSharedKeyLength(pub) {

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -122,6 +122,21 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	if prv.PublicKey.Curve != pub.Curve {
 		return nil, ErrInvalidCurve
 	}
+	// Reject a point that is not on the curve before it reaches ScalarMult. An
+	// invalid-curve point turns the multiplication into an oracle that leaks
+	// bits of the private key. Upstream go-ethereum added this check in
+	// "crypto/ecies: fix ECIES invalid-curve handling" (46bee92f9, CVE-2026-26315).
+	//
+	// The handshake path into this function is already covered here: Decrypt
+	// obtains the peer's point through elliptic.Unmarshal, which validates it for
+	// both curves this tree resolves S256() to (see the note in
+	// crypto/secp256k1/curve.go on the unmarshaler interface), so an off-curve
+	// point is refused before GenerateShared is reached. This check covers the
+	// callers that build a PublicKey directly instead, and keeps the guarantee
+	// from depending on that property of the curve types.
+	if pub.X == nil || pub.Y == nil || !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+		return nil, ErrInvalidPublicKey
+	}
 	if skLen+macLen > MaxSharedKeyLength(pub) {
 		return nil, ErrSharedKeyTooBig
 	}

--- a/crypto/ecies/invalid_curve_test.go
+++ b/crypto/ecies/invalid_curve_test.go
@@ -1,0 +1,37 @@
+package ecies
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TestGenerateSharedRejectsOffCurve pins the CVE-2026-26315 guard: a point that
+// is not on the curve must be refused before the ECDH multiplication, and with
+// ErrInvalidPublicKey rather than whatever the multiplication happens to
+// produce. (0, 0) is a well-formed encoding of such a point.
+func TestGenerateSharedRejectsOffCurve(t *testing.T) {
+	prv, err := GenerateKey(rand.Reader, crypto.S256(), nil)
+	if err != nil {
+		t.Fatalf("key generation failed: %v", err)
+	}
+	offCurve := &PublicKey{
+		X:      new(big.Int),
+		Y:      new(big.Int),
+		Curve:  prv.PublicKey.Curve,
+		Params: prv.PublicKey.Params,
+	}
+	if prv.PublicKey.Curve.IsOnCurve(offCurve.X, offCurve.Y) {
+		t.Fatal("the test point is on the curve, so it proves nothing")
+	}
+	sk, err := prv.GenerateShared(offCurve, 16, 16)
+	t.Logf("GenerateShared returned err=%v", err)
+	if err != ErrInvalidPublicKey {
+		t.Fatalf("want ErrInvalidPublicKey, got %v", err)
+	}
+	if sk != nil {
+		t.Fatalf("a shared key was derived from an off-curve point")
+	}
+}

--- a/crypto/ecies/invalid_curve_test.go
+++ b/crypto/ecies/invalid_curve_test.go
@@ -35,3 +35,34 @@ func TestGenerateSharedRejectsOffCurve(t *testing.T) {
 		t.Fatalf("a shared key was derived from an off-curve point")
 	}
 }
+
+// TestGenerateSharedRejectsUnreducedCoordinates pins the range half of the same
+// guard, which the two build modes would otherwise treat differently: the cgo
+// curve's IsOnCurve rejects a coordinate at or above P, while btcec converts to
+// Jacobian coordinates first and so tests it as if it had been reduced. Adding
+// P to a valid coordinate produces exactly that input.
+func TestGenerateSharedRejectsUnreducedCoordinates(t *testing.T) {
+	prv, err := GenerateKey(rand.Reader, crypto.S256(), nil)
+	if err != nil {
+		t.Fatalf("key generation failed: %v", err)
+	}
+	p := prv.PublicKey.Curve.Params().P
+
+	for _, tc := range []struct {
+		name string
+		x, y *big.Int
+	}{
+		{"x above P", new(big.Int).Add(prv.PublicKey.X, p), prv.PublicKey.Y},
+		{"y above P", prv.PublicKey.X, new(big.Int).Add(prv.PublicKey.Y, p)},
+		{"x negative", new(big.Int).Neg(prv.PublicKey.X), prv.PublicKey.Y},
+	} {
+		pub := &PublicKey{X: tc.x, Y: tc.y, Curve: prv.PublicKey.Curve, Params: prv.PublicKey.Params}
+		sk, err := prv.GenerateShared(pub, 16, 16)
+		if err != ErrInvalidPublicKey {
+			t.Errorf("%s: want ErrInvalidPublicKey, got %v", tc.name, err)
+		}
+		if sk != nil {
+			t.Errorf("%s: a shared key was derived", tc.name)
+		}
+	}
+}

--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -95,9 +95,21 @@ func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
 	// Reject coordinates that are negative or not fully reduced modulo P.
 	// Without this bound, a malformed point supplied by a remote peer during
 	// the RLPx handshake can satisfy the curve equation modulo P yet feed an
-	// out-of-range value into the scalar-multiplication path. This is the
-	// chokepoint elliptic.Unmarshal uses to validate decoded points, so it
-	// guards both the Go and CGo ScalarMult paths. (CVE-2026-26313/26314/26315)
+	// out-of-range value into the scalar-multiplication path.
+	// (CVE-2026-26314/26315, upstream 895a8597c)
+	//
+	// This is the chokepoint elliptic.Unmarshal uses to validate decoded points,
+	// so it guards both the Go and CGo ScalarMult paths. That holds because
+	// BitCurve does not implement crypto/elliptic's unmarshaler interface, which
+	// requires both Unmarshal and UnmarshalCompressed: elliptic.Unmarshal only
+	// delegates to a curve that implements both, and otherwise runs its own
+	// decoder, which range-checks and then calls IsOnCurve. BitCurve.Unmarshal
+	// alone does neither check, so adding UnmarshalCompressed here would silently
+	// route decoding around this guard. Keep them together or not at all.
+	//
+	// CVE-2026-26313 was listed here in an earlier version of this comment and
+	// does not belong: it is a memory-exhaustion issue in p2p message decoding,
+	// handled in eth/protocols/eth/response_gate.go.
 	if x.Sign() < 0 || y.Sign() < 0 || x.Cmp(BitCurve.P) >= 0 || y.Cmp(BitCurve.P) >= 0 {
 		return false
 	}

--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -98,9 +98,12 @@ func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
 	// out-of-range value into the scalar-multiplication path.
 	// (CVE-2026-26314/26315, upstream 895a8597c)
 	//
-	// This is the chokepoint elliptic.Unmarshal uses to validate decoded points,
-	// so it guards both the Go and CGo ScalarMult paths. That holds because
-	// BitCurve does not implement crypto/elliptic's unmarshaler interface, which
+	// This is the chokepoint elliptic.Unmarshal uses to validate decoded points
+	// in this package, which is the cgo build. The non-cgo build resolves S256()
+	// to btcec and gets the same range check from crypto.btCurve.IsOnCurve; the
+	// two are deliberately kept equivalent. That the chokepoint applies at all
+	// holds because BitCurve does not implement crypto/elliptic's unmarshaler
+	// interface, which
 	// requires both Unmarshal and UnmarshalCompressed: elliptic.Unmarshal only
 	// delegates to a curve that implements both, and otherwise runs its own
 	// decoder, which range-checks and then calls IsOnCurve. BitCurve.Unmarshal

--- a/crypto/secp256k1/ext.h
+++ b/crypto/secp256k1/ext.h
@@ -109,8 +109,14 @@ int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point,
 	ARG_CHECK(scalar != NULL);
 	(void)ctx;
 
-	secp256k1_fe_set_b32(&feX, point);
-	secp256k1_fe_set_b32(&feY, point+32);
+	/* Refuse a coordinate that does not fit the field. Upstream go-ethereum
+	   added this in "crypto/secp256k1: fix coordinate check" (895a8597c,
+	   CVE-2026-26314); without it an out-of-range coordinate is silently
+	   reduced and multiplied. */
+	if (!secp256k1_fe_set_b32(&feX, point) ||
+		!secp256k1_fe_set_b32(&feY, point+32)) {
+		return 0;
+	}
 	secp256k1_ge_set_xy(&ge, &feX, &feY);
 	secp256k1_scalar_set_b32(&s, scalar, &overflow);
 	if (overflow || secp256k1_scalar_is_zero(&s)) {

--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -196,11 +196,19 @@ func (p *Peer) dispatcher() {
 			req.Sent = time.Now()
 
 			requestTracker.Track(p.id, p.version, req.code, req.want, req.id)
+
+			// Make the id visible to the response gate before the request goes
+			// out, so a peer that answers instantly cannot be gated out by an
+			// index that has not caught up. See response_gate.go.
+			p.trackPending(req.id)
+
 			err := p2p.Send(p.rw, req.code, req.data)
 			reqOp.fail <- err
 
 			if err == nil {
 				pending[req.id] = req
+			} else {
+				p.untrackPending(req.id)
 			}
 
 		case cancelOp := <-p.reqCancel:
@@ -213,6 +221,7 @@ func (p *Peer) dispatcher() {
 			}
 			// Stop tracking the request
 			delete(pending, cancelOp.id)
+			p.untrackPending(cancelOp.id)
 			cancelOp.fail <- nil
 
 		case resOp := <-p.resDispatch:
@@ -245,6 +254,7 @@ func (p *Peer) dispatcher() {
 
 				// Stop tracking the request, the response dispatcher will deliver
 				delete(pending, res.id)
+				p.untrackPending(res.id)
 			}
 
 		case <-p.term:

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -314,9 +314,18 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 func handleBlockHeaders(backend Backend, msg Decoder, peer *Peer) error {
-	// A batch of headers arrived to one of our previous requests
-	res := new(BlockHeadersPacket)
-	if err := msg.Decode(res); err != nil {
+	// A batch of headers arrived to one of our previous requests. Confirm it was
+	// one of ours before decoding the payload — see response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(BlockHeadersMsg, env.RequestId)
+		return nil
+	}
+	res := &BlockHeadersPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.BlockHeadersRequest); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	metadata := func() interface{} {
@@ -334,9 +343,18 @@ func handleBlockHeaders(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 func handleBlockBodies(backend Backend, msg Decoder, peer *Peer) error {
-	// A batch of block bodies arrived to one of our previous requests
-	res := new(BlockBodiesPacket)
-	if err := msg.Decode(res); err != nil {
+	// A batch of block bodies arrived to one of our previous requests. Confirm it
+	// was one of ours before decoding the payload — see response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(BlockBodiesMsg, env.RequestId)
+		return nil
+	}
+	res := &BlockBodiesPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.BlockBodiesResponse); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	metadata := func() interface{} {
@@ -363,9 +381,18 @@ func handleBlockBodies(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 func handleReceipts(backend Backend, msg Decoder, peer *Peer) error {
-	// A batch of receipts arrived to one of our previous requests
-	res := new(ReceiptsPacket)
-	if err := msg.Decode(res); err != nil {
+	// A batch of receipts arrived to one of our previous requests. Confirm it was
+	// one of ours before decoding the payload — see response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(ReceiptsMsg, env.RequestId)
+		return nil
+	}
+	res := &ReceiptsPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.ReceiptsResponse); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	metadata := func() interface{} {
@@ -466,9 +493,23 @@ func handlePooledTransactions(backend Backend, msg Decoder, peer *Peer) error {
 	if !backend.AcceptTxs() {
 		return nil
 	}
+	// Confirm the reply belongs to a retrieval we asked this peer for before
+	// decoding the transactions — see response_gate.go. Pooled transactions do
+	// not go through the dispatcher, so RequestTxs registers the id itself and
+	// this is where it is retired.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(PooledTransactionsMsg, env.RequestId)
+		return nil
+	}
+	peer.untrackPending(env.RequestId)
+
 	// Transactions can be processed, parse all of them and deliver to the pool
-	var txs PooledTransactionsPacket
-	if err := msg.Decode(&txs); err != nil {
+	txs := PooledTransactionsPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &txs.PooledTransactionsResponse); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	for i, tx := range txs.PooledTransactionsResponse {

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	metaapi "github.com/ethereum/go-ethereum/metadium/api"
 	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // Concurrency caps for the asynchronous Metadium message handlers below. Each
@@ -59,8 +60,22 @@ func handleGetBlobSidecars69(backend Backend, msg Decoder, peer *Peer) error {
 // handleBlobSidecars69 forwards a received blob-sidecar reply to the backend,
 // which correlates it with the in-flight request and validates/persists it.
 func handleBlobSidecars69(backend Backend, msg Decoder, peer *Peer) error {
-	var res BlobSidecarsPacket
-	if err := msg.Decode(&res); err != nil {
+	// Confirm this reply answers a fetch we issued before decoding the sidecars.
+	// A sidecar is up to 128KB of blob plus commitments, so this is the largest
+	// amplification the protocol offers an unsolicited sender. See
+	// response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(BlobSidecarsMsg, env.RequestId)
+		return nil
+	}
+	peer.untrackPending(env.RequestId)
+
+	res := BlobSidecarsPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.Sidecars); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	return backend.Handle(peer, &res)

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -316,11 +316,12 @@ func handleGetNodeData(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 // handleNodeData handles a NodeData response from an eth/66 peer.
-// Since we don't request node data, this is a no-op.
+//
+// This node never sends GetNodeData, so every one of these is unsolicited by
+// definition and there is nothing to match it against — the message carries no
+// request id. Discarding it without decoding is the same property the response
+// gate gives the dispatcher-path responses: a peer cannot make us expand a
+// payload we never asked for.
 func handleNodeData(backend Backend, msg Decoder, peer *Peer) error {
-	var data NodeDataPacket
-	if err := msg.Decode(&data); err != nil {
-		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
-	}
 	return nil
 }

--- a/eth/protocols/eth/metadium_peer.go
+++ b/eth/protocols/eth/metadium_peer.go
@@ -71,6 +71,12 @@ func (p *Peer) SendNodeData(data [][]byte) error {
 func (p *Peer) RequestBlobSidecars(id uint64, hashes []common.Hash) error {
 	p.Log().Debug("Fetching blob sidecars", "count", len(hashes))
 	requestTracker.Track(p.id, p.version, GetBlobSidecarsMsg, BlobSidecarsMsg, id)
+
+	// Blob sidecars are the largest payload this protocol carries, and this
+	// request also bypasses the dispatcher, so register the id for the response
+	// gate here; handleBlobSidecars69 retires it. See response_gate.go.
+	p.trackPending(id)
+
 	return p2p.Send(p.rw, GetBlobSidecarsMsg, &GetBlobSidecarsPacket{
 		RequestId: id,
 		Hashes:    hashes,

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -89,6 +89,16 @@ type Peer struct {
 	reqCancel   chan *cancel   // Dispatch channel to cancel pending requests and untrack them
 	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
 
+	// pendingIDs mirrors the dispatcher's pending request ids so that a message
+	// handler can tell whether a response was solicited before it decodes the
+	// payload. See response_gate.go. Written by the dispatcher goroutine and by
+	// the meta/69 blob-sidecar requester, read by the message-handling
+	// goroutine, hence its own lock rather than the field lock below.
+	pendingIDs  map[uint64]struct{}
+	pendingRing [maxPendingIDs]uint64 // insertion order, to bound the index
+	pendingPos  int
+	pendingLock sync.RWMutex
+
 	term chan struct{} // Termination channel to stop the broadcasters
 	lock sync.RWMutex  // Mutex protecting the internal fields
 
@@ -117,6 +127,7 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Pe
 		reqDispatch:     make(chan *request),
 		reqCancel:       make(chan *cancel),
 		resDispatch:     make(chan *response),
+		pendingIDs:      make(map[uint64]struct{}),
 		txpool:          txpool,
 		term:            make(chan struct{}),
 	}
@@ -459,6 +470,11 @@ func (p *Peer) RequestTxs(hashes []common.Hash) error {
 	id := rand.Uint64()
 
 	requestTracker.Track(p.id, p.version, GetPooledTransactionsMsg, PooledTransactionsMsg, id)
+
+	// This retrieval bypasses the dispatcher, so register the id for the response
+	// gate here; handlePooledTransactions retires it. See response_gate.go.
+	p.trackPending(id)
+
 	return p2p.Send(p.rw, GetPooledTransactionsMsg, &GetPooledTransactionsPacket{
 		RequestId:                    id,
 		GetPooledTransactionsRequest: hashes,

--- a/eth/protocols/eth/response_gate.go
+++ b/eth/protocols/eth/response_gate.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-metadium library.
+//
+// The go-metadium library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-metadium library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-metadium library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import "github.com/ethereum/go-ethereum/rlp"
+
+// This file keeps a response from being decoded before we know we asked for it.
+//
+// Every response message on this protocol is `[request-id, payload]`. The
+// handlers used to decode the whole thing and only then hand it to the
+// dispatcher, which is where the request id is matched against the in-flight
+// requests. A peer that never received a request from us could therefore make
+// us expand an arbitrary payload — bounded in wire size by maxMessageSize, but
+// not in the size of the Go values it decodes into, which is the amplification
+// that makes it worth anything to an attacker.
+//
+// The gate below is the same property upstream go-ethereum adopted in
+// "eth/protocols/eth, eth/protocols/snap: delayed p2p message decoding"
+// (0cba803fb, v1.17.0, CVE-2026-26313): confirm the response belongs to an
+// active request first, decode second. Upstream's version reaches further —
+// it also defers decoding until the response is checked against the request's
+// limits, and it restructured p2p/tracker into a per-peer instance to do it.
+// That rework sits on the eth/69-72 protocol layout and does not transplant
+// onto this tree; what is here is the part that closes the unsolicited-message
+// path, applied to the dispatcher this fork actually runs.
+//
+// The gate is deliberately keyed on the request id alone. A response whose id
+// is live but whose message code is wrong keeps its existing treatment (the
+// dispatcher reports errMismatchingResponseType and the peer is dropped), so
+// this change only ever converts work that used to happen into work that is
+// skipped.
+
+// maxPendingIDs bounds the gate's index. Not every request path can untrack its
+// id: the dispatcher-managed ones (headers, bodies, receipts) are removed
+// exactly, but pooled transactions and blob sidecars are sent straight to the
+// wire and are only untracked when an answer arrives, so an unanswered request
+// would otherwise sit in the index for the life of the connection.
+//
+// The bound is a ring: inserting past capacity evicts the oldest id. Real
+// concurrency per peer is a handful of requests (the dispatcher's in-flight
+// set, one pooled-transaction retrieval, one serial blob fetch), so eviction
+// only ever reaches ids that have long since gone unanswered. Evicting a live
+// id would drop a legitimate response, which is why the capacity is far above
+// what the request paths can produce.
+const maxPendingIDs = 256
+
+// responseEnvelope decodes the request id of a response message while leaving
+// the payload as raw RLP. The payload is decoded separately, and only once the
+// gate has passed.
+type responseEnvelope struct {
+	RequestId uint64
+	Payload   rlp.RawValue
+}
+
+// trackPending records that a request id was sent to this peer.
+//
+// Registration happens before the request is written to the wire, so a peer
+// that answers immediately cannot have its response gated out by an index that
+// has not caught up yet. The index may therefore hold an id whose send
+// subsequently failed; that is the harmless direction, and untrackPending
+// cleans it up.
+func (p *Peer) trackPending(id uint64) {
+	p.pendingLock.Lock()
+	defer p.pendingLock.Unlock()
+
+	if _, ok := p.pendingIDs[id]; ok {
+		return
+	}
+	// Reclaim the slot this insert is about to take. The id found there may
+	// already have been untracked, in which case the delete is a no-op.
+	if victim := p.pendingRing[p.pendingPos]; victim != 0 {
+		delete(p.pendingIDs, victim)
+	}
+	p.pendingRing[p.pendingPos] = id
+	p.pendingPos = (p.pendingPos + 1) % len(p.pendingRing)
+	p.pendingIDs[id] = struct{}{}
+}
+
+// untrackPending forgets an in-flight request id.
+func (p *Peer) untrackPending(id uint64) {
+	p.pendingLock.Lock()
+	defer p.pendingLock.Unlock()
+	delete(p.pendingIDs, id)
+}
+
+// solicited reports whether the given request id belongs to a request we sent
+// to this peer and have not yet accounted for.
+func (p *Peer) solicited(id uint64) bool {
+	p.pendingLock.RLock()
+	defer p.pendingLock.RUnlock()
+	_, ok := p.pendingIDs[id]
+	return ok
+}
+
+// dropUnsolicited reports the response as dangling and tells the caller to stop
+// processing it. Dropping such a response silently is the pre-existing
+// behaviour: the dispatcher answered an untracked id with errDanglingResponse,
+// which dispatchResponse turned into a nil return. The tracker is still told,
+// so the dangling-response metrics keep counting what they used to count.
+func (p *Peer) dropUnsolicited(code, id uint64) {
+	requestTracker.Fulfil(p.id, p.version, code, id)
+}

--- a/eth/protocols/eth/response_gate_test.go
+++ b/eth/protocols/eth/response_gate_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-metadium library.
+//
+// The go-metadium library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-metadium library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-metadium library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// The tests below distinguish "gated out" from "decoded" by sending a payload
+// that is well-formed RLP but cannot decode into the response type. A handler
+// that decodes before checking the request id reports errDecode; one that
+// gates first returns nil without ever looking at the payload. That makes the
+// undecodable payload the observable, so these tests fail if the gate is
+// removed rather than merely covering it.
+//
+// unpaired is such a payload: a list where the response type expects a list of
+// structs, and whose single element is a string.
+func unpairedPayload(t *testing.T) rlp.RawValue {
+	t.Helper()
+	enc, err := rlp.EncodeToBytes([]string{"not a header"})
+	if err != nil {
+		t.Fatalf("encoding the test payload failed: %v", err)
+	}
+	return enc
+}
+
+// acceptTxsBackend is testBackend with transaction processing turned on.
+// testBackend.AcceptTxs panics on purpose ("data processing tests should be done
+// in the handler package"), and handlePooledTransactions consults it before
+// reaching the gate, so the tests below need this much of a backend.
+type acceptTxsBackend struct{ *testBackend }
+
+func (b acceptTxsBackend) AcceptTxs() bool { return true }
+
+// deliver writes one message into the peer's pipe and returns what the handler
+// made of it.
+func deliver(t *testing.T, peer *Peer, code uint64, id uint64, payload rlp.RawValue,
+	handler func(Backend, Decoder, *Peer) error, backend Backend) error {
+	t.Helper()
+
+	enc, err := rlp.EncodeToBytes(&responseEnvelope{RequestId: id, Payload: payload})
+	if err != nil {
+		t.Fatalf("encoding the envelope failed: %v", err)
+	}
+	app, net := p2p.MsgPipe()
+	defer app.Close()
+	defer net.Close()
+
+	go func() {
+		p2p.Send(app, code, rlp.RawValue(enc))
+	}()
+	msg, err := net.ReadMsg()
+	if err != nil {
+		t.Fatalf("reading the test message failed: %v", err)
+	}
+	defer msg.Discard()
+
+	return handler(backend, msg, peer)
+}
+
+// TestResponseGateDropsUnsolicited checks that a response nobody asked for is
+// dropped before its payload is decoded, for every response message that
+// carries a request id.
+func TestResponseGateDropsUnsolicited(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("gate", ETH69, backend)
+	processing := acceptTxsBackend{backend}
+	defer peer.close()
+
+	payload := unpairedPayload(t)
+
+	for _, tt := range []struct {
+		name    string
+		code    uint64
+		handler func(Backend, Decoder, *Peer) error
+	}{
+		{"headers", BlockHeadersMsg, handleBlockHeaders},
+		{"bodies", BlockBodiesMsg, handleBlockBodies},
+		{"receipts", ReceiptsMsg, handleReceipts},
+		{"pooled transactions", PooledTransactionsMsg, handlePooledTransactions},
+		{"blob sidecars", BlobSidecarsMsg, handleBlobSidecars69},
+	} {
+		// 0xdead was never requested from this peer.
+		if err := deliver(t, peer.Peer, tt.code, 0xdead, payload, tt.handler, processing); err != nil {
+			t.Errorf("%s: unsolicited response was processed instead of dropped: %v", tt.name, err)
+		}
+	}
+}
+
+// TestResponseGateDecodesSolicited is the other half: once the id is in flight,
+// the payload is decoded, and a payload that cannot be decoded is reported as
+// such. Without this, a gate that dropped everything would pass the test above.
+func TestResponseGateDecodesSolicited(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("gate", ETH69, backend)
+	processing := acceptTxsBackend{backend}
+	defer peer.close()
+
+	payload := unpairedPayload(t)
+
+	for _, tt := range []struct {
+		name    string
+		code    uint64
+		handler func(Backend, Decoder, *Peer) error
+	}{
+		{"headers", BlockHeadersMsg, handleBlockHeaders},
+		{"bodies", BlockBodiesMsg, handleBlockBodies},
+		{"receipts", ReceiptsMsg, handleReceipts},
+		{"pooled transactions", PooledTransactionsMsg, handlePooledTransactions},
+		{"blob sidecars", BlobSidecarsMsg, handleBlobSidecars69},
+	} {
+		const id = 0xbeef
+		peer.Peer.trackPending(id)
+
+		err := deliver(t, peer.Peer, tt.code, id, payload, tt.handler, processing)
+		if !errors.Is(err, errDecode) {
+			t.Errorf("%s: solicited response was not decoded (want errDecode, got %v)", tt.name, err)
+		}
+		peer.Peer.untrackPending(id)
+	}
+}
+
+// TestPendingIndexBounded checks that the index cannot grow without bound. The
+// paths that bypass the dispatcher only untrack on an answer, so an unanswered
+// request must not accumulate for the life of the connection.
+func TestPendingIndexBounded(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("bounded", ETH69, backend)
+	defer peer.close()
+
+	for i := uint64(1); i <= maxPendingIDs*3; i++ {
+		peer.Peer.trackPending(i)
+	}
+	peer.Peer.pendingLock.RLock()
+	size := len(peer.Peer.pendingIDs)
+	peer.Peer.pendingLock.RUnlock()
+
+	if size > maxPendingIDs {
+		t.Fatalf("pending index grew past its bound: %d > %d", size, maxPendingIDs)
+	}
+	// The most recent ids must have survived the eviction, or the gate would
+	// drop responses to requests that are actually in flight.
+	for i := uint64(maxPendingIDs*3 - 10); i <= maxPendingIDs*3; i++ {
+		if !peer.Peer.solicited(i) {
+			t.Fatalf("recent request id %d was evicted", i)
+		}
+	}
+	// And the oldest must be gone, which is what keeps the bound.
+	if peer.Peer.solicited(1) {
+		t.Fatalf("oldest request id was not evicted")
+	}
+}
+
+// TestTrackPendingIdempotent guards the ring bookkeeping: registering the same
+// id twice must not consume two slots, or a retried request would shrink the
+// effective capacity.
+func TestTrackPendingIdempotent(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("idempotent", ETH69, backend)
+	defer peer.close()
+
+	for i := 0; i < maxPendingIDs*2; i++ {
+		peer.Peer.trackPending(7)
+	}
+	peer.Peer.pendingLock.RLock()
+	size := len(peer.Peer.pendingIDs)
+	peer.Peer.pendingLock.RUnlock()
+
+	if size != 1 {
+		t.Fatalf("re-tracking one id filled the index: size %d", size)
+	}
+	if !peer.Peer.solicited(7) {
+		t.Fatalf("re-tracked id was evicted by itself")
+	}
+}

--- a/p2p/rlpx/rlpx_invalid_curve_test.go
+++ b/p2p/rlpx/rlpx_invalid_curve_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rlpx
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+)
+
+// TestHandshakeECIESInvalidCurve is upstream go-ethereum's proof for
+// CVE-2026-26315 (46bee92f9), ported as a regression test.
+//
+// The handshake decrypts unauthenticated network input. An ephemeral public key
+// that is not on the curve must be refused outright; if it reaches ECDH and
+// fails later at MAC verification, the difference in error and in work done is
+// an oracle.
+//
+// This tree already satisfies that: Decrypt decodes the point with
+// elliptic.Unmarshal, which validates it here (see crypto/secp256k1/curve.go on
+// the unmarshaler interface), so the packet is rejected with ErrInvalidPublicKey
+// with or without the guard added to GenerateShared. The test therefore pins the
+// handshake's behaviour rather than proving that guard — the direct proof for it
+// is TestGenerateSharedRejectsOffCurve in crypto/ecies.
+func TestHandshakeECIESInvalidCurve(t *testing.T) {
+	initKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	respKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	init := handshakeState{
+		initiator: true,
+		remote:    ecies.ImportECDSAPublic(&respKey.PublicKey),
+	}
+	authMsg, err := init.makeAuthMsg(initKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet, err := init.sealEIP8(authMsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The untampered packet has to decrypt, or the test below would pass for
+	// the wrong reason.
+	var recv handshakeState
+	if _, err := recv.readMsg(new(authMsgV4), respKey, bytes.NewReader(packet)); err != nil {
+		t.Fatalf("valid handshake packet failed to decrypt: %v", err)
+	}
+
+	// Replace the ephemeral point with (0, 0), which is a well-formed
+	// uncompressed encoding of a point that is not on secp256k1.
+	tampered := append([]byte(nil), packet...)
+	if len(tampered) < 2+65 {
+		t.Fatalf("unexpected packet length %d", len(tampered))
+	}
+	tampered[2] = 0x04
+	for i := 1; i < 65; i++ {
+		tampered[2+i] = 0x00
+	}
+
+	var recv2 handshakeState
+	_, err = recv2.readMsg(new(authMsgV4), respKey, bytes.NewReader(tampered))
+	if err == nil {
+		t.Fatal("handshake accepted a point that is not on the curve")
+	}
+	if !errors.Is(err, ecies.ErrInvalidPublicKey) {
+		t.Fatalf("want ErrInvalidPublicKey, got %v", err)
+	}
+}


### PR DESCRIPTION
Fourth in the queued cleanups, and like #91, #92 and #93 it is **opened for review only — merging waits until after the 2026-08-27 fork**. It shares no file with those three, so it can be read independently of them.

Two commits, and they differ in kind: the first closes a real path, the second is insurance whose rationale is the interesting part.

## 1. Gate responses on having asked for them (CVE-2026-26313)

Every response on this protocol is `[request-id, payload]`, and the handlers decoded the whole message before handing it to the dispatcher — which is where the request id is matched against what we actually asked for. A peer that had received no request from us could therefore make us expand an arbitrary payload. The wire size is capped at `maxMessageSize`; the size of the Go values it decodes into is not, and that amplification is the point of the attack.

Upstream adopted "confirm first, decode second" for this in `0cba803fb` (v1.17.0), but that change does not transplant: it reaches further (decoding is also deferred until the response is checked against the request's limits) and gets there by restructuring `p2p/tracker` into a per-peer instance across the eth/69-72 protocol layout — 26 files against a tree we do not have. What this implements is the part that closes the unsolicited path, on the dispatcher this fork runs:

- `responseEnvelope` decodes the request id and keeps the payload as raw RLP;
- the peer carries an index of request ids it has sent, mirroring the dispatcher's pending map, which the message-handling goroutine cannot read;
- `handleBlockHeaders`, `handleBlockBodies`, `handleReceipts`, `handlePooledTransactions` and `handleBlobSidecars69` consult it, and decode the payload only after it answers yes.

Three design points worth stating explicitly, since each is a place where the obvious choice is the wrong one:

**Registration happens before the request is written to the wire.** Doing it after the send would let a peer that answers instantly have its response gated out by an index that had not caught up. Failing open in that direction is the harmless one; a failed send untracks the id again.

**The gate keys on the request id alone.** A response whose id is live but whose message code is wrong keeps its existing treatment, so this only ever turns work that used to happen into work that is skipped — it cannot reject anything the old code accepted.

**The index is a bounded 256-entry ring.** Pooled transactions and blob sidecars bypass the dispatcher and are only untracked when an answer arrives, so an unanswered request would otherwise sit there for the life of the connection. Real per-peer concurrency is a handful of requests, so eviction only ever reaches ids that have long gone unanswered.

## 2. Port the point-validation guards, and correct a CVE reference

Three upstream fixes for the RLPx handshake advisories were never ported: `crypto/ecies.GenerateShared` refusing an off-curve point (`46bee92f9`, CVE-2026-26315), `crypto.UnmarshalPubkey` checking the decoded point (`159fb1a1d`, CVE-2025-24883), and `crypto/secp256k1/ext.h` refusing a coordinate that does not fit the field instead of silently reducing it (`895a8597c`, CVE-2026-26314).

**None of them closes a hole in this tree**, and the PR says so rather than claiming credit it does not have. An off-curve point arriving over the wire is decoded by `elliptic.Unmarshal`, which validates — range plus `IsOnCurve` — for every curve that does not implement its unmarshaler interface. That interface requires *both* `Unmarshal` and `UnmarshalCompressed`; secp256k1's `BitCurve` implements only the first, and btcec's `KoblitzCurve` (what `S256()` resolves to without cgo) implements neither. Both build modes therefore already take the validating path, which the added handshake test traces: a tampered packet is refused at the `Unmarshal` check, with or without the `GenerateShared` guard.

Upstream needed the explicit checks because their curve types *do* implement the interface and so bypass that validation. The value here is insurance of a specific shape: the checks stop depending on a property of the curve types that a later `UnmarshalCompressed` method would quietly remove.

Also corrected: the comment on `BitCurve.IsOnCurve` listed CVE-2026-26313 among what it guards. That advisory is the p2p decoding issue commit 1 addresses — unrelated to coordinate validation — and reading the comment as coverage for it would have hidden the real gap. The comment now names the interface property the chokepoint claim actually rests on, so that adding `UnmarshalCompressed` to `BitCurve` cannot look harmless.

## Verification

- `CGO_ENABLED=1 go test ./eth/protocols/eth/ ./crypto/... ./p2p/rlpx/ ./p2p/enode/` — pass
- `CGO_ENABLED=0 go test ./crypto/ ./crypto/ecies/ ./p2p/rlpx/ ./eth/protocols/eth/` — pass (the btcec path)
- `go test ./eth/downloader/... ./eth/fetcher/...` — pass; the solicited path is unchanged
- A/B on the gate: `TestResponseGateDropsUnsolicited` (dropped) and `TestResponseGateDecodesSolicited` (reaches the decoder and reports `errDecode`) split on the same message, which is what shows the gate keys on solicitation rather than on content
- A/B on the guard: `TestGenerateSharedRejectsOffCurve` fails without it, with `ErrSharedKeyIsPointAtInfinity` instead of `ErrInvalidPublicKey`
- `go vet` clean, `gofmt` clean
