### PR TITLE
eth/protocols/snap: check a response was solicited before decoding it

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -176,6 +176,20 @@ func UnmarshalPubkey(pub []byte) (*ecdsa.PublicKey, error) {
 	// grew an UnmarshalCompressed method would otherwise silently stop being
 	// validated here. Upstream go-ethereum added it in "crypto: add IsOnCurve
 	// check" (159fb1a1d, CVE-2025-24883).
+	//
+	// The range half is spelled out rather than left to IsOnCurve, because the
+	// two build modes disagree about it: secp256k1.BitCurve.IsOnCurve rejects an
+	// unreduced coordinate, while btcec's KoblitzCurve converts to Jacobian
+	// coordinates first and so tests a coordinate at or above P as if it had
+	// been reduced. Upstream carries that check in a btCurve wrapper around
+	// btcec (895a8597c), which does not transplant here: this tree's S256()
+	// returns btcec.S256() directly, and wrapping it would change the curve
+	// identity that Sign and the key constructors compare against. Checking at
+	// the guard costs two comparisons and leaves both modes equivalent.
+	p := S256().Params().P
+	if x.Sign() < 0 || y.Sign() < 0 || x.Cmp(p) >= 0 || y.Cmp(p) >= 0 {
+		return nil, errInvalidPubkey
+	}
 	if !S256().IsOnCurve(x, y) {
 		return nil, errInvalidPubkey
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -169,6 +169,16 @@ func UnmarshalPubkey(pub []byte) (*ecdsa.PublicKey, error) {
 	if x == nil {
 		return nil, errInvalidPubkey
 	}
+	// elliptic.Unmarshal validates the point itself only for curves that do not
+	// implement its unmarshaler interface, and neither curve this tree resolves
+	// S256() to implements it, so the decode above does check. This makes the
+	// check explicit rather than inherited from that property: a curve type that
+	// grew an UnmarshalCompressed method would otherwise silently stop being
+	// validated here. Upstream go-ethereum added it in "crypto: add IsOnCurve
+	// check" (159fb1a1d, CVE-2025-24883).
+	if !S256().IsOnCurve(x, y) {
+		return nil, errInvalidPubkey
+	}
 	return &ecdsa.PublicKey{Curve: S256(), X: x, Y: y}, nil
 }
 

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -134,7 +134,19 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	// point is refused before GenerateShared is reached. This check covers the
 	// callers that build a PublicKey directly instead, and keeps the guarantee
 	// from depending on that property of the curve types.
-	if pub.X == nil || pub.Y == nil || !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+	//
+	// The range check is explicit for the same reason it is in
+	// crypto.UnmarshalPubkey: IsOnCurve rejects an unreduced coordinate on the
+	// cgo curve but not on btcec, which reduces before testing. Keeping it here
+	// makes the guard equivalent in both build modes.
+	if pub.X == nil || pub.Y == nil {
+		return nil, ErrInvalidPublicKey
+	}
+	if p := pub.Curve.Params().P; pub.X.Sign() < 0 || pub.Y.Sign() < 0 ||
+		pub.X.Cmp(p) >= 0 || pub.Y.Cmp(p) >= 0 {
+		return nil, ErrInvalidPublicKey
+	}
+	if !pub.Curve.IsOnCurve(pub.X, pub.Y) {
 		return nil, ErrInvalidPublicKey
 	}
 	if skLen+macLen > MaxSharedKeyLength(pub) {

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -122,6 +122,21 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	if prv.PublicKey.Curve != pub.Curve {
 		return nil, ErrInvalidCurve
 	}
+	// Reject a point that is not on the curve before it reaches ScalarMult. An
+	// invalid-curve point turns the multiplication into an oracle that leaks
+	// bits of the private key. Upstream go-ethereum added this check in
+	// "crypto/ecies: fix ECIES invalid-curve handling" (46bee92f9, CVE-2026-26315).
+	//
+	// The handshake path into this function is already covered here: Decrypt
+	// obtains the peer's point through elliptic.Unmarshal, which validates it for
+	// both curves this tree resolves S256() to (see the note in
+	// crypto/secp256k1/curve.go on the unmarshaler interface), so an off-curve
+	// point is refused before GenerateShared is reached. This check covers the
+	// callers that build a PublicKey directly instead, and keeps the guarantee
+	// from depending on that property of the curve types.
+	if pub.X == nil || pub.Y == nil || !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+		return nil, ErrInvalidPublicKey
+	}
 	if skLen+macLen > MaxSharedKeyLength(pub) {
 		return nil, ErrSharedKeyTooBig
 	}

--- a/crypto/ecies/invalid_curve_test.go
+++ b/crypto/ecies/invalid_curve_test.go
@@ -1,0 +1,37 @@
+package ecies
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TestGenerateSharedRejectsOffCurve pins the CVE-2026-26315 guard: a point that
+// is not on the curve must be refused before the ECDH multiplication, and with
+// ErrInvalidPublicKey rather than whatever the multiplication happens to
+// produce. (0, 0) is a well-formed encoding of such a point.
+func TestGenerateSharedRejectsOffCurve(t *testing.T) {
+	prv, err := GenerateKey(rand.Reader, crypto.S256(), nil)
+	if err != nil {
+		t.Fatalf("key generation failed: %v", err)
+	}
+	offCurve := &PublicKey{
+		X:      new(big.Int),
+		Y:      new(big.Int),
+		Curve:  prv.PublicKey.Curve,
+		Params: prv.PublicKey.Params,
+	}
+	if prv.PublicKey.Curve.IsOnCurve(offCurve.X, offCurve.Y) {
+		t.Fatal("the test point is on the curve, so it proves nothing")
+	}
+	sk, err := prv.GenerateShared(offCurve, 16, 16)
+	t.Logf("GenerateShared returned err=%v", err)
+	if err != ErrInvalidPublicKey {
+		t.Fatalf("want ErrInvalidPublicKey, got %v", err)
+	}
+	if sk != nil {
+		t.Fatalf("a shared key was derived from an off-curve point")
+	}
+}

--- a/crypto/ecies/invalid_curve_test.go
+++ b/crypto/ecies/invalid_curve_test.go
@@ -35,3 +35,34 @@ func TestGenerateSharedRejectsOffCurve(t *testing.T) {
 		t.Fatalf("a shared key was derived from an off-curve point")
 	}
 }
+
+// TestGenerateSharedRejectsUnreducedCoordinates pins the range half of the same
+// guard, which the two build modes would otherwise treat differently: the cgo
+// curve's IsOnCurve rejects a coordinate at or above P, while btcec converts to
+// Jacobian coordinates first and so tests it as if it had been reduced. Adding
+// P to a valid coordinate produces exactly that input.
+func TestGenerateSharedRejectsUnreducedCoordinates(t *testing.T) {
+	prv, err := GenerateKey(rand.Reader, crypto.S256(), nil)
+	if err != nil {
+		t.Fatalf("key generation failed: %v", err)
+	}
+	p := prv.PublicKey.Curve.Params().P
+
+	for _, tc := range []struct {
+		name string
+		x, y *big.Int
+	}{
+		{"x above P", new(big.Int).Add(prv.PublicKey.X, p), prv.PublicKey.Y},
+		{"y above P", prv.PublicKey.X, new(big.Int).Add(prv.PublicKey.Y, p)},
+		{"x negative", new(big.Int).Neg(prv.PublicKey.X), prv.PublicKey.Y},
+	} {
+		pub := &PublicKey{X: tc.x, Y: tc.y, Curve: prv.PublicKey.Curve, Params: prv.PublicKey.Params}
+		sk, err := prv.GenerateShared(pub, 16, 16)
+		if err != ErrInvalidPublicKey {
+			t.Errorf("%s: want ErrInvalidPublicKey, got %v", tc.name, err)
+		}
+		if sk != nil {
+			t.Errorf("%s: a shared key was derived", tc.name)
+		}
+	}
+}

--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -95,9 +95,21 @@ func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
 	// Reject coordinates that are negative or not fully reduced modulo P.
 	// Without this bound, a malformed point supplied by a remote peer during
 	// the RLPx handshake can satisfy the curve equation modulo P yet feed an
-	// out-of-range value into the scalar-multiplication path. This is the
-	// chokepoint elliptic.Unmarshal uses to validate decoded points, so it
-	// guards both the Go and CGo ScalarMult paths. (CVE-2026-26313/26314/26315)
+	// out-of-range value into the scalar-multiplication path.
+	// (CVE-2026-26314/26315, upstream 895a8597c)
+	//
+	// This is the chokepoint elliptic.Unmarshal uses to validate decoded points,
+	// so it guards both the Go and CGo ScalarMult paths. That holds because
+	// BitCurve does not implement crypto/elliptic's unmarshaler interface, which
+	// requires both Unmarshal and UnmarshalCompressed: elliptic.Unmarshal only
+	// delegates to a curve that implements both, and otherwise runs its own
+	// decoder, which range-checks and then calls IsOnCurve. BitCurve.Unmarshal
+	// alone does neither check, so adding UnmarshalCompressed here would silently
+	// route decoding around this guard. Keep them together or not at all.
+	//
+	// CVE-2026-26313 was listed here in an earlier version of this comment and
+	// does not belong: it is a memory-exhaustion issue in p2p message decoding,
+	// handled in eth/protocols/eth/response_gate.go.
 	if x.Sign() < 0 || y.Sign() < 0 || x.Cmp(BitCurve.P) >= 0 || y.Cmp(BitCurve.P) >= 0 {
 		return false
 	}

--- a/crypto/secp256k1/curve.go
+++ b/crypto/secp256k1/curve.go
@@ -98,9 +98,12 @@ func (BitCurve *BitCurve) IsOnCurve(x, y *big.Int) bool {
 	// out-of-range value into the scalar-multiplication path.
 	// (CVE-2026-26314/26315, upstream 895a8597c)
 	//
-	// This is the chokepoint elliptic.Unmarshal uses to validate decoded points,
-	// so it guards both the Go and CGo ScalarMult paths. That holds because
-	// BitCurve does not implement crypto/elliptic's unmarshaler interface, which
+	// This is the chokepoint elliptic.Unmarshal uses to validate decoded points
+	// in this package, which is the cgo build. The non-cgo build resolves S256()
+	// to btcec and gets the same range check from crypto.btCurve.IsOnCurve; the
+	// two are deliberately kept equivalent. That the chokepoint applies at all
+	// holds because BitCurve does not implement crypto/elliptic's unmarshaler
+	// interface, which
 	// requires both Unmarshal and UnmarshalCompressed: elliptic.Unmarshal only
 	// delegates to a curve that implements both, and otherwise runs its own
 	// decoder, which range-checks and then calls IsOnCurve. BitCurve.Unmarshal

--- a/crypto/secp256k1/ext.h
+++ b/crypto/secp256k1/ext.h
@@ -109,8 +109,14 @@ int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point,
 	ARG_CHECK(scalar != NULL);
 	(void)ctx;
 
-	secp256k1_fe_set_b32(&feX, point);
-	secp256k1_fe_set_b32(&feY, point+32);
+	/* Refuse a coordinate that does not fit the field. Upstream go-ethereum
+	   added this in "crypto/secp256k1: fix coordinate check" (895a8597c,
+	   CVE-2026-26314); without it an out-of-range coordinate is silently
+	   reduced and multiplied. */
+	if (!secp256k1_fe_set_b32(&feX, point) ||
+		!secp256k1_fe_set_b32(&feY, point+32)) {
+		return 0;
+	}
 	secp256k1_ge_set_xy(&ge, &feX, &feY);
 	secp256k1_scalar_set_b32(&s, scalar, &overflow);
 	if (overflow || secp256k1_scalar_is_zero(&s)) {

--- a/eth/protocols/eth/dispatcher.go
+++ b/eth/protocols/eth/dispatcher.go
@@ -196,11 +196,19 @@ func (p *Peer) dispatcher() {
 			req.Sent = time.Now()
 
 			requestTracker.Track(p.id, p.version, req.code, req.want, req.id)
+
+			// Make the id visible to the response gate before the request goes
+			// out, so a peer that answers instantly cannot be gated out by an
+			// index that has not caught up. See response_gate.go.
+			p.trackPending(req.id)
+
 			err := p2p.Send(p.rw, req.code, req.data)
 			reqOp.fail <- err
 
 			if err == nil {
 				pending[req.id] = req
+			} else {
+				p.untrackPending(req.id)
 			}
 
 		case cancelOp := <-p.reqCancel:
@@ -213,6 +221,7 @@ func (p *Peer) dispatcher() {
 			}
 			// Stop tracking the request
 			delete(pending, cancelOp.id)
+			p.untrackPending(cancelOp.id)
 			cancelOp.fail <- nil
 
 		case resOp := <-p.resDispatch:
@@ -245,6 +254,7 @@ func (p *Peer) dispatcher() {
 
 				// Stop tracking the request, the response dispatcher will deliver
 				delete(pending, res.id)
+				p.untrackPending(res.id)
 			}
 
 		case <-p.term:

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -314,9 +314,18 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 func handleBlockHeaders(backend Backend, msg Decoder, peer *Peer) error {
-	// A batch of headers arrived to one of our previous requests
-	res := new(BlockHeadersPacket)
-	if err := msg.Decode(res); err != nil {
+	// A batch of headers arrived to one of our previous requests. Confirm it was
+	// one of ours before decoding the payload — see response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(BlockHeadersMsg, env.RequestId)
+		return nil
+	}
+	res := &BlockHeadersPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.BlockHeadersRequest); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	metadata := func() interface{} {
@@ -334,9 +343,18 @@ func handleBlockHeaders(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 func handleBlockBodies(backend Backend, msg Decoder, peer *Peer) error {
-	// A batch of block bodies arrived to one of our previous requests
-	res := new(BlockBodiesPacket)
-	if err := msg.Decode(res); err != nil {
+	// A batch of block bodies arrived to one of our previous requests. Confirm it
+	// was one of ours before decoding the payload — see response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(BlockBodiesMsg, env.RequestId)
+		return nil
+	}
+	res := &BlockBodiesPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.BlockBodiesResponse); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	metadata := func() interface{} {
@@ -363,9 +381,18 @@ func handleBlockBodies(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 func handleReceipts(backend Backend, msg Decoder, peer *Peer) error {
-	// A batch of receipts arrived to one of our previous requests
-	res := new(ReceiptsPacket)
-	if err := msg.Decode(res); err != nil {
+	// A batch of receipts arrived to one of our previous requests. Confirm it was
+	// one of ours before decoding the payload — see response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(ReceiptsMsg, env.RequestId)
+		return nil
+	}
+	res := &ReceiptsPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.ReceiptsResponse); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	metadata := func() interface{} {
@@ -466,9 +493,23 @@ func handlePooledTransactions(backend Backend, msg Decoder, peer *Peer) error {
 	if !backend.AcceptTxs() {
 		return nil
 	}
+	// Confirm the reply belongs to a retrieval we asked this peer for before
+	// decoding the transactions — see response_gate.go. Pooled transactions do
+	// not go through the dispatcher, so RequestTxs registers the id itself and
+	// this is where it is retired.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(PooledTransactionsMsg, env.RequestId)
+		return nil
+	}
+	peer.untrackPending(env.RequestId)
+
 	// Transactions can be processed, parse all of them and deliver to the pool
-	var txs PooledTransactionsPacket
-	if err := msg.Decode(&txs); err != nil {
+	txs := PooledTransactionsPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &txs.PooledTransactionsResponse); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	for i, tx := range txs.PooledTransactionsResponse {

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	metaapi "github.com/ethereum/go-ethereum/metadium/api"
 	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // Concurrency caps for the asynchronous Metadium message handlers below. Each
@@ -59,8 +60,22 @@ func handleGetBlobSidecars69(backend Backend, msg Decoder, peer *Peer) error {
 // handleBlobSidecars69 forwards a received blob-sidecar reply to the backend,
 // which correlates it with the in-flight request and validates/persists it.
 func handleBlobSidecars69(backend Backend, msg Decoder, peer *Peer) error {
-	var res BlobSidecarsPacket
-	if err := msg.Decode(&res); err != nil {
+	// Confirm this reply answers a fetch we issued before decoding the sidecars.
+	// A sidecar is up to 128KB of blob plus commitments, so this is the largest
+	// amplification the protocol offers an unsolicited sender. See
+	// response_gate.go.
+	env := new(responseEnvelope)
+	if err := msg.Decode(env); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(env.RequestId) {
+		peer.dropUnsolicited(BlobSidecarsMsg, env.RequestId)
+		return nil
+	}
+	peer.untrackPending(env.RequestId)
+
+	res := BlobSidecarsPacket{RequestId: env.RequestId}
+	if err := rlp.DecodeBytes(env.Payload, &res.Sidecars); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	return backend.Handle(peer, &res)

--- a/eth/protocols/eth/metadium_handlers.go
+++ b/eth/protocols/eth/metadium_handlers.go
@@ -316,11 +316,12 @@ func handleGetNodeData(backend Backend, msg Decoder, peer *Peer) error {
 }
 
 // handleNodeData handles a NodeData response from an eth/66 peer.
-// Since we don't request node data, this is a no-op.
+//
+// This node never sends GetNodeData, so every one of these is unsolicited by
+// definition and there is nothing to match it against — the message carries no
+// request id. Discarding it without decoding is the same property the response
+// gate gives the dispatcher-path responses: a peer cannot make us expand a
+// payload we never asked for.
 func handleNodeData(backend Backend, msg Decoder, peer *Peer) error {
-	var data NodeDataPacket
-	if err := msg.Decode(&data); err != nil {
-		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
-	}
 	return nil
 }

--- a/eth/protocols/eth/metadium_peer.go
+++ b/eth/protocols/eth/metadium_peer.go
@@ -71,6 +71,12 @@ func (p *Peer) SendNodeData(data [][]byte) error {
 func (p *Peer) RequestBlobSidecars(id uint64, hashes []common.Hash) error {
 	p.Log().Debug("Fetching blob sidecars", "count", len(hashes))
 	requestTracker.Track(p.id, p.version, GetBlobSidecarsMsg, BlobSidecarsMsg, id)
+
+	// Blob sidecars are the largest payload this protocol carries, and this
+	// request also bypasses the dispatcher, so register the id for the response
+	// gate here; handleBlobSidecars69 retires it. See response_gate.go.
+	p.trackPending(id)
+
 	return p2p.Send(p.rw, GetBlobSidecarsMsg, &GetBlobSidecarsPacket{
 		RequestId: id,
 		Hashes:    hashes,

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -89,6 +89,16 @@ type Peer struct {
 	reqCancel   chan *cancel   // Dispatch channel to cancel pending requests and untrack them
 	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
 
+	// pendingIDs mirrors the dispatcher's pending request ids so that a message
+	// handler can tell whether a response was solicited before it decodes the
+	// payload. See response_gate.go. Written by the dispatcher goroutine and by
+	// the meta/69 blob-sidecar requester, read by the message-handling
+	// goroutine, hence its own lock rather than the field lock below.
+	pendingIDs  map[uint64]struct{}
+	pendingRing [maxPendingIDs]uint64 // insertion order, to bound the index
+	pendingPos  int
+	pendingLock sync.RWMutex
+
 	term chan struct{} // Termination channel to stop the broadcasters
 	lock sync.RWMutex  // Mutex protecting the internal fields
 
@@ -117,6 +127,7 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Pe
 		reqDispatch:     make(chan *request),
 		reqCancel:       make(chan *cancel),
 		resDispatch:     make(chan *response),
+		pendingIDs:      make(map[uint64]struct{}),
 		txpool:          txpool,
 		term:            make(chan struct{}),
 	}
@@ -459,6 +470,11 @@ func (p *Peer) RequestTxs(hashes []common.Hash) error {
 	id := rand.Uint64()
 
 	requestTracker.Track(p.id, p.version, GetPooledTransactionsMsg, PooledTransactionsMsg, id)
+
+	// This retrieval bypasses the dispatcher, so register the id for the response
+	// gate here; handlePooledTransactions retires it. See response_gate.go.
+	p.trackPending(id)
+
 	return p2p.Send(p.rw, GetPooledTransactionsMsg, &GetPooledTransactionsPacket{
 		RequestId:                    id,
 		GetPooledTransactionsRequest: hashes,

--- a/eth/protocols/eth/response_gate.go
+++ b/eth/protocols/eth/response_gate.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-metadium library.
+//
+// The go-metadium library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-metadium library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-metadium library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import "github.com/ethereum/go-ethereum/rlp"
+
+// This file keeps a response from being decoded before we know we asked for it.
+//
+// Every response message on this protocol is `[request-id, payload]`. The
+// handlers used to decode the whole thing and only then hand it to the
+// dispatcher, which is where the request id is matched against the in-flight
+// requests. A peer that never received a request from us could therefore make
+// us expand an arbitrary payload — bounded in wire size by maxMessageSize, but
+// not in the size of the Go values it decodes into, which is the amplification
+// that makes it worth anything to an attacker.
+//
+// The gate below is the same property upstream go-ethereum adopted in
+// "eth/protocols/eth, eth/protocols/snap: delayed p2p message decoding"
+// (0cba803fb, v1.17.0, CVE-2026-26313): confirm the response belongs to an
+// active request first, decode second. Upstream's version reaches further —
+// it also defers decoding until the response is checked against the request's
+// limits, and it restructured p2p/tracker into a per-peer instance to do it.
+// That rework sits on the eth/69-72 protocol layout and does not transplant
+// onto this tree; what is here is the part that closes the unsolicited-message
+// path, applied to the dispatcher this fork actually runs.
+//
+// The gate is deliberately keyed on the request id alone. A response whose id
+// is live but whose message code is wrong keeps its existing treatment (the
+// dispatcher reports errMismatchingResponseType and the peer is dropped), so
+// this change only ever converts work that used to happen into work that is
+// skipped.
+
+// maxPendingIDs bounds the gate's index. Not every request path can untrack its
+// id: the dispatcher-managed ones (headers, bodies, receipts) are removed
+// exactly, but pooled transactions and blob sidecars are sent straight to the
+// wire and are only untracked when an answer arrives, so an unanswered request
+// would otherwise sit in the index for the life of the connection.
+//
+// The bound is a ring: inserting past capacity evicts the oldest id. Real
+// concurrency per peer is a handful of requests (the dispatcher's in-flight
+// set, one pooled-transaction retrieval, one serial blob fetch), so eviction
+// only ever reaches ids that have long since gone unanswered. Evicting a live
+// id would drop a legitimate response, which is why the capacity is far above
+// what the request paths can produce.
+const maxPendingIDs = 256
+
+// responseEnvelope decodes the request id of a response message while leaving
+// the payload as raw RLP. The payload is decoded separately, and only once the
+// gate has passed.
+type responseEnvelope struct {
+	RequestId uint64
+	Payload   rlp.RawValue
+}
+
+// trackPending records that a request id was sent to this peer.
+//
+// Registration happens before the request is written to the wire, so a peer
+// that answers immediately cannot have its response gated out by an index that
+// has not caught up yet. The index may therefore hold an id whose send
+// subsequently failed; that is the harmless direction, and untrackPending
+// cleans it up.
+func (p *Peer) trackPending(id uint64) {
+	p.pendingLock.Lock()
+	defer p.pendingLock.Unlock()
+
+	if _, ok := p.pendingIDs[id]; ok {
+		return
+	}
+	// Reclaim the slot this insert is about to take. The id found there may
+	// already have been untracked, in which case the delete is a no-op.
+	if victim := p.pendingRing[p.pendingPos]; victim != 0 {
+		delete(p.pendingIDs, victim)
+	}
+	p.pendingRing[p.pendingPos] = id
+	p.pendingPos = (p.pendingPos + 1) % len(p.pendingRing)
+	p.pendingIDs[id] = struct{}{}
+}
+
+// untrackPending forgets an in-flight request id.
+func (p *Peer) untrackPending(id uint64) {
+	p.pendingLock.Lock()
+	defer p.pendingLock.Unlock()
+	delete(p.pendingIDs, id)
+}
+
+// solicited reports whether the given request id belongs to a request we sent
+// to this peer and have not yet accounted for.
+func (p *Peer) solicited(id uint64) bool {
+	p.pendingLock.RLock()
+	defer p.pendingLock.RUnlock()
+	_, ok := p.pendingIDs[id]
+	return ok
+}
+
+// dropUnsolicited reports the response as dangling and tells the caller to stop
+// processing it. Dropping such a response silently is the pre-existing
+// behaviour: the dispatcher answered an untracked id with errDanglingResponse,
+// which dispatchResponse turned into a nil return. The tracker is still told,
+// so the dangling-response metrics keep counting what they used to count.
+func (p *Peer) dropUnsolicited(code, id uint64) {
+	requestTracker.Fulfil(p.id, p.version, code, id)
+}

--- a/eth/protocols/eth/response_gate_test.go
+++ b/eth/protocols/eth/response_gate_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-metadium library.
+//
+// The go-metadium library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-metadium library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-metadium library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// The tests below distinguish "gated out" from "decoded" by sending a payload
+// that is well-formed RLP but cannot decode into the response type. A handler
+// that decodes before checking the request id reports errDecode; one that
+// gates first returns nil without ever looking at the payload. That makes the
+// undecodable payload the observable, so these tests fail if the gate is
+// removed rather than merely covering it.
+//
+// unpaired is such a payload: a list where the response type expects a list of
+// structs, and whose single element is a string.
+func unpairedPayload(t *testing.T) rlp.RawValue {
+	t.Helper()
+	enc, err := rlp.EncodeToBytes([]string{"not a header"})
+	if err != nil {
+		t.Fatalf("encoding the test payload failed: %v", err)
+	}
+	return enc
+}
+
+// acceptTxsBackend is testBackend with transaction processing turned on.
+// testBackend.AcceptTxs panics on purpose ("data processing tests should be done
+// in the handler package"), and handlePooledTransactions consults it before
+// reaching the gate, so the tests below need this much of a backend.
+type acceptTxsBackend struct{ *testBackend }
+
+func (b acceptTxsBackend) AcceptTxs() bool { return true }
+
+// deliver writes one message into the peer's pipe and returns what the handler
+// made of it.
+func deliver(t *testing.T, peer *Peer, code uint64, id uint64, payload rlp.RawValue,
+	handler func(Backend, Decoder, *Peer) error, backend Backend) error {
+	t.Helper()
+
+	enc, err := rlp.EncodeToBytes(&responseEnvelope{RequestId: id, Payload: payload})
+	if err != nil {
+		t.Fatalf("encoding the envelope failed: %v", err)
+	}
+	app, net := p2p.MsgPipe()
+	defer app.Close()
+	defer net.Close()
+
+	go func() {
+		p2p.Send(app, code, rlp.RawValue(enc))
+	}()
+	msg, err := net.ReadMsg()
+	if err != nil {
+		t.Fatalf("reading the test message failed: %v", err)
+	}
+	defer msg.Discard()
+
+	return handler(backend, msg, peer)
+}
+
+// TestResponseGateDropsUnsolicited checks that a response nobody asked for is
+// dropped before its payload is decoded, for every response message that
+// carries a request id.
+func TestResponseGateDropsUnsolicited(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("gate", ETH69, backend)
+	processing := acceptTxsBackend{backend}
+	defer peer.close()
+
+	payload := unpairedPayload(t)
+
+	for _, tt := range []struct {
+		name    string
+		code    uint64
+		handler func(Backend, Decoder, *Peer) error
+	}{
+		{"headers", BlockHeadersMsg, handleBlockHeaders},
+		{"bodies", BlockBodiesMsg, handleBlockBodies},
+		{"receipts", ReceiptsMsg, handleReceipts},
+		{"pooled transactions", PooledTransactionsMsg, handlePooledTransactions},
+		{"blob sidecars", BlobSidecarsMsg, handleBlobSidecars69},
+	} {
+		// 0xdead was never requested from this peer.
+		if err := deliver(t, peer.Peer, tt.code, 0xdead, payload, tt.handler, processing); err != nil {
+			t.Errorf("%s: unsolicited response was processed instead of dropped: %v", tt.name, err)
+		}
+	}
+}
+
+// TestResponseGateDecodesSolicited is the other half: once the id is in flight,
+// the payload is decoded, and a payload that cannot be decoded is reported as
+// such. Without this, a gate that dropped everything would pass the test above.
+func TestResponseGateDecodesSolicited(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("gate", ETH69, backend)
+	processing := acceptTxsBackend{backend}
+	defer peer.close()
+
+	payload := unpairedPayload(t)
+
+	for _, tt := range []struct {
+		name    string
+		code    uint64
+		handler func(Backend, Decoder, *Peer) error
+	}{
+		{"headers", BlockHeadersMsg, handleBlockHeaders},
+		{"bodies", BlockBodiesMsg, handleBlockBodies},
+		{"receipts", ReceiptsMsg, handleReceipts},
+		{"pooled transactions", PooledTransactionsMsg, handlePooledTransactions},
+		{"blob sidecars", BlobSidecarsMsg, handleBlobSidecars69},
+	} {
+		const id = 0xbeef
+		peer.Peer.trackPending(id)
+
+		err := deliver(t, peer.Peer, tt.code, id, payload, tt.handler, processing)
+		if !errors.Is(err, errDecode) {
+			t.Errorf("%s: solicited response was not decoded (want errDecode, got %v)", tt.name, err)
+		}
+		peer.Peer.untrackPending(id)
+	}
+}
+
+// TestPendingIndexBounded checks that the index cannot grow without bound. The
+// paths that bypass the dispatcher only untrack on an answer, so an unanswered
+// request must not accumulate for the life of the connection.
+func TestPendingIndexBounded(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("bounded", ETH69, backend)
+	defer peer.close()
+
+	for i := uint64(1); i <= maxPendingIDs*3; i++ {
+		peer.Peer.trackPending(i)
+	}
+	peer.Peer.pendingLock.RLock()
+	size := len(peer.Peer.pendingIDs)
+	peer.Peer.pendingLock.RUnlock()
+
+	if size > maxPendingIDs {
+		t.Fatalf("pending index grew past its bound: %d > %d", size, maxPendingIDs)
+	}
+	// The most recent ids must have survived the eviction, or the gate would
+	// drop responses to requests that are actually in flight.
+	for i := uint64(maxPendingIDs*3 - 10); i <= maxPendingIDs*3; i++ {
+		if !peer.Peer.solicited(i) {
+			t.Fatalf("recent request id %d was evicted", i)
+		}
+	}
+	// And the oldest must be gone, which is what keeps the bound.
+	if peer.Peer.solicited(1) {
+		t.Fatalf("oldest request id was not evicted")
+	}
+}
+
+// TestTrackPendingIdempotent guards the ring bookkeeping: registering the same
+// id twice must not consume two slots, or a retried request would shrink the
+// effective capacity.
+func TestTrackPendingIdempotent(t *testing.T) {
+	backend := newTestBackend(1)
+	defer backend.close()
+
+	peer, _ := newTestPeer("idempotent", ETH69, backend)
+	defer peer.close()
+
+	for i := 0; i < maxPendingIDs*2; i++ {
+		peer.Peer.trackPending(7)
+	}
+	peer.Peer.pendingLock.RLock()
+	size := len(peer.Peer.pendingIDs)
+	peer.Peer.pendingLock.RUnlock()
+
+	if size != 1 {
+		t.Fatalf("re-tracking one id filled the index: size %d", size)
+	}
+	if !peer.Peer.solicited(7) {
+		t.Fatalf("re-tracked id was evicted by itself")
+	}
+}

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -171,10 +171,13 @@ func HandleMessage(backend Backend, peer *Peer) error {
 		})
 
 	case msg.Code == AccountRangeMsg:
-		// A range of accounts arrived to one of our previous requests
+		// A range of accounts arrived to one of our previous requests. Check the
+		// request id before expanding the payload; see response_gate.go.
 		res := new(AccountRangePacket)
-		if err := msg.Decode(res); err != nil {
-			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		if gated, err := gateResponse(peer, msg, AccountRangeMsg, res); err != nil {
+			return err
+		} else if gated {
+			return nil
 		}
 		// Ensure the range is monotonically increasing
 		for i := 1; i < len(res.Accounts); i++ {
@@ -205,8 +208,10 @@ func HandleMessage(backend Backend, peer *Peer) error {
 	case msg.Code == StorageRangesMsg:
 		// A range of storage slots arrived to one of our previous requests
 		res := new(StorageRangesPacket)
-		if err := msg.Decode(res); err != nil {
-			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		if gated, err := gateResponse(peer, msg, StorageRangesMsg, res); err != nil {
+			return err
+		} else if gated {
+			return nil
 		}
 		// Ensure the ranges are monotonically increasing
 		for i, slots := range res.Slots {
@@ -238,8 +243,10 @@ func HandleMessage(backend Backend, peer *Peer) error {
 	case msg.Code == ByteCodesMsg:
 		// A batch of byte codes arrived to one of our previous requests
 		res := new(ByteCodesPacket)
-		if err := msg.Decode(res); err != nil {
-			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		if gated, err := gateResponse(peer, msg, ByteCodesMsg, res); err != nil {
+			return err
+		} else if gated {
+			return nil
 		}
 		requestTracker.Fulfil(peer.id, peer.version, ByteCodesMsg, res.ID)
 
@@ -265,8 +272,10 @@ func HandleMessage(backend Backend, peer *Peer) error {
 	case msg.Code == TrieNodesMsg:
 		// A batch of trie nodes arrived to one of our previous requests
 		res := new(TrieNodesPacket)
-		if err := msg.Decode(res); err != nil {
-			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		if gated, err := gateResponse(peer, msg, TrieNodesMsg, res); err != nil {
+			return err
+		} else if gated {
+			return nil
 		}
 		requestTracker.Fulfil(peer.id, peer.version, TrieNodesMsg, res.ID)
 

--- a/eth/protocols/snap/peer.go
+++ b/eth/protocols/snap/peer.go
@@ -17,6 +17,8 @@
 package snap
 
 import (
+	"sync"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -29,6 +31,13 @@ type Peer struct {
 	*p2p.Peer                   // The embedded P2P package peer
 	rw        p2p.MsgReadWriter // Input/output streams for snap
 	version   uint              // Protocol version negotiated
+
+	// Request ids sent to this peer, so that a response can be checked before
+	// it is decoded. See response_gate.go.
+	pendingLock sync.RWMutex
+	pendingIDs  map[uint64]struct{}
+	pendingRing []uint64
+	pendingPos  int
 
 	logger log.Logger // Contextual logger with the peer id injected
 }
@@ -77,13 +86,21 @@ func (p *Peer) RequestAccountRange(id uint64, root common.Hash, origin, limit co
 	p.logger.Trace("Fetching range of accounts", "reqid", id, "root", root, "origin", origin, "limit", limit, "bytes", common.StorageSize(bytes))
 
 	requestTracker.Track(p.id, p.version, GetAccountRangeMsg, AccountRangeMsg, id)
-	return p2p.Send(p.rw, GetAccountRangeMsg, &GetAccountRangePacket{
+
+	// Register before sending, so the response cannot outrun the index. See
+	// response_gate.go; handleMessage retires the id when the answer arrives.
+	p.trackPending(id)
+	err := p2p.Send(p.rw, GetAccountRangeMsg, &GetAccountRangePacket{
 		ID:     id,
 		Root:   root,
 		Origin: origin,
 		Limit:  limit,
 		Bytes:  bytes,
 	})
+	if err != nil {
+		p.untrackPending(id)
+	}
+	return err
 }
 
 // RequestStorageRanges fetches a batch of storage slots belonging to one or more
@@ -96,7 +113,9 @@ func (p *Peer) RequestStorageRanges(id uint64, root common.Hash, accounts []comm
 		p.logger.Trace("Fetching ranges of small storage slots", "reqid", id, "root", root, "accounts", len(accounts), "first", accounts[0], "bytes", common.StorageSize(bytes))
 	}
 	requestTracker.Track(p.id, p.version, GetStorageRangesMsg, StorageRangesMsg, id)
-	return p2p.Send(p.rw, GetStorageRangesMsg, &GetStorageRangesPacket{
+
+	p.trackPending(id)
+	err := p2p.Send(p.rw, GetStorageRangesMsg, &GetStorageRangesPacket{
 		ID:       id,
 		Root:     root,
 		Accounts: accounts,
@@ -104,6 +123,10 @@ func (p *Peer) RequestStorageRanges(id uint64, root common.Hash, accounts []comm
 		Limit:    limit,
 		Bytes:    bytes,
 	})
+	if err != nil {
+		p.untrackPending(id)
+	}
+	return err
 }
 
 // RequestByteCodes fetches a batch of bytecodes by hash.
@@ -111,11 +134,17 @@ func (p *Peer) RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) e
 	p.logger.Trace("Fetching set of byte codes", "reqid", id, "hashes", len(hashes), "bytes", common.StorageSize(bytes))
 
 	requestTracker.Track(p.id, p.version, GetByteCodesMsg, ByteCodesMsg, id)
-	return p2p.Send(p.rw, GetByteCodesMsg, &GetByteCodesPacket{
+
+	p.trackPending(id)
+	err := p2p.Send(p.rw, GetByteCodesMsg, &GetByteCodesPacket{
 		ID:     id,
 		Hashes: hashes,
 		Bytes:  bytes,
 	})
+	if err != nil {
+		p.untrackPending(id)
+	}
+	return err
 }
 
 // RequestTrieNodes fetches a batch of account or storage trie nodes rooted in
@@ -124,10 +153,16 @@ func (p *Peer) RequestTrieNodes(id uint64, root common.Hash, paths []TrieNodePat
 	p.logger.Trace("Fetching set of trie nodes", "reqid", id, "root", root, "pathsets", len(paths), "bytes", common.StorageSize(bytes))
 
 	requestTracker.Track(p.id, p.version, GetTrieNodesMsg, TrieNodesMsg, id)
-	return p2p.Send(p.rw, GetTrieNodesMsg, &GetTrieNodesPacket{
+
+	p.trackPending(id)
+	err := p2p.Send(p.rw, GetTrieNodesMsg, &GetTrieNodesPacket{
 		ID:    id,
 		Root:  root,
 		Paths: paths,
 		Bytes: bytes,
 	})
+	if err != nil {
+		p.untrackPending(id)
+	}
+	return err
 }

--- a/eth/protocols/snap/response_gate.go
+++ b/eth/protocols/snap/response_gate.go
@@ -1,0 +1,168 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-metadium library.
+//
+// The go-metadium library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-metadium library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-metadium library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// This file keeps a snap response from being decoded before we know we asked
+// for it. It is the counterpart of eth/protocols/eth/response_gate.go, and the
+// reason it exists separately is that this protocol reaches the same hazard by
+// a different route.
+//
+// Nothing on this network snap-syncs — the fork refuses --syncmode snap — but
+// the response handlers are reachable all the same, because what exposes them
+// is capability negotiation rather than our sync mode: Ethereum.Protocols
+// appends snap/1 whenever SnapshotCache is above zero, and that defaults to
+// 102. So a node running --syncmode full advertises snap, and its handlers used
+// to decode a response in full before AccountRangePacket.ID was compared
+// against anything.
+//
+// Never snap-syncing is in fact what makes this worse rather than better: with
+// no request outstanding, the id can match nothing, and the syncer's handling
+// of an id it does not know is to log and return nil — the peer is not dropped,
+// so one connection can repeat the same message indefinitely. Bytecodes and
+// trie nodes are [][]byte with no ordering constraint to satisfy on the way in,
+// which makes them the cheapest shape: the wire size is capped by
+// maxMessageSize, the size of the Go values it expands into is not.
+//
+// The gate reads the leading request id, checks it against the ids this peer
+// was actually sent, and decodes the payload only then.
+//
+// Why not the envelope struct the eth gate uses: there, every response is
+// `[request-id, payload]` — two elements, so leaving the second as
+// rlp.RawValue is enough. Snap's responses are flat lists whose first element
+// happens to be the id (`[id, accounts, proof]`), so there is no payload
+// element to hold back. peekRequestID therefore reads the id off a stream over
+// the already-buffered message and stops, and the full decode re-reads those
+// same bytes once the gate has passed. Buffering the message costs its wire
+// size, which the maxMessageSize check above the handler has already bounded;
+// it is the expansion that the gate is there to prevent.
+
+// maxPendingIDs bounds the index, as a ring: inserting past capacity evicts the
+// oldest id.
+//
+// Snap has no dispatcher, so a request is only untracked when its answer
+// arrives (or when the send fails). An unanswered request would otherwise sit
+// in the index for the life of the connection. The syncer's real concurrency is
+// a handful of requests per peer, so eviction only ever reaches ids that have
+// long gone unanswered — and on this network the index stays empty, since
+// nothing sends snap requests at all.
+const maxPendingIDs = 256
+
+// peekRequestID reads the leading request id of a response message without
+// decoding the rest of it. Every response this protocol defines is a list whose
+// first element is the id.
+func peekRequestID(raw []byte) (uint64, error) {
+	s := rlp.NewStream(bytes.NewReader(raw), uint64(len(raw)))
+	if _, err := s.List(); err != nil {
+		return 0, err
+	}
+	return s.Uint64()
+}
+
+// gateResponse buffers a response message, checks its request id against the
+// ids this peer was sent, and decodes it into res only if it matches.
+//
+// It reports whether the caller should stop: (true, nil) means the response was
+// unsolicited and has been dropped without being decoded, which is what the
+// syncer used to do with it after decoding. A non-nil error is a decode failure
+// and keeps its previous meaning — the peer is dropped.
+func gateResponse(peer *Peer, msg p2p.Msg, code uint64, res any) (bool, error) {
+	// Buffering costs the wire size, which handleMessage has already bounded by
+	// maxMessageSize. It is the decode that would cost more than that.
+	raw, err := io.ReadAll(msg.Payload)
+	if err != nil {
+		return false, fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	id, err := peekRequestID(raw)
+	if err != nil {
+		return false, fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if !peer.solicited(id) {
+		peer.dropUnsolicited(code, id)
+		return true, nil
+	}
+	// The answer has arrived; the id is spent whether or not the payload turns
+	// out to be well formed.
+	peer.untrackPending(id)
+
+	if err := rlp.DecodeBytes(raw, res); err != nil {
+		return false, fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	return false, nil
+}
+
+// trackPending records that a request id was sent to this peer.
+//
+// Registration happens before the request reaches the wire, so a peer that
+// answers immediately cannot have its response gated out by an index that has
+// not caught up. The index may therefore briefly hold an id whose send then
+// failed; that is the harmless direction, and the callers untrack it.
+func (p *Peer) trackPending(id uint64) {
+	p.pendingLock.Lock()
+	defer p.pendingLock.Unlock()
+
+	if p.pendingIDs == nil {
+		p.pendingIDs = make(map[uint64]struct{})
+		p.pendingRing = make([]uint64, maxPendingIDs)
+	}
+	if _, ok := p.pendingIDs[id]; ok {
+		return
+	}
+	// Reclaim the slot this insert is about to take. The id found there may
+	// already have been untracked, in which case the delete is a no-op.
+	if victim := p.pendingRing[p.pendingPos]; victim != 0 {
+		delete(p.pendingIDs, victim)
+	}
+	p.pendingRing[p.pendingPos] = id
+	p.pendingPos = (p.pendingPos + 1) % len(p.pendingRing)
+	p.pendingIDs[id] = struct{}{}
+}
+
+// untrackPending forgets an in-flight request id.
+func (p *Peer) untrackPending(id uint64) {
+	p.pendingLock.Lock()
+	defer p.pendingLock.Unlock()
+	delete(p.pendingIDs, id)
+}
+
+// solicited reports whether the given request id belongs to a request we sent
+// to this peer and have not yet accounted for.
+func (p *Peer) solicited(id uint64) bool {
+	p.pendingLock.RLock()
+	defer p.pendingLock.RUnlock()
+	_, ok := p.pendingIDs[id]
+	return ok
+}
+
+// dropUnsolicited reports the response as dangling and tells the caller to stop
+// processing it.
+//
+// Dropping it without disconnecting is the pre-existing behaviour: such a
+// response used to be decoded, handed to the syncer, and discarded there with a
+// warning and a nil return. The tracker is still told, so the metrics keep
+// counting what they counted before.
+func (p *Peer) dropUnsolicited(code, id uint64) {
+	requestTracker.Fulfil(p.id, p.version, code, id)
+}

--- a/eth/protocols/snap/response_gate_test.go
+++ b/eth/protocols/snap/response_gate_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-metadium library.
+//
+// The go-metadium library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-metadium library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-metadium library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// The tests below pair the two directions against the same message: a payload
+// that cannot decode into the response type. A solicited id must reach the
+// decoder and report that failure; an unsolicited id must be dropped before the
+// payload is ever looked at, so the same message comes back as a nil error.
+// Using an undecodable payload is what makes these tests fail if the gate is
+// removed, rather than merely covering it.
+//
+// Each bad payload has the element count its response type expects, so the
+// decode fails on the contents rather than on the arity -- a list where a byte
+// string or a struct is expected. Getting this wrong is easy: a plain
+// []string does decode into ByteCodesPacket.Codes ([][]byte), which is how the
+// first version of this test passed while proving nothing for two of the four.
+func gatedMessage(t *testing.T, code, id uint64, body []any) (p2p.Msg, func()) {
+	t.Helper()
+
+	enc, err := rlp.EncodeToBytes(append([]any{id}, body...))
+	if err != nil {
+		t.Fatalf("encoding the test message failed: %v", err)
+	}
+	app, net := p2p.MsgPipe()
+	go func() {
+		p2p.Send(app, code, rlp.RawValue(enc))
+	}()
+	msg, err := net.ReadMsg()
+	if err != nil {
+		app.Close()
+		net.Close()
+		t.Fatalf("reading the test message failed: %v", err)
+	}
+	return msg, func() {
+		msg.Discard()
+		app.Close()
+		net.Close()
+	}
+}
+
+// newGatePeer is a peer with nothing but a writable pipe: the gate never sends
+// anything, it only consults the index.
+func newGatePeer() *Peer {
+	_, net := p2p.MsgPipe()
+	return NewFakePeer(1, "0123456789abcdef", net)
+}
+
+// responseCases enumerates the four response codes the gate covers, each with a
+// freshly allocated destination and a body that cannot decode into it.
+func responseCases() []struct {
+	name string
+	code uint64
+	res  any
+	body []any
+} {
+	// A list where a struct or a byte string is expected.
+	nested := [][]string{{"not a struct"}}
+
+	return []struct {
+		name string
+		code uint64
+		res  any
+		body []any
+	}{
+		{"AccountRange", AccountRangeMsg, new(AccountRangePacket), []any{nested, [][]byte{}}},
+		{"StorageRanges", StorageRangesMsg, new(StorageRangesPacket), []any{nested, [][]byte{}}},
+		{"ByteCodes", ByteCodesMsg, new(ByteCodesPacket), []any{nested}},
+		{"TrieNodes", TrieNodesMsg, new(TrieNodesPacket), []any{nested}},
+	}
+}
+
+// TestGateDropsUnsolicited is the property the change exists for: a response
+// for an id this peer was never sent is dropped without decoding its payload.
+func TestGateDropsUnsolicited(t *testing.T) {
+	for _, tc := range responseCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := newGatePeer()
+			msg, done := gatedMessage(t, tc.code, 42, tc.body)
+			defer done()
+
+			gated, err := gateResponse(peer, msg, tc.code, tc.res)
+			if err != nil {
+				t.Fatalf("an unsolicited response reached the decoder: %v", err)
+			}
+			if !gated {
+				t.Fatal("an unsolicited response was not gated")
+			}
+		})
+	}
+}
+
+// TestGateDecodesSolicited is the other half: the same undecodable payload,
+// with the id registered, must reach the decoder and fail there. Without this
+// the gate could be passing by rejecting everything.
+func TestGateDecodesSolicited(t *testing.T) {
+	for _, tc := range responseCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := newGatePeer()
+			peer.trackPending(42)
+
+			msg, done := gatedMessage(t, tc.code, 42, tc.body)
+			defer done()
+
+			gated, err := gateResponse(peer, msg, tc.code, tc.res)
+			if gated {
+				t.Fatal("a solicited response was gated out")
+			}
+			if err == nil {
+				t.Fatal("the undecodable payload was accepted")
+			}
+			if peer.solicited(42) {
+				t.Error("the id was not retired once its answer arrived")
+			}
+		})
+	}
+}
+
+// TestGateRejectsMalformedEnvelope checks that a message which is not even a
+// list with a leading integer is refused by the id peek, before any attempt to
+// decode it as a response.
+func TestGateRejectsMalformedEnvelope(t *testing.T) {
+	peer := newGatePeer()
+
+	enc, err := rlp.EncodeToBytes("not a list")
+	if err != nil {
+		t.Fatalf("encoding failed: %v", err)
+	}
+	app, net := p2p.MsgPipe()
+	defer app.Close()
+	defer net.Close()
+	go func() {
+		p2p.Send(app, AccountRangeMsg, rlp.RawValue(enc))
+	}()
+	msg, err := net.ReadMsg()
+	if err != nil {
+		t.Fatalf("reading the test message failed: %v", err)
+	}
+	defer msg.Discard()
+
+	if _, err := gateResponse(peer, msg, AccountRangeMsg, new(AccountRangePacket)); err == nil {
+		t.Error("a message with no request id was accepted")
+	}
+}
+
+// TestPendingIndexBounded pins the ring: the index never grows past its
+// capacity, and what falls out is the oldest id.
+func TestPendingIndexBounded(t *testing.T) {
+	peer := newGatePeer()
+	for id := uint64(1); id <= maxPendingIDs+10; id++ {
+		peer.trackPending(id)
+	}
+	if got := len(peer.pendingIDs); got != maxPendingIDs {
+		t.Errorf("the index holds %d ids, want %d", got, maxPendingIDs)
+	}
+	if peer.solicited(1) {
+		t.Error("the oldest id survived eviction")
+	}
+	if !peer.solicited(maxPendingIDs + 10) {
+		t.Error("the newest id was not retained")
+	}
+}
+
+// TestTrackPendingIdempotent checks that re-registering a live id does not
+// consume a second ring slot, which would evict an unrelated live id.
+func TestTrackPendingIdempotent(t *testing.T) {
+	peer := newGatePeer()
+	peer.trackPending(7)
+	pos := peer.pendingPos
+	peer.trackPending(7)
+
+	if peer.pendingPos != pos {
+		t.Error("re-registering a live id consumed a ring slot")
+	}
+	if !peer.solicited(7) {
+		t.Error("the id was lost")
+	}
+}
+
+// TestRequestRegistersPendingID covers the wiring rather than the gate itself:
+// that each request method registers its id, and that a request which never
+// reaches the wire does not leave one behind.
+//
+// This is worth its own test because the package's sync tests cannot reach it.
+// Their testPeer implements the Request* methods itself and calls the syncer's
+// OnAccounts and friends directly, so nothing in that suite crosses p2p
+// messaging or handleMessage -- a gate that rejected every legitimate response
+// would still leave them green.
+func TestRequestRegistersPendingID(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		send func(*Peer, uint64) error
+	}{
+		{"AccountRange", func(p *Peer, id uint64) error {
+			return p.RequestAccountRange(id, common.Hash{}, common.Hash{}, common.Hash{}, 1024)
+		}},
+		{"StorageRanges", func(p *Peer, id uint64) error {
+			return p.RequestStorageRanges(id, common.Hash{}, []common.Hash{{}}, nil, nil, 1024)
+		}},
+		{"ByteCodes", func(p *Peer, id uint64) error {
+			return p.RequestByteCodes(id, []common.Hash{{}}, 1024)
+		}},
+		{"TrieNodes", func(p *Peer, id uint64) error {
+			return p.RequestTrieNodes(id, common.Hash{}, nil, 1024)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app, net := p2p.MsgPipe()
+			defer app.Close()
+			defer net.Close()
+
+			// MsgPipe is synchronous, so the request needs a reader.
+			read := make(chan error, 1)
+			go func() {
+				msg, err := app.ReadMsg()
+				if err == nil {
+					msg.Discard()
+				}
+				read <- err
+			}()
+
+			peer := NewFakePeer(1, "0123456789abcdef", net)
+			if err := tc.send(peer, 99); err != nil {
+				t.Fatalf("sending the request failed: %v", err)
+			}
+			if err := <-read; err != nil {
+				t.Fatalf("reading the request failed: %v", err)
+			}
+			if !peer.solicited(99) {
+				t.Error("the request id was not registered, so its response would be gated out")
+			}
+		})
+	}
+
+	t.Run("failed send untracks", func(t *testing.T) {
+		app, net := p2p.MsgPipe()
+		app.Close()
+		net.Close()
+
+		peer := NewFakePeer(1, "0123456789abcdef", net)
+		if err := peer.RequestByteCodes(99, []common.Hash{{}}, 1024); err == nil {
+			t.Fatal("sending on a closed pipe succeeded")
+		}
+		if peer.solicited(99) {
+			t.Error("a request that never reached the wire left its id in the index")
+		}
+	})
+}

--- a/p2p/rlpx/rlpx_invalid_curve_test.go
+++ b/p2p/rlpx/rlpx_invalid_curve_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rlpx
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+)
+
+// TestHandshakeECIESInvalidCurve is upstream go-ethereum's proof for
+// CVE-2026-26315 (46bee92f9), ported as a regression test.
+//
+// The handshake decrypts unauthenticated network input. An ephemeral public key
+// that is not on the curve must be refused outright; if it reaches ECDH and
+// fails later at MAC verification, the difference in error and in work done is
+// an oracle.
+//
+// This tree already satisfies that: Decrypt decodes the point with
+// elliptic.Unmarshal, which validates it here (see crypto/secp256k1/curve.go on
+// the unmarshaler interface), so the packet is rejected with ErrInvalidPublicKey
+// with or without the guard added to GenerateShared. The test therefore pins the
+// handshake's behaviour rather than proving that guard — the direct proof for it
+// is TestGenerateSharedRejectsOffCurve in crypto/ecies.
+func TestHandshakeECIESInvalidCurve(t *testing.T) {
+	initKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	respKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	init := handshakeState{
+		initiator: true,
+		remote:    ecies.ImportECDSAPublic(&respKey.PublicKey),
+	}
+	authMsg, err := init.makeAuthMsg(initKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet, err := init.sealEIP8(authMsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The untampered packet has to decrypt, or the test below would pass for
+	// the wrong reason.
+	var recv handshakeState
+	if _, err := recv.readMsg(new(authMsgV4), respKey, bytes.NewReader(packet)); err != nil {
+		t.Fatalf("valid handshake packet failed to decrypt: %v", err)
+	}
+
+	// Replace the ephemeral point with (0, 0), which is a well-formed
+	// uncompressed encoding of a point that is not on secp256k1.
+	tampered := append([]byte(nil), packet...)
+	if len(tampered) < 2+65 {
+		t.Fatalf("unexpected packet length %d", len(tampered))
+	}
+	tampered[2] = 0x04
+	for i := 1; i < 65; i++ {
+		tampered[2+i] = 0x00
+	}
+
+	var recv2 handshakeState
+	_, err = recv2.readMsg(new(authMsgV4), respKey, bytes.NewReader(tampered))
+	if err == nil {
+		t.Fatal("handshake accepted a point that is not on the curve")
+	}
+	if !errors.Is(err, ecies.ErrInvalidPublicKey) {
+		t.Fatalf("want ErrInvalidPublicKey, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #95. **Stacked on #94** — that branch is not in this repo, so GitHub has to show its three commits here too; **the only new commit is the last one**, `00759aa92`. Reviewing that one against #94's head is the whole delta. Like the rest of the queue, this is opened for review only and merges after the 2026-08-27 fork, behind #94.

## Why this exists separately

#94 closed "decode before checking the request id" on `eth`, and its commit message said snap was out of reach here because this fork refuses `--syncmode snap`. @cp-khs and @trident90 each found that wrong independently, and they were right: our sync mode governs whether we ever *send* snap requests, while what exposes the response handlers is capability negotiation. `Ethereum.Protocols` appends snap/1 whenever `SnapshotCache > 0`, and that defaults to 102, so a node on `--syncmode full --gcmode archive` advertises snap/1 and its handlers decode `AccountRangePacket` in full before `ID` is compared against anything.

Never snap-syncing makes it worse rather than better. With no request outstanding the id can match nothing, and the syncer's answer to an id it does not know is to log and `return nil` — the peer is not dropped, so one connection can repeat the same message for the life of the connection. `ByteCodes` and `TrieNodes` are `[][]byte` with no ordering constraint to satisfy on the way in, which makes them the cheapest shape: `maxMessageSize` bounds the wire, nothing bounds what it expands into.

## What this changes

The peer carries an index of request ids it was sent, and the four response handlers consult it before decoding:

- **registration precedes the send**, so a peer that answers instantly cannot be gated out by an index that has not caught up; a failed send untracks the id again;
- snap has no dispatcher, so an id is otherwise **retired when its answer arrives**;
- the index is a **256-entry ring**, for the same reason as in eth — an unanswered request would otherwise sit there for the life of the connection, while real concurrency is a handful of requests per peer. On this network it stays empty, since nothing sends snap requests at all.

**The eth gate's envelope struct does not carry over**, and this is the one design difference worth attention. There, every response is `[request-id, payload]`, so leaving the payload as `rlp.RawValue` is enough. Snap's responses are flat lists that merely *begin* with the id (`[id, accounts, proof]`), so there is no payload element to hold back. `peekRequestID` reads the id off a stream over the buffered message and stops; the full decode re-reads those same bytes once the gate has passed. Buffering costs the wire size, which the `maxMessageSize` check above the handler has already bounded — the expansion is what the gate prevents, and that is what stays behind it.

Behaviour is otherwise preserved: an unsolicited response is still dropped without disconnecting (it used to be decoded and discarded by the syncer with a warning), and `requestTracker.Fulfil` is still called for it, so the dangling-response metrics keep counting what they counted before.

## On the other option in #95

#95 also lists "stop advertising snap on Metadium networks", which is cheaper and removes the surface rather than gating it. I did not take it here: it is a wire-behaviour change — peers stop seeing the capability — and that deserves its own operational decision rather than riding inside a security fix. This change is the one that cannot regress operationally, and it keeps working if snap sync is ever enabled here. The two are not exclusive; if the fleet decision is to stop advertising, this still belongs in the code.

## Verification

- `go test ./eth/protocols/snap/` — pass (11.4s, the full suite including the sync tests)
- `go test -race ./eth/protocols/snap/ -run 'TestGate|TestPending|TestTrack|TestRequestRegisters' -count=3` — clean
- `go test ./eth/protocols/eth/ ./eth/downloader/... ./eth/fetcher/...` — unchanged
- `go build ./...`, `go vet`, `gofmt` — clean

Two notes on the tests, both of which cost me a wrong version first:

**The payloads are per response type.** The tests pair the two directions against the same undecodable payload, which is what makes them fail if the gate is removed rather than merely cover it — but a plain `[]string` decodes into `ByteCodesPacket.Codes` (`[][]byte`) perfectly well, so my first version passed while proving nothing for two of the four. Each case now carries a body with the arity its type expects and an element that cannot decode into it.

**The wiring has its own test, because the sync suite cannot reach it.** `sync_test.go`'s `testPeer` implements the `Request*` methods itself and calls `OnAccounts` and friends directly, so nothing in that suite crosses p2p messaging or `handleMessage` — a gate that rejected every legitimate response would leave it green. `TestRequestRegistersPendingID` covers that each request method registers its id over a real `MsgPipe`, and that a send which fails does not leave one behind.
