### PR TITLE
.github: add a pull request template, and correct the contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,40 +1,51 @@
 # Contributing
 
-Thank you for considering to help out with the source code! We welcome 
-contributions from anyone on the internet, and are grateful for even the 
-smallest of fixes!
+This repository is Metadium's node implementation, forked from
+[go-ethereum](https://github.com/ethereum/go-ethereum). Contributions are
+welcome — fork, fix, commit, and open a pull request.
 
-If you'd like to contribute to go-ethereum, please fork, fix, commit and send a 
-pull request for the maintainers to review and merge into the main code base. If
-you wish to submit more complex changes though, please check up with the core 
-devs first on [our gitter channel](https://gitter.im/ethereum/go-ethereum) to 
-ensure those changes are in line with the general philosophy of the project 
-and/or get some early feedback which can make both your efforts much lighter as
-well as our review and merge procedures quick and simple.
+If a change is larger than a fix, open an issue first and describe the approach.
+That is cheaper than discovering in review that the change cannot ship for a
+reason that has nothing to do with its code.
+
+## Pull requests
+
+ * **Open pull requests against `dev`, not `master`.** `master` is the release
+   line: it carries tagged releases and is advanced from `dev` per release.
+ * Fill in the pull request template. Two parts of it are not optional:
+   * **Compatibility tier.** Metadium cannot require exchanges and external node
+     operators to upgrade, so every change is judged by what a node still running
+     the current release sees. A change that makes us accept something older
+     nodes reject is a hard fork, and calling it anything else is how a network
+     splits by accident.
+   * **Rollout.** Testnet block producers are upgraded first, and the remaining
+     testnet nodes are then verified on the old build, before any mainnet node is
+     touched. That is the only test that exercises a mixed fleet, which is the
+     state mainnet passes through and external operators stay in.
+ * Say what your tests prove. A test that fails without the change is worth more
+   than one that merely covers it.
 
 ## Coding guidelines
 
 Please make sure your contributions adhere to our coding guidelines:
 
- * Code must adhere to the official Go 
-[formatting](https://golang.org/doc/effective_go.html#formatting) guidelines 
+ * Code must adhere to the official Go
+[formatting](https://golang.org/doc/effective_go.html#formatting) guidelines
 (i.e. uses [gofmt](https://golang.org/cmd/gofmt/)).
- * Code must be documented adhering to the official Go 
+ * Code must be documented adhering to the official Go
 [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
- * Pull requests need to be based on and opened against the `master` branch.
  * Commit messages should be prefixed with the package(s) they modify.
    * E.g. "eth, rpc: make trace configs optional"
 
-## Can I have feature X
+## Building and testing
 
-Before you submit a feature request, please check and make sure that it isn't 
-possible through some other means. The JavaScript-enabled console is a powerful 
-feature in the right hands. Please check our 
-[Geth documentation page](https://geth.ethereum.org/docs/) for more info
-and help.
+See the README for build commands, the release build, and the local three-node
+PoA network. Both database engines have to build: the default LevelDB build and
+`-tags rocksdb`.
 
 ## Configuration, dependencies, and tests
 
-Please see the [Developers' Guide](https://geth.ethereum.org/docs/developers/geth-developer/dev-guide)
-for more details on configuring your environment, managing project dependencies
-and testing procedures.
+Much of the tree is still upstream go-ethereum, so the
+[Developers' Guide](https://geth.ethereum.org/docs/developers/geth-developer/dev-guide)
+remains a good reference for environment setup, dependency management, and
+testing procedures.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,66 @@
+<!-- Base this on `dev`, not `master`. `master` is the release line. -->
+
+## What this changes
+
+<!-- One paragraph: why, not only what. -->
+
+## Compatibility tier
+
+Metadium cannot force exchanges and external node operators to upgrade, so every
+change is judged by what a node still running the current release sees. Pick
+exactly one tier.
+
+- [ ] **C0 — consensus, loosening.** Accepts a block or transaction the current
+      release rejects. **This is a hard fork**: every node that has not upgraded
+      splits off. Needs a fork block, release notes, and exchange notice at D-14.
+- [ ] **C1 — consensus, tightening.** Rejects something the current release
+      accepts. External nodes are unaffected — they accept our blocks either way
+      — but a node running the rule stalls on a block that violates it, and the
+      only producers are our own BPs. So the question is not how fast we roll,
+      it is **whether the blocks being produced today already satisfy the rule**:
+      if they do, verifiers roll one at a time like any other release; if they
+      do not, **the producers move first** and the verifiers follow. State which
+      case this is, with evidence. A rule that also applies to history needs a
+      clean sync over the affected range before it is deployed at all.
+- [ ] **C2 — P2P wire.** Protocol versions or message shapes. `meta/66` must stay
+      advertised; it is the only version shared with the remaining 0.10.x nodes.
+- [ ] **C3 — database format.** Breaks the rollback path. Rolling back one minor
+      release currently works and must keep working.
+- [ ] **C4 — RPC/API.** Does not break a node that stays put, but breaks its
+      operator when they upgrade. Removing a namespace or changing a response
+      shape needs a deprecation window and notice, whatever upstream did.
+- [ ] **C5 — local pool or propagation policy.** No consensus effect; a mixed
+      fleet may route transactions differently.
+- [ ] **C6 — build or OS baseline.** glibc 2.31 (Ubuntu 20.04) is the floor —
+      raising it excludes operators. `make release-check` enforces it.
+- [ ] **C7 — internal only.** Tests, docs, tooling, or producer-side behaviour
+      that does not change block validity.
+
+**Why this tier:**
+
+<!-- One or two sentences. For C0-C4, state what a node on the current release sees. -->
+
+## Rollout
+
+- [ ] **Testnet BPs first, then verify the rest of the testnet on the old build.**
+      Upgrade only the testnet block producers, then confirm the non-BP nodes still
+      follow the chain, serve RPC, and accept transactions. **This must pass before
+      any mainnet node is touched** — it is the only test that exercises a genuinely
+      mixed fleet, which is the state mainnet will be in.
+- [ ] Remaining testnet nodes upgraded and soaked
+- [ ] Mainnet BPs rolled one at a time (PoA: never stop two at once, never `kill -9`)
+- [ ] C1 only: blocks in production already satisfy the rule (evidence above), or
+      the producers were upgraded first; and, if the rule applies to history, a
+      clean sync over the affected range has passed
+- [ ] C0 only: fork block set, release notes published, exchanges notified
+- [ ] Not applicable — nothing deploys (C7)
+
+## Verification
+
+<!-- What you ran and what it proved. A test that fails without the change is worth
+     more than one that merely covers it. -->
+
+- [ ] Affected packages pass (`make test`, or the specific packages)
+- [ ] Both engines build (`CGO_ENABLED=0`, and `-tags rocksdb`)
+- [ ] SPoA private network run — if consensus or mining is touched
+- [ ] Clean sync over the affected range — if the rule applies to history


### PR DESCRIPTION
Adds a pull request template, and corrects the contributing guide.

### Why

Metadium cannot require exchanges and external node operators to upgrade. That makes the question that decides whether a change can ship not *what it does* but *what a node still running the current release sees when it lands* — and that question was being answered per-change from memory.

It is easy to get wrong in the direction that matters. A change that makes us accept something older nodes reject splits the network; the reverse only ever stalls us. The two look alike in a diff.

### The template

**Compatibility tier** is a required field. The tiers name the axis rather than the severity: consensus loosening and tightening are separated because they have opposite blast radii, and wire, database format, RPC, pool policy and build baseline are listed apart because each breaks a different party at a different time. Each tier carries the constraint it has to respect, so a reviewer does not have to go find the policy — `meta/66` stays advertised because it is the only version shared with the remaining 0.10.x nodes, the rollback path stays open, glibc 2.31 stays the floor. There is a free-text line under the checkbox because a checked box records a claim and not a reason.

**Rollout** leads with the gate the fleet's own history argues for: testnet block producers are upgraded alone, and the rest of the testnet is then verified on the old build, before a mainnet node is touched. Upgrading everything at once and finding it healthy proves nothing about the state mainnet passes through on the way — and that external operators stay in permanently. A tightening rule shows its teeth only while the fleet is mixed.

### Contributing guide

It said to open pull requests against `master`. This tree releases from `master` and develops on `dev`, so that line pointed every contributor at the wrong base. Corrected, along with the dead gitter link and the framing that addressed the reader as an upstream go-ethereum contributor. The two-engine build requirement is now stated where someone looking for build instructions will find it.

### Compatibility tier of this change

**C7 — internal only.** Documentation and repository configuration; no code, no deployment.

### Verification

Rebased onto `dev` after the #91–#96 merges; rebase is clean. Markdown only — no build or test surface.
