### PR TITLE
p2p: give up on a stalled dial instead of holding its slot forever

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -25,6 +25,7 @@ import (
 	mrand "math/rand"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -248,7 +249,7 @@ loop:
 			}
 
 		case task := <-d.doneCh:
-			id := task.dest.ID()
+			id := task.dest().ID()
 			delete(d.dialing, id)
 			d.updateStaticPool(id)
 			d.doneSinceLastLog++
@@ -410,7 +411,7 @@ func (d *dialScheduler) startStaticDials(n int) (started int) {
 // updateStaticPool attempts to move the given static dial back into staticPool.
 func (d *dialScheduler) updateStaticPool(id enode.ID) {
 	task, ok := d.static[id]
-	if ok && task.staticPoolIndex < 0 && d.checkDial(task.dest) == nil {
+	if ok && task.staticPoolIndex < 0 && d.checkDial(task.dest()) == nil {
 		d.addToStaticPool(task)
 	}
 }
@@ -437,10 +438,11 @@ func (d *dialScheduler) removeFromStaticPool(idx int) {
 
 // startDial runs the given dial task in a separate goroutine.
 func (d *dialScheduler) startDial(task *dialTask) {
-	d.log.Trace("Starting p2p dial", "id", task.dest.ID(), "ip", task.dest.IP(), "flag", task.flags)
-	hkey := string(task.dest.ID().Bytes())
+	node := task.dest()
+	d.log.Trace("Starting p2p dial", "id", node.ID(), "ip", node.IP(), "flag", task.flags)
+	hkey := string(node.ID().Bytes())
 	d.history.add(hkey, d.clock.Now().Add(dialHistoryExpiration))
-	d.dialing[task.dest.ID()] = task
+	d.dialing[node.ID()] = task
 	go func() {
 		task.run(d)
 		d.doneCh <- task
@@ -451,19 +453,26 @@ func (d *dialScheduler) startDial(task *dialTask) {
 type dialTask struct {
 	staticPoolIndex int
 	flags           connFlag
+
 	// These fields are private to the task and should not be
 	// accessed by dialScheduler while the task is running.
-	dest         *enode.Node
+	destPtr      atomic.Pointer[enode.Node]
 	lastResolved mclock.AbsTime
 	resolveDelay time.Duration
 }
 
 func newDialTask(dest *enode.Node, flags connFlag) *dialTask {
-	return &dialTask{dest: dest, flags: flags, staticPoolIndex: -1}
+	t := &dialTask{flags: flags, staticPoolIndex: -1}
+	t.destPtr.Store(dest)
+	return t
 }
 
 type dialError struct {
 	error
+}
+
+func (t *dialTask) dest() *enode.Node {
+	return t.destPtr.Load()
 }
 
 func (t *dialTask) run(d *dialScheduler) {
@@ -471,19 +480,19 @@ func (t *dialTask) run(d *dialScheduler) {
 		return
 	}
 
-	err := t.dial(d, t.dest)
+	err := t.dial(d, t.dest())
 	if err != nil {
 		// For static nodes, resolve one more time if dialing fails.
 		if _, ok := err.(*dialError); ok && t.flags&staticDialedConn != 0 {
 			if t.resolve(d) {
-				t.dial(d, t.dest)
+				t.dial(d, t.dest())
 			}
 		}
 	}
 }
 
 func (t *dialTask) needResolve() bool {
-	return t.flags&staticDialedConn != 0 && t.dest.IP() == nil
+	return t.flags&staticDialedConn != 0 && t.dest().IP() == nil
 }
 
 // resolve attempts to find the current endpoint for the destination
@@ -502,29 +511,31 @@ func (t *dialTask) resolve(d *dialScheduler) bool {
 	if t.lastResolved > 0 && time.Duration(d.clock.Now()-t.lastResolved) < t.resolveDelay {
 		return false
 	}
-	resolved := d.resolver.Resolve(t.dest)
+
+	node := t.dest()
+	resolved := d.resolver.Resolve(node)
 	t.lastResolved = d.clock.Now()
 	if resolved == nil {
 		t.resolveDelay *= 2
 		if t.resolveDelay > maxResolveDelay {
 			t.resolveDelay = maxResolveDelay
 		}
-		d.log.Debug("Resolving node failed", "id", t.dest.ID(), "newdelay", t.resolveDelay)
+		d.log.Debug("Resolving node failed", "id", node.ID(), "newdelay", t.resolveDelay)
 		return false
 	}
 	// The node was found.
 	t.resolveDelay = initialResolveDelay
-	t.dest = resolved
-	d.log.Debug("Resolved node", "id", t.dest.ID(), "addr", &net.TCPAddr{IP: t.dest.IP(), Port: t.dest.TCP()})
+	t.destPtr.Store(resolved)
+	d.log.Debug("Resolved node", "id", resolved.ID(), "addr", &net.TCPAddr{IP: resolved.IP(), Port: resolved.TCP()})
 	return true
 }
 
 // dial performs the actual connection attempt.
 func (t *dialTask) dial(d *dialScheduler, dest *enode.Node) error {
 	dialMeter.Mark(1)
-	fd, err := d.dialer.Dial(d.ctx, t.dest)
+	fd, err := d.dialer.Dial(d.ctx, dest)
 	if err != nil {
-		d.log.Trace("Dial error", "id", t.dest.ID(), "addr", nodeAddr(t.dest), "conn", t.flags, "err", cleanupDialErr(err))
+		d.log.Trace("Dial error", "id", dest.ID(), "addr", nodeAddr(dest), "conn", t.flags, "err", cleanupDialErr(err))
 		dialConnectionError.Mark(1)
 		return &dialError{err}
 	}
@@ -532,8 +543,9 @@ func (t *dialTask) dial(d *dialScheduler, dest *enode.Node) error {
 }
 
 func (t *dialTask) String() string {
-	id := t.dest.ID()
-	return fmt.Sprintf("%v %x %v:%d", t.flags, id[:8], t.dest.IP(), t.dest.TCP())
+	node := t.dest()
+	id := node.ID()
+	return fmt.Sprintf("%v %x %v:%d", t.flags, id[:8], node.IP(), node.TCP())
 }
 
 func cleanupDialErr(err error) error {

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -47,6 +47,22 @@ const (
 	// Endpoint resolution is throttled with bounded backoff.
 	initialResolveDelay = 60 * time.Second
 	maxResolveDelay     = time.Hour
+
+	// A dial task holds its destination in d.dialing for as long as it runs, and
+	// checkDial refuses to dial a node that is already in there. Nothing bounds how
+	// long a task may run: the socket dial and both handshakes have deadlines, but
+	// Server.checkpoint then waits on the run loop with none, so a task that never
+	// returns keeps its destination unreachable for the life of the process. Static
+	// peers never come back, and admin_addPeer keeps reporting success because it
+	// only registers the node -- which is what makes it hard to see.
+	//
+	// After this much time the scheduler gives up on a task and releases the slot,
+	// so a stall degrades to a delayed retry instead of a permanent one. The bound
+	// is far beyond any healthy dial: defaultDialTimeout is 15s and each handshake
+	// has a 5s deadline, so a task that is still running here is not making
+	// progress. The abandoned goroutine is left alone -- there is no way to cancel
+	// it -- and if it ever does connect, the server rejects the duplicate.
+	stalledDialTimeout = 2 * time.Minute
 )
 
 // NodeDialer is used to connect to nodes in the network, typically by using
@@ -110,6 +126,11 @@ type dialScheduler struct {
 	peers     map[enode.ID]struct{}  // all connected peers
 	dialPeers int                    // current number of dialed peers
 
+	// running counts the task goroutines that have not reported back yet. It differs
+	// from len(dialing) once a slot has been reaped: the task keeps running and will
+	// still send on doneCh, so shutdown has to drain this many, not that many.
+	running int
+
 	// The static map tracks all static dial tasks. The subset of usable static dial tasks
 	// (i.e. those passing checkDial) is kept in staticPool. The scheduler prefers
 	// launching random static tasks from the pool over launching dynamic dials from the
@@ -120,6 +141,9 @@ type dialScheduler struct {
 	// The dial history keeps recently dialed nodes. Members of history are not dialed.
 	history      expHeap
 	historyTimer *mclock.Alarm
+
+	// stalledTimer fires when the oldest entry in dialing is due to be given up on.
+	stalledTimer *mclock.Alarm
 
 	// for logStats
 	lastStatsLog     mclock.AbsTime
@@ -164,6 +188,7 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 	d := &dialScheduler{
 		dialConfig:   cfg,
 		historyTimer: mclock.NewAlarm(cfg.clock),
+		stalledTimer: mclock.NewAlarm(cfg.clock),
 		setupFunc:    setupFunc,
 		dialing:      make(map[enode.ID]*dialTask),
 		static:       make(map[enode.ID]*dialTask),
@@ -238,6 +263,7 @@ loop:
 			nodesCh = nil
 		}
 		d.rearmHistoryTimer()
+		d.rearmStalledTimer()
 		d.logStats()
 
 		select {
@@ -250,7 +276,12 @@ loop:
 
 		case task := <-d.doneCh:
 			id := task.dest().ID()
-			delete(d.dialing, id)
+			d.running--
+			// The slot may already have been given up on and handed to a later
+			// task for the same node, in which case this one no longer owns it.
+			if d.dialing[id] == task {
+				delete(d.dialing, id)
+			}
 			d.updateStaticPool(id)
 			d.doneSinceLastLog++
 
@@ -301,6 +332,9 @@ loop:
 		case <-d.historyTimer.C():
 			d.expireHistory()
 
+		case <-d.stalledTimer.C():
+			d.reapStalledDials()
+
 		case <-d.ctx.Done():
 			it.Close()
 			break loop
@@ -308,7 +342,8 @@ loop:
 	}
 
 	d.historyTimer.Stop()
-	for range d.dialing {
+	d.stalledTimer.Stop()
+	for ; d.running > 0; d.running-- {
 		<-d.doneCh
 	}
 	d.wg.Done()
@@ -349,6 +384,38 @@ func (d *dialScheduler) rearmHistoryTimer() {
 		return
 	}
 	d.historyTimer.Schedule(d.history.nextExpiry())
+}
+
+// rearmStalledTimer configures d.stalledTimer to fire when the oldest running
+// dial task is due to be given up on.
+func (d *dialScheduler) rearmStalledTimer() {
+	if len(d.dialing) == 0 {
+		return
+	}
+	var next mclock.AbsTime
+	first := true
+	for _, task := range d.dialing {
+		if first || task.reapAt < next {
+			next, first = task.reapAt, false
+		}
+	}
+	d.stalledTimer.Schedule(next)
+}
+
+// reapStalledDials releases the slots held by dial tasks that have run for longer
+// than stalledDialTimeout, so their destinations can be dialed again. The tasks
+// themselves keep running; they cannot be cancelled, and the slot is what matters.
+func (d *dialScheduler) reapStalledDials() {
+	now := d.clock.Now()
+	for id, task := range d.dialing {
+		if now < task.reapAt {
+			continue
+		}
+		d.log.Warn("Giving up on stalled p2p dial",
+			"id", id, "flag", task.flags, "elapsed", now.Sub(task.startedAt))
+		delete(d.dialing, id)
+		d.updateStaticPool(id)
+	}
 }
 
 // expireHistory removes expired items from d.history.
@@ -441,8 +508,12 @@ func (d *dialScheduler) startDial(task *dialTask) {
 	node := task.dest()
 	d.log.Trace("Starting p2p dial", "id", node.ID(), "ip", node.IP(), "flag", task.flags)
 	hkey := string(node.ID().Bytes())
-	d.history.add(hkey, d.clock.Now().Add(dialHistoryExpiration))
+	now := d.clock.Now()
+	d.history.add(hkey, now.Add(dialHistoryExpiration))
+	task.startedAt = now
+	task.reapAt = now.Add(stalledDialTimeout)
 	d.dialing[node.ID()] = task
+	d.running++
 	go func() {
 		task.run(d)
 		d.doneCh <- task
@@ -453,6 +524,10 @@ func (d *dialScheduler) startDial(task *dialTask) {
 type dialTask struct {
 	staticPoolIndex int
 	flags           connFlag
+	// startedAt and reapAt are set by the scheduler before the task is launched and
+	// read only by the scheduler, so the task goroutine never touches them.
+	startedAt mclock.AbsTime
+	reapAt    mclock.AbsTime
 
 	// These fields are private to the task and should not be
 	// accessed by dialScheduler while the task is running.

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -61,7 +61,11 @@ const (
 	// is far beyond any healthy dial: defaultDialTimeout is 15s and each handshake
 	// has a 5s deadline, so a task that is still running here is not making
 	// progress. The abandoned goroutine is left alone -- there is no way to cancel
-	// it -- and if it ever does connect, the server rejects the duplicate.
+	// it -- and if it ever does connect, the server rejects the duplicate. It does
+	// still report back, so shutdown drains it like any other. A destination that
+	// stays wedged is retried on this period and accumulates one goroutine each
+	// time, which is the cost of not being able to cancel; the alternative is the
+	// peer never being dialed again.
 	stalledDialTimeout = 2 * time.Minute
 )
 
@@ -414,6 +418,21 @@ func (d *dialScheduler) reapStalledDials() {
 		d.log.Warn("Giving up on stalled p2p dial",
 			"id", id, "flag", task.flags, "elapsed", now.Sub(task.startedAt))
 		delete(d.dialing, id)
+		// A static destination is served by one long-lived task object, which
+		// updateStaticPool returns to the pool and startStaticDials launches
+		// again. Handing that same object to a replacement while the abandoned
+		// goroutine still holds it would put two runs inside one dialTask: the
+		// identity check in the doneCh handler could not tell them apart, and
+		// both would write lastResolved and resolveDelay in resolve(). Give the
+		// static entry a fresh object and leave the old one to its goroutine.
+		//
+		// The resolver backoff is not carried over, because a task that got far
+		// enough to stall has already resolved -- needResolve is false once dest
+		// has an IP -- so there is no backoff worth preserving, and reading those
+		// fields here would be the very race this avoids.
+		if cur, ok := d.static[id]; ok && cur == task {
+			d.static[id] = newDialTask(task.dest(), task.flags)
+		}
 		d.updateStaticPool(id)
 	}
 }

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -186,6 +186,195 @@ func TestDialSchedStalledDial(t *testing.T) {
 	runDialTest(t, config, rounds)
 }
 
+// seqDialTestDialer hands every Dial call to the test on a channel, so two
+// concurrent dials to the same node can be completed independently.
+// dialTestDialer cannot do that: it keys blocked calls by node ID, so the second
+// dial to a node overwrites the first and the first can never be released.
+type seqDialTestDialer struct {
+	calls chan *dialTestReq
+}
+
+func newSeqDialTestDialer() *seqDialTestDialer {
+	return &seqDialTestDialer{calls: make(chan *dialTestReq, 8)}
+}
+
+func (d *seqDialTestDialer) Dial(ctx context.Context, n *enode.Node) (net.Conn, error) {
+	req := &dialTestReq{n: n, unblock: make(chan error, 1)}
+	select {
+	case d.calls <- req:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case err := <-req.unblock:
+		if err != nil {
+			return nil, err
+		}
+		pipe, _ := net.Pipe()
+		return pipe, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// nextDial returns the next dial call, failing the test if none arrives.
+func (d *seqDialTestDialer) nextDial(t *testing.T, what string) *dialTestReq {
+	t.Helper()
+	select {
+	case req := <-d.calls:
+		return req
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+		return nil
+	}
+}
+
+// noDial fails the test if any dial is attempted within the grace period.
+func (d *seqDialTestDialer) noDial(t *testing.T, grace time.Duration, why string) {
+	t.Helper()
+	select {
+	case req := <-d.calls:
+		t.Fatalf("unexpected dial to %v: %s", req.n.ID(), why)
+	case <-time.After(grace):
+	}
+}
+
+// newStalledDialTestScheduler builds a scheduler wired to a sequential dialer,
+// with one static node whose first dial is already in flight and stalled.
+func newStalledDialTestScheduler(t *testing.T, node *enode.Node) (*dialScheduler, *seqDialTestDialer, *mclock.Simulated, *dialTestReq) {
+	t.Helper()
+
+	clock := new(mclock.Simulated)
+	dialer := newSeqDialTestDialer()
+	config := dialConfig{
+		maxActiveDials: 2,
+		maxDialPeers:   2,
+		clock:          clock,
+		dialer:         dialer,
+		log:            testlog.Logger(t, log.LvlTrace),
+		rand:           rand.New(rand.NewSource(0x2222)),
+	}
+	d := newDialScheduler(config, newDialTestIterator(), func(net.Conn, connFlag, *enode.Node) error {
+		return nil
+	})
+
+	d.addStatic(node)
+	return d, dialer, clock, dialer.nextDial(t, "the first dial")
+}
+
+// This test checks that when an abandoned dial finally returns, it does not take
+// away the slot held by the dial that replaced it.
+//
+// A static destination is served by one long-lived dialTask that is returned to
+// the pool and launched again, so the abandoned run and its replacement would
+// otherwise be the same object. The identity check in the doneCh handler cannot
+// tell those apart, so the late return would free a slot that is still in use
+// and the scheduler would start a third concurrent dial to the same node.
+func TestDialSchedReapedStaticDialKeepsItsSlot(t *testing.T) {
+	node := newNode(uintID(0x01), "127.0.0.1:30303")
+	d, dialer, clock, first := newStalledDialTestScheduler(t, node)
+	defer d.stop()
+
+	// The first dial never completes, so its slot is given up on and the node is
+	// dialed again.
+	clock.Run(stalledDialTimeout + time.Second)
+	second := dialer.nextDial(t, "the redial after the stall")
+
+	// Now the abandoned run returns. The second dial is still in flight.
+	first.unblock <- errors.New("stalled dial finally returned")
+
+	// Expire the dial history, which is the only other thing that would hold a
+	// third dial back. Nothing may be dialed: the slot belongs to the second run.
+	clock.Run(dialHistoryExpiration + time.Second)
+	dialer.noDial(t, 300*time.Millisecond, "the abandoned run released a slot it no longer owned")
+
+	second.unblock <- errors.New("done")
+}
+
+// This test checks that shutdown waits for every dial goroutine it launched,
+// including those whose slot was given up on. Draining one reply per entry in
+// dialing rather than one per goroutine leaves an abandoned task blocked on the
+// unbuffered doneCh forever.
+func TestDialSchedShutdownDrainsReapedDial(t *testing.T) {
+	node := newNode(uintID(0x02), "127.0.0.1:30303")
+	d, dialer, clock, _ := newStalledDialTestScheduler(t, node)
+
+	// Give up on the first dial and let the replacement start, so there are two
+	// task goroutines outstanding but only one entry in dialing.
+	clock.Run(stalledDialTimeout + time.Second)
+	dialer.nextDial(t, "the redial after the stall")
+
+	// Both dials are still blocked; stop cancels their context, so both return
+	// and both must be drained.
+	d.stop()
+
+	// Nothing may be left waiting to report. A reply arriving here is one the
+	// drain failed to take.
+	select {
+	case task := <-d.doneCh:
+		t.Fatalf("shutdown left a dial task undrained: %v", task.dest().ID())
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// blockingDialTestResolver holds every Resolve call until the test releases it,
+// so more than one task can be parked inside resolve() at the same time.
+type blockingDialTestResolver struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingDialTestResolver) Resolve(n *enode.Node) *enode.Node {
+	r.entered <- struct{}{}
+	<-r.release
+	return newNode(n.ID(), "127.0.0.1:30303")
+}
+
+// This test checks that an abandoned dial and the one replacing it do not end up
+// inside resolve() on the same task.
+//
+// A static node with no endpoint has to be resolved before it can be dialed, and
+// resolve() writes lastResolved and resolveDelay. Those are plain fields, so two
+// runs sharing a task would race on them -- reachable only through a reap, since
+// that is what launches a second run while the first is still going. Run under
+// -race; without the fix the detector reports the write pair.
+func TestDialSchedReapedStaticDialDoesNotShareResolveState(t *testing.T) {
+	resolver := &blockingDialTestResolver{
+		entered: make(chan struct{}, 4),
+		release: make(chan struct{}),
+	}
+	clock := new(mclock.Simulated)
+	dialer := newSeqDialTestDialer()
+	config := dialConfig{
+		maxActiveDials: 2,
+		maxDialPeers:   2,
+		clock:          clock,
+		dialer:         dialer,
+		resolver:       resolver,
+		log:            testlog.Logger(t, log.LvlTrace),
+		rand:           rand.New(rand.NewSource(0x3333)),
+	}
+	d := newDialScheduler(config, newDialTestIterator(), func(net.Conn, connFlag, *enode.Node) error {
+		return nil
+	})
+	defer func() {
+		close(resolver.release)
+		d.stop()
+	}()
+
+	// A static node with no endpoint: the task parks in resolve() and never
+	// reaches the dialer, so its slot is eventually given up on.
+	d.addStatic(newNode(uintID(0x03), ""))
+	<-resolver.entered
+
+	clock.Run(stalledDialTimeout + time.Second)
+	select {
+	case <-resolver.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the replacement task never reached resolve")
+	}
+}
+
 // This test checks that static dials work and obey the limits.
 func TestDialSchedStaticDial(t *testing.T) {
 	t.Parallel()

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -152,6 +152,40 @@ func TestDialSchedNetRestrict(t *testing.T) {
 	})
 }
 
+// This test checks that a dial task which never finishes stops holding its slot,
+// so the node it was dialing can be dialed again. Without that, the destination
+// stays in dialing forever, checkDial refuses every later attempt, and a static
+// peer lost this way never comes back short of restarting the process.
+func TestDialSchedStalledDial(t *testing.T) {
+	t.Parallel()
+
+	node := newNode(uintID(0x01), "127.0.0.1:30303")
+	config := dialConfig{
+		// One slot, so the stalled task also starves the scheduler until it
+		// is given up on.
+		maxActiveDials: 1,
+		maxDialPeers:   1,
+	}
+
+	rounds := []dialTestRound{
+		// The dial is launched here and never completed: the round lists it
+		// under neither succeeded nor failed.
+		{
+			update:       func(d *dialScheduler) { d.addStatic(node) },
+			wantNewDials: []*enode.Node{node},
+		},
+	}
+	// Wait out stalledDialTimeout. Each round advances the clock by 16s, and no
+	// round in between may launch a dial -- the slot is still held.
+	for elapsed := 16 * time.Second; elapsed <= stalledDialTimeout; elapsed += 16 * time.Second {
+		rounds = append(rounds, dialTestRound{})
+	}
+	// The slot is released by now, so the node is dialed again.
+	rounds = append(rounds, dialTestRound{wantNewDials: []*enode.Node{node}})
+
+	runDialTest(t, config, rounds)
+}
+
 // This test checks that static dials work and obey the limits.
 func TestDialSchedStaticDial(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Bounds the damage from issue #103, where a node stops dialling a peer entirely and never resumes. Does not fix the underlying stall — see the last section.

## What this changes

A dial task keeps its destination in `dialing` for as long as it runs, and `checkDial` refuses to dial a node that is already in there. Nothing bounds how long a task may run: the socket dial and both handshakes have deadlines, but `Server.checkpoint` then waits on the run loop with none, so a task that never returns keeps its destination unreachable for the life of the process.

We have hit this twice, both after a peer restarted underneath a node. One of our block producers stopped re-dialling a restarted peer for fifteen minutes and recovered only when we restarted the node itself. An exchange's node lost its peers the same way and sat there for sixteen days, alive and serving RPC, holding a transaction in its local pool that went out the moment it came back with peers.

Neither node sent a TCP SYN in that state — nothing was being attempted — and nothing appeared in the log at any verbosity, for the same reason. `admin_addPeer` kept returning `true` throughout, because `addStatic` only registers the node. `removePeer` followed by `addPeer` did not help either: `removeStatic` leaves the `dialing` entry untouched, so the fresh task is refused with `errAlreadyDialing` and never reaches the static pool. Both calls succeed and nothing happens, which is most of why this was hard to see.

**The change bounds how long an entry may hold its slot.** After `stalledDialTimeout` the scheduler drops it and returns the static task to the pool, so a stall degrades to a delayed retry rather than a permanent one. Two minutes is far beyond any healthy dial: `defaultDialTimeout` is 15s and each handshake has a 5s deadline.

Two consequences worth calling out, both in the diff:

- **The loop now counts running tasks separately from the `dialing` map.** Once a slot has been reaped the two differ, and shutdown has to drain one reply per goroutine launched, not one per entry still held. The first version of this got that wrong and hung in `stop()`; the existing tests caught it.
- **The `doneCh` handler only clears the map when the finishing task still owns the slot.** Otherwise a late reply from a reaped task would evict the task that replaced it.

The abandoned task is left running. There is no way to cancel it, and if it ever does connect, the server rejects the duplicate.

## Why the first commit is here

`21779f091` cherry-picks upstream `758fce71f` (p2p: fix race in dialScheduler, #29235), which moves `dialTask.dest` behind an `atomic.Pointer`.

It is not cosmetic sequencing. Reaping touches a task while it is still running, and `updateStaticPool` then reads `task.dest()` through `checkDial` — while `resolve()` may be writing it on the task goroutine. That is exactly the race upstream fixed. Landing the reap without it would knowingly widen a known race rather than inherit the fix, so it goes first.

## Compatibility tier

- [x] **C7 — internal only.**

**Why this tier:** No consensus rule, wire protocol version, message shape, database format, or RPC surface is touched. In normal operation the behaviour is identical — a healthy dial finishes in well under two minutes and is never reaped. The only case where a node behaves differently is one where it is currently doing nothing at all.

## Rollout

This ships in a binary, so it is not exempt from the deployment gate even though it is C7. Nothing is deployed yet — no release carries it, and these apply whenever it is cut:

- [ ] **Testnet BPs first, then verify the rest of the testnet on the old build**
- [ ] Remaining testnet nodes upgraded and soaked
- [ ] Mainnet BPs rolled one at a time
- [x] C1 only — not applicable
- [x] C0 only — not applicable

Worth noting for whoever runs that rollout: a rolling restart is precisely the event that triggered both incidents, so the reattachment check in the runbook matters more here than usual.

## Verification

Built in a container (`golang:1.21`, `-buildvcs=false`), since this workstation has no Go toolchain.

**The new test fails without the change.** With the reap disabled but the constant and fields left in place, `TestDialSchedStalledDial` fails at `round 8: timed out waiting for dials to [0001…]` — the stalled node is never dialled again. With the reap it passes. That is the whole property, stated as an A/B rather than as coverage.

- `go test ./p2p/` — ok
- `go test ./p2p/ -race -count=5 -run TestDialSched` (CGO=1) — ok
- `go build ./...` — builds
- `go vet ./p2p/...`, `gofmt -l p2p/` — clean

⚠️ `go test ./p2p/ -race` over `TestServer*` reports 7 data races, and **they are pre-existing**: the same run on `dev` without this branch reports the same 7. They are in `internal/testlog` — the test logger's `flush` against `bufHandler.WithAttrs` — not in the dial or server path. Not addressed here.

- [x] Affected packages pass
- [ ] Both engines build — not separately checked. The change is pure Go in `p2p` with no database or cgo surface; it compiled under `CGO_ENABLED=0` and again under `CGO_ENABLED=1` for the race run, but no `-tags rocksdb` link was done.
- [ ] SPoA private network run — not applicable, no consensus or mining change
- [ ] Clean sync — not applicable

## What this does not do

**The root cause of the stall is still open.** Both incidents were recovered by restarting before anything captured the goroutine state, and the August logs have since aged out. The most exposed candidate is `Server.checkpoint` waiting on the run loop with no timeout, but that is a hypothesis, not a finding.

Upstream carries the same unbounded wait and the same absence of a reaper as of `v1.17.5`, so there is nothing further to backport.

This is therefore a bound on the damage, not a fix for the hang. #103 stays open, and the runbook now says to capture `debug_stacks` before restarting a node that fails to reattach — that dump is what would close it.
