### PR TITLE
cmd, params, core: close the config guard-rail residuals

### DIFF
--- a/cmd/geth/metadium_genesis_test.go
+++ b/cmd/geth/metadium_genesis_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// asPoA switches the process-wide consensus method for one test. Without it
+// core.DefaultGenesisBlock returns Ethereum's genesis, because the default
+// outside a running node is PoW.
+func asPoA(t *testing.T) {
+	t.Helper()
+	old := params.ConsensusMethod
+	params.ConsensusMethod = params.ConsensusPoA
+	t.Cleanup(func() { params.ConsensusMethod = old })
+}
+
+// servedGenesis renders a genesis document the way a peer would, with the chain
+// config replaced by the given one. Marshalling the canonical genesis and then
+// swapping the config is what produces a document whose block hash is canonical
+// while its config is not — the case this guards against.
+func servedGenesis(t *testing.T, network string, config *params.ChainConfig) []byte {
+	t.Helper()
+
+	var genesis *core.Genesis
+	switch network {
+	case "mainnet":
+		genesis = core.DefaultGenesisBlock()
+	case "testnet":
+		genesis = core.DefaultTestnetGenesisBlock()
+	default:
+		t.Fatalf("unknown network %q", network)
+	}
+	doc, err := json.Marshal(genesis)
+	if err != nil {
+		t.Fatalf("marshalling the %s genesis: %v", network, err)
+	}
+	if config == nil {
+		return doc
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(doc, &raw); err != nil {
+		t.Fatalf("re-reading the %s genesis: %v", network, err)
+	}
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling the replacement config: %v", err)
+	}
+	raw["config"] = encoded
+	doc, err = json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("re-writing the %s genesis: %v", network, err)
+	}
+	return doc
+}
+
+// TestCanonicalGenesisConfigReplacesStaleConfig is the case from issue #72: a
+// peer serves a genesis whose block is canonical but whose config predates a
+// fork. The block hash cannot detect that — the config is not part of the block
+// — so the config has to be compared and replaced.
+func TestCanonicalGenesisConfigReplacesStaleConfig(t *testing.T) {
+	asPoA(t)
+
+	for _, network := range []string{"mainnet", "testnet"} {
+		stale := *params.MetadiumMainnetChainConfig
+		if network == "testnet" {
+			stale = *params.MetadiumTestnetChainConfig
+		}
+		stale.CamelliaBlock = nil // as served by a pre-Camellia peer
+
+		out, got, replaced, err := canonicalGenesisConfig(servedGenesis(t, network, &stale))
+		if err != nil {
+			t.Fatalf("%s: %v", network, err)
+		}
+		if got != network {
+			t.Fatalf("%s: recognized as %q", network, got)
+		}
+		if !replaced {
+			t.Fatalf("%s: a stale config was passed through", network)
+		}
+		var result core.Genesis
+		if err := json.Unmarshal(out, &result); err != nil {
+			t.Fatalf("%s: the rewritten document does not parse: %v", network, err)
+		}
+		if result.Config.CamelliaBlock == nil {
+			t.Errorf("%s: the rewritten config still has no camelliaBlock", network)
+		}
+		// The block itself must be untouched, or the file would initialize a
+		// different chain than the one it was checked against.
+		want := servedGenesis(t, network, nil)
+		var original core.Genesis
+		if err := json.Unmarshal(want, &original); err != nil {
+			t.Fatalf("%s: %v", network, err)
+		}
+		if result.ToBlock().Hash() != original.ToBlock().Hash() {
+			t.Errorf("%s: the genesis block changed: have %x, want %x",
+				network, result.ToBlock().Hash(), original.ToBlock().Hash())
+		}
+	}
+}
+
+// TestCanonicalGenesisConfigAcceptsMatching leaves a correct document alone.
+func TestCanonicalGenesisConfigAcceptsMatching(t *testing.T) {
+	asPoA(t)
+
+	doc := servedGenesis(t, "mainnet", nil)
+
+	out, network, replaced, err := canonicalGenesisConfig(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != "mainnet" {
+		t.Fatalf("recognized as %q", network)
+	}
+	if replaced {
+		t.Fatal("a matching config was replaced")
+	}
+	if string(out) != string(doc) {
+		t.Fatal("a matching document was rewritten")
+	}
+}
+
+// TestCanonicalGenesisConfigPassesPrivateNet checks that the guard does not
+// break the command's other use: private networks bootstrap from a peer exactly
+// this way, and there is no canonical config to compare them against.
+func TestCanonicalGenesisConfigPassesPrivateNet(t *testing.T) {
+	asPoA(t)
+
+	private := core.DefaultGenesisBlock()
+	private.Nonce = 0x4242 // any change to a block field moves the hash
+	doc, err := json.Marshal(private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, network, replaced, err := canonicalGenesisConfig(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != "" || replaced {
+		t.Fatalf("a private genesis was treated as %q (replaced=%v)", network, replaced)
+	}
+	if string(out) != string(doc) {
+		t.Fatal("a private genesis was rewritten")
+	}
+}

--- a/cmd/geth/metadiumcmd.go
+++ b/cmd/geth/metadiumcmd.go
@@ -26,12 +26,15 @@ import (
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metadium/logrot"
 	"github.com/ethereum/go-ethereum/metadium/metclient"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/urfave/cli/v2"
 )
 
@@ -563,6 +566,66 @@ type genesisReturn struct {
 	Result string `json:"result"`
 }
 
+// canonicalGenesisConfig checks a genesis document served by a peer and, when it
+// is one of the canonical Metadium networks, replaces its chain config with the
+// compiled one.
+//
+// The genesis block hash does not cover the chain config, so a file that is
+// stale by a fork -- one written before camelliaBlock existed, say -- produces
+// the canonical hash while carrying a config that diverges from this binary's.
+// Initializing an empty datadir with such a file runs the first session on that
+// config, because $datadir/genesis.json is preferred over the embedded one
+// (core.loadDefaultGenesisFile). A restart self-heals, since the stored-config
+// path substitutes the compiled config, but the first session does not (#72).
+//
+// Everything except "config" is passed through byte for byte: the block fields
+// are what the hash is computed over, and they matched. A genesis that is not a
+// canonical network is left alone -- private networks bootstrap from a peer
+// exactly this way, and there is nothing to compare them against.
+//
+// It returns the document to write, the network name ("" when not canonical),
+// and whether the config was replaced.
+func canonicalGenesisConfig(doc []byte) ([]byte, string, bool, error) {
+	var parsed core.Genesis
+	if err := json.Unmarshal(doc, &parsed); err != nil {
+		return nil, "", false, fmt.Errorf("the served genesis does not parse: %w", err)
+	}
+	var (
+		network  string
+		compiled *params.ChainConfig
+	)
+	switch parsed.ToBlock().Hash() {
+	case params.MetadiumMainnetGenesisHash:
+		network, compiled = "mainnet", params.MetadiumMainnetChainConfig
+	case params.MetadiumTestnetGenesisHash:
+		network, compiled = "testnet", params.MetadiumTestnetChainConfig
+	default:
+		return doc, "", false, nil
+	}
+	served, err := json.Marshal(parsed.Config)
+	if err != nil {
+		return nil, network, false, err
+	}
+	want, err := json.Marshal(compiled)
+	if err != nil {
+		return nil, network, false, err
+	}
+	if bytes.Equal(served, want) {
+		return doc, network, false, nil
+	}
+	// Replace the config key only, leaving the rest of the document untouched.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(doc, &raw); err != nil {
+		return nil, network, false, err
+	}
+	raw["config"] = want
+	out, err := json.MarshalIndent(raw, "", "    ")
+	if err != nil {
+		return nil, network, false, err
+	}
+	return append(out, '\n'), network, true, nil
+}
+
 func downloadGenesis(ctx *cli.Context) error {
 	url := ctx.String(urlFlag.Name)
 	if url == "" {
@@ -586,6 +649,20 @@ func downloadGenesis(ctx *cli.Context) error {
 		return err
 	}
 
+	doc, network, replaced, err := canonicalGenesisConfig([]byte(genesis.Result))
+	if err != nil {
+		return err
+	}
+	switch {
+	case network == "":
+		log.Info("Genesis is not a canonical Metadium network, using it as served")
+	case replaced:
+		log.Warn("Peer served a stale chain config for a canonical network; using the compiled one",
+			"network", network)
+	default:
+		log.Info("Genesis matches the canonical network and its compiled config", "network", network)
+	}
+
 	w := os.Stdout
 	if fn := ctx.String(outFlag.Name); fn != "" {
 		w, err = os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
@@ -595,7 +672,7 @@ func downloadGenesis(ctx *cli.Context) error {
 		defer w.Close()
 	}
 
-	w.Write([]byte(genesis.Result))
+	w.Write(doc)
 	return nil
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -344,6 +344,14 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedbpkg.Database
 	// stored-vs-compiled compatibility check below still guards the switch;
 	// with the testnet DAO/Petersburg fields restored to 0.10.x parity there
 	// is no first-check mismatch left to mask later forks' checks.
+	//
+	// The consequence, recorded so it is discoverable rather than surprising
+	// (issue #72): a datadir initialized from a *modified* canonical genesis
+	// file — same genesis block, deliberately divergent stored config — loses
+	// those overrides here, because the compiled config wins for canonical
+	// hashes. Passing the genesis file explicitly is the escape. No internal
+	// rig depends on the old behaviour; this was verified when the exclusion
+	// was introduced.
 	if genesis == nil && stored != params.MainnetGenesisHash && stored != params.MetadiumMainnetGenesisHash && stored != params.MetadiumTestnetGenesisHash {
 		newcfg = storedcfg
 		applyOverrides(newcfg)

--- a/params/config.go
+++ b/params/config.go
@@ -741,12 +741,26 @@ func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64, time u
 
 // CheckConfigForkOrder checks that we don't "skip" any forks, geth isn't pluggable enough
 // to guarantee that forks can be implemented in a different order than on official networks
+// CheckConfigForkOrder deliberately enforces nothing.
+//
+// Metadium chains carry stored configs written by earlier releases, and some of
+// them do not satisfy upstream's ordering rules. Enforcing at runtime would
+// refuse to start on those datadirs, which is a separate piece of work with its
+// own analysis (issue #72).
+//
+// The ordering logic itself is not dead, though: checkForkOrder holds it, and
+// the built-in Metadium configs are checked against it in the params tests. That
+// is what would have caught the nil PetersburgBlock that survived two release
+// lines, since nothing else compares a config against the fork sequence.
 func (c *ChainConfig) CheckConfigForkOrder() error {
-	// In metadium, this is not enforced.
-	if true {
-		return nil
-	}
+	return nil
+}
 
+// checkForkOrder reports whether the fork schedule is internally consistent:
+// no gap before a later fork, no fork scheduled before its predecessor, and no
+// block-numbered fork after a timestamped one. It is upstream's check, kept
+// callable for tests over configs this repository ships.
+func (c *ChainConfig) checkForkOrder() error {
 	type fork struct {
 		name      string
 		block     *big.Int // forks up to - and including the merge - were defined with block numbers

--- a/params/metadium_config_test.go
+++ b/params/metadium_config_test.go
@@ -11,6 +11,7 @@ package params
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 )
 
@@ -107,5 +108,81 @@ func TestMetadiumChainConfigsPinned(t *testing.T) {
 				"checkCompatible returns on the first failing check)",
 				network.name, c.DAOForkSupport, network.daoFork)
 		}
+	}
+}
+
+// TestMetadiumConfigForkOrder records what the built-in configs do when measured
+// against upstream's fork ordering rules — and they do not satisfy them. On both
+// networks EIP-150 is scheduled long after EIP-155 and EIP-158, which upstream
+// treats as an ordering violation.
+//
+// That is deployed history: mainnet has been running since block 0 with this
+// schedule, and it cannot be reordered. It is also the concrete reason
+// CheckConfigForkOrder must keep enforcing nothing at runtime — turning it on
+// would refuse to start on our own mainnet (issue #72).
+//
+// Pinning the exact deviation is what makes the check useful here: a schedule
+// that grows a second, unintended violation changes this string, and so does
+// fixing this one.
+func TestMetadiumConfigForkOrder(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		config *ChainConfig
+		want   string
+	}{
+		{"mainnet", MetadiumMainnetChainConfig, "eip150Block enabled at block 11441000, but eip155Block enabled at block 0"},
+		{"testnet", MetadiumTestnetChainConfig, "eip150Block enabled at block 5623000, but eip155Block enabled at block 0"},
+	} {
+		err := tt.config.checkForkOrder()
+		if err == nil {
+			t.Errorf("%s: the known ordering deviation is gone; if that was intended, update this test", tt.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tt.want) {
+			t.Errorf("%s: fork ordering changed\n have: %v\n want it to contain: %s", tt.name, err, tt.want)
+		}
+		// The runtime entry point stays inert regardless.
+		if err := tt.config.CheckConfigForkOrder(); err != nil {
+			t.Errorf("%s: CheckConfigForkOrder started enforcing, which would refuse this config at startup: %v", tt.name, err)
+		}
+	}
+}
+
+// TestForkOrderCatchesAGap guards the extracted check itself: a test that only
+// ever sees the same input cannot tell a working check from one that returns
+// nil. The gap it catches here — Istanbul scheduled with Petersburg unset — is
+// the shape that survived two release lines in the testnet config.
+func TestForkOrderCatchesAGap(t *testing.T) {
+	ordered := &ChainConfig{
+		ChainID:             big.NewInt(1),
+		HomesteadBlock:      big.NewInt(0),
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+	}
+	if err := ordered.checkForkOrder(); err != nil {
+		t.Fatalf("a well-ordered config was rejected: %v", err)
+	}
+
+	gapped := *ordered
+	gapped.PetersburgBlock = nil
+	err := gapped.checkForkOrder()
+	if err == nil {
+		t.Fatal("a config with Istanbul set and Petersburg unset was accepted")
+	}
+	if !strings.Contains(err.Error(), "petersburgBlock") {
+		t.Fatalf("the error does not name the missing fork: %v", err)
+	}
+
+	// And one scheduled out of sequence.
+	backwards := *ordered
+	backwards.IstanbulBlock = big.NewInt(0)
+	backwards.PetersburgBlock = big.NewInt(100)
+	if err := backwards.checkForkOrder(); err == nil {
+		t.Fatal("a fork scheduled before its predecessor was accepted")
 	}
 }


### PR DESCRIPTION
Closes the remaining config guard-rail items from issue #72.

### What this changes

**`downloadGenesis` now substitutes the compiled chain config for canonical networks.** The genesis block hash does not cover the chain config, so a genesis file that is stale by a fork — one written before `camelliaBlock` existed, say — still hashes to the canonical value while carrying a config that diverges from this binary's. Initializing an empty datadir with such a file runs the *first* session on that config, because `$datadir/genesis.json` is preferred over the embedded one. A restart self-heals, since the stored-config path substitutes the compiled config, but the first session does not.

Everything except `config` is passed through byte for byte: the block fields are what the hash is computed over, and they matched. A genesis that is not a canonical network is left alone — private networks bootstrap from a peer exactly this way, and there is nothing to compare them against. The three outcomes are logged distinctly, so "peer served a stale config" is visible rather than silent.

**`CheckConfigForkOrder` is honest about enforcing nothing.** It previously carried upstream's ordering logic behind `if true { return nil }`, which reads as an oversight rather than a decision. Metadium chains carry stored configs written by earlier releases and some do not satisfy upstream's ordering rules, so enforcing at runtime would refuse to start on those datadirs — that is separate work with its own analysis. The logic is not deleted: it moves to `checkForkOrder`, and the built-in Metadium configs are checked against it in the params tests. That is what would have caught the nil `PetersburgBlock` that survived two release lines, since nothing else compares a config against the fork sequence.

**A consequence in `core/genesis.go` is now recorded** rather than left to be rediscovered: a datadir initialized from a *modified* canonical genesis file loses those overrides, because the compiled config wins for canonical hashes. Passing the genesis file explicitly is the escape.

### Compatibility tier

**C7 — internal only.** No consensus, wire, database, or RPC surface. `CheckConfigForkOrder` still returns `nil`, so runtime behaviour on existing datadirs is unchanged; the new fork-order check runs only in tests. The `downloadGenesis` change affects a one-shot CLI command, and only in the direction of using this binary's own compiled config.

### Verification

Rebased onto `dev` after the #91–#96 merges. The rebase conflicted in one place — `#91` and this branch each added an import to the same block in `cmd/geth/metadiumcmd.go` — resolved by keeping both.

Run on a clean worktree at the rebased commit:

- `gofmt -l` — clean
- `CGO_ENABLED=0 go build ./cmd/geth` — builds
- `go vet ./cmd/geth/ ./params/ ./core/` — clean
- `go test ./cmd/geth/ -run Genesis` — ok
- `go test ./params/` — ok
- `go test ./metadium/logrot/` — ok (regression check, since the conflict was in a file #91 also changed)
