### PR TITLE
core/types: derive the receipt fields the RPC has been returning as null

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
@@ -2167,10 +2168,12 @@ func (bc *BlockChain) recoverAncestors(block *types.Block) (common.Hash, error) 
 // collectLogs collects the logs that were generated or removed during
 // the processing of a block. These logs are later announced as deleted or reborn.
 func (bc *BlockChain) collectLogs(b *types.Block, removed bool) []*types.Log {
-	excessBlobGas := b.Header().ExcessBlobGas
-	_ = excessBlobGas // not used in Metadium DeriveFields signature
+	var blobGasPrice *big.Int
+	if excessBlobGas := b.Header().ExcessBlobGas; excessBlobGas != nil {
+		blobGasPrice = eip4844.CalcBlobFee(excessBlobGas.Uint64())
+	}
 	receipts := rawdb.ReadRawReceipts(bc.db, b.Hash(), b.NumberU64())
-	if err := receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Transactions()); err != nil {
+	if err := receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.BaseFee(), blobGasPrice, b.Transactions()); err != nil {
 		log.Error("Failed to derive block receipts fields", "hash", b.Hash(), "number", b.NumberU64(), "err", err)
 	}
 	var logs []*types.Log

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -389,7 +389,11 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		} else if len(receipts) < len(txs) {
 			txs = txs[:len(receipts)]
 		}
-		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), txs); err != nil {
+		var blobGasPrice *big.Int
+		if excessBlobGas := block.ExcessBlobGas(); excessBlobGas != nil {
+			blobGasPrice = eip4844.CalcBlobFee(*excessBlobGas)
+		}
+		if err := receipts.DeriveFields(config, block.Hash(), block.NumberU64(), block.BaseFee(), blobGasPrice, txs); err != nil {
 			panic(err)
 		}
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -624,7 +625,20 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, time uint64,
 		log.Error("Missing body but have receipt", "hash", hash, "number", number)
 		return nil
 	}
-	if err := receipts.DeriveFields(config, hash, number, body.Transactions); err != nil {
+	header := ReadHeader(db, hash, number)
+
+	var baseFee *big.Int
+	if header == nil {
+		baseFee = big.NewInt(0)
+	} else {
+		baseFee = header.BaseFee
+	}
+	// Compute effective blob gas price.
+	var blobGasPrice *big.Int
+	if header != nil && header.ExcessBlobGas != nil {
+		blobGasPrice = eip4844.CalcBlobFee(header.ExcessBlobGas.Uint64())
+	}
+	if err := receipts.DeriveFields(config, hash, number, baseFee, blobGasPrice, body.Transactions); err != nil {
 		log.Error("Failed to derive block receipts fields", "hash", hash, "number", number, "err", err)
 		return nil
 	}

--- a/core/types/feedelegate_dynamic_fee_tx.go
+++ b/core/types/feedelegate_dynamic_fee_tx.go
@@ -127,6 +127,20 @@ func (tx *FeeDelegateDynamicFeeTx) rawFeePayerSignatureValues() (v, r, s *big.In
 	return tx.FV, tx.FR, tx.FS
 }
 
+// effectiveGasPrice is the price per gas the feePayer actually pays, which is
+// the sender transaction's dynamic-fee price. It has to agree with what state
+// processing charges, so it follows DynamicFeeTx over the SenderTx fields.
+func (tx *FeeDelegateDynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	if baseFee == nil {
+		return dst.Set(tx.SenderTx.GasFeeCap)
+	}
+	tip := dst.Sub(tx.SenderTx.GasFeeCap, baseFee)
+	if tip.Cmp(tx.SenderTx.GasTipCap) > 0 {
+		tip.Set(tx.SenderTx.GasTipCap)
+	}
+	return tip.Add(tip, baseFee)
+}
+
 func (tx *FeeDelegateDynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.SenderTx.rawSignatureValues()
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -413,7 +413,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 
 // DeriveFields fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
-func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, txs Transactions) error {
+func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, number uint64, baseFee *big.Int, blobGasPrice *big.Int, txs Transactions) error {
 	signer := MakeSigner(config, new(big.Int).SetUint64(number), 0)
 
 	logIndex := uint(0)
@@ -424,6 +424,13 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		// The transaction type and hash can be retrieved from the transaction itself
 		rs[i].Type = txs[i].Type()
 		rs[i].TxHash = txs[i].Hash()
+		rs[i].EffectiveGasPrice = txs[i].inner.effectiveGasPrice(new(big.Int), baseFee)
+
+		// EIP-4844 blob transaction fields
+		if txs[i].Type() == BlobTxType {
+			rs[i].BlobGasUsed = txs[i].BlobGas()
+			rs[i].BlobGasPrice = blobGasPrice
+		}
 
 		// block location fields
 		rs[i].BlockHash = hash

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -218,6 +220,10 @@ func TestDeriveFields(t *testing.T) {
 	// Create a few transactions to have receipts for
 	to2 := common.HexToAddress("0x2")
 	to3 := common.HexToAddress("0x3")
+	to4 := common.HexToAddress("0x4")
+	to5 := common.HexToAddress("0x5")
+	to6 := common.HexToAddress("0x6")
+	to7 := common.HexToAddress("0x7")
 	txs := Transactions{
 		NewTx(&LegacyTx{
 			Nonce:    1,
@@ -238,6 +244,46 @@ func TestDeriveFields(t *testing.T) {
 			Value:    big.NewInt(3),
 			Gas:      3,
 			GasPrice: big.NewInt(3),
+		}),
+		NewTx(&DynamicFeeTx{
+			To:        &to4,
+			Nonce:     4,
+			Value:     big.NewInt(4),
+			Gas:       4,
+			GasTipCap: big.NewInt(44),
+			GasFeeCap: big.NewInt(1045),
+		}),
+		NewTx(&DynamicFeeTx{
+			To:        &to5,
+			Nonce:     5,
+			Value:     big.NewInt(5),
+			Gas:       5,
+			GasTipCap: big.NewInt(56),
+			GasFeeCap: big.NewInt(1055),
+		}),
+		NewTx(&BlobTx{
+			To:               &to6,
+			Nonce:            6,
+			Value:            uint256.NewInt(6),
+			Gas:              6,
+			GasTipCap:        uint256.NewInt(66),
+			GasFeeCap:        uint256.NewInt(1066),
+			MaxFeePerBlobGas: uint256.NewInt(100077),
+			BlobHashes:       []common.Hash{{}, {}, {}},
+		}),
+		NewTx(&FeeDelegateDynamicFeeTx{
+			SenderTx: DynamicFeeTx{
+				To:        &to7,
+				Nonce:     7,
+				Value:     big.NewInt(7),
+				Gas:       7,
+				GasTipCap: big.NewInt(77),
+				GasFeeCap: big.NewInt(1077),
+			},
+			FeePayer: &to7,
+			FV:       new(big.Int),
+			FR:       new(big.Int),
+			FS:       new(big.Int),
 		}),
 	}
 	// Create the corresponding receipts
@@ -276,13 +322,63 @@ func TestDeriveFields(t *testing.T) {
 			ContractAddress: common.BytesToAddress([]byte{0x03, 0x33, 0x33}),
 			GasUsed:         3,
 		},
+		&Receipt{
+			Type:              DynamicFeeTxType,
+			PostState:         common.Hash{4}.Bytes(),
+			CumulativeGasUsed: 10,
+			Logs:              []*Log{},
+			TxHash:            txs[3].Hash(),
+			GasUsed:           4,
+		},
+		&Receipt{
+			Type:              DynamicFeeTxType,
+			PostState:         common.Hash{5}.Bytes(),
+			CumulativeGasUsed: 15,
+			Logs:              []*Log{},
+			TxHash:            txs[4].Hash(),
+			GasUsed:           5,
+		},
+		&Receipt{
+			Type:              BlobTxType,
+			PostState:         common.Hash{6}.Bytes(),
+			CumulativeGasUsed: 21,
+			Logs:              []*Log{},
+			TxHash:            txs[5].Hash(),
+			GasUsed:           6,
+		},
+		&Receipt{
+			Type:              FeeDelegateDynamicFeeTxType,
+			PostState:         common.Hash{7}.Bytes(),
+			CumulativeGasUsed: 28,
+			Logs:              []*Log{},
+			TxHash:            txs[6].Hash(),
+			GasUsed:           7,
+		},
 	}
 	// Clear all the computed fields and re-derive them
 	number := big.NewInt(1)
 	hash := common.BytesToHash([]byte{0x03, 0x14})
 
+	// The effective gas price is what the sender (or feePayer) is actually
+	// charged per gas, so the expectations are stated as literal values rather
+	// than recomputed through the same code under test. baseFee is 1000:
+	// legacy and access-list transactions pay their gas price as-is, the two
+	// dynamic-fee transactions exercise both sides of min(feeCap, baseFee+tip),
+	// and the blob and fee-delegation types follow the dynamic-fee rule.
+	baseFee := big.NewInt(1000)
+	blobGasPrice := big.NewInt(920)
+	wantEffectiveGasPrice := []*big.Int{
+		big.NewInt(1),    // legacy: gas price
+		big.NewInt(2),    // legacy: gas price
+		big.NewInt(3),    // access list: gas price
+		big.NewInt(1044), // dynamic fee: baseFee+tip below the cap
+		big.NewInt(1055), // dynamic fee: capped by feeCap
+		big.NewInt(1066), // blob: dynamic-fee rule over uint256 fields
+		big.NewInt(1077), // fee delegation: dynamic-fee rule over SenderTx
+	}
+
 	clearComputedFieldsOnReceipts(t, receipts)
-	if err := receipts.DeriveFields(params.TestChainConfig, hash, number.Uint64(), txs); err != nil {
+	if err := receipts.DeriveFields(params.TestChainConfig, hash, number.Uint64(), baseFee, blobGasPrice, txs); err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
 	// Iterate over all the computed fields and check that they're correct
@@ -307,6 +403,23 @@ func TestDeriveFields(t *testing.T) {
 		}
 		if receipts[i].GasUsed != txs[i].Gas() {
 			t.Errorf("receipts[%d].GasUsed = %d, want %d", i, receipts[i].GasUsed, txs[i].Gas())
+		}
+		if receipts[i].EffectiveGasPrice == nil {
+			t.Errorf("receipts[%d].EffectiveGasPrice = nil, want %s", i, wantEffectiveGasPrice[i])
+		} else if receipts[i].EffectiveGasPrice.Cmp(wantEffectiveGasPrice[i]) != 0 {
+			t.Errorf("receipts[%d].EffectiveGasPrice = %s, want %s", i, receipts[i].EffectiveGasPrice, wantEffectiveGasPrice[i])
+		}
+		if txs[i].Type() == BlobTxType {
+			if receipts[i].BlobGasUsed != txs[i].BlobGas() {
+				t.Errorf("receipts[%d].BlobGasUsed = %d, want %d", i, receipts[i].BlobGasUsed, txs[i].BlobGas())
+			}
+			if receipts[i].BlobGasPrice == nil || receipts[i].BlobGasPrice.Cmp(blobGasPrice) != 0 {
+				t.Errorf("receipts[%d].BlobGasPrice = %s, want %s", i, receipts[i].BlobGasPrice, blobGasPrice)
+			}
+		} else {
+			if receipts[i].BlobGasUsed != 0 || receipts[i].BlobGasPrice != nil {
+				t.Errorf("receipts[%d] carries blob gas fields on a non-blob transaction", i)
+			}
 		}
 		if txs[i].To() != nil && receipts[i].ContractAddress != (common.Address{}) {
 			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), (common.Address{}).String())
@@ -481,6 +594,9 @@ func clearComputedFieldsOnReceipt(t *testing.T, receipt *Receipt) {
 	receipt.TransactionIndex = math.MaxUint32
 	receipt.ContractAddress = common.Address{}
 	receipt.GasUsed = 0
+	receipt.EffectiveGasPrice = nil
+	receipt.BlobGasUsed = 0
+	receipt.BlobGasPrice = nil
 
 	clearComputedFieldsOnLogs(t, receipt.Logs)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -109,6 +109,15 @@ type TxData interface {
 
 	rawSignatureValues() (v, r, s *big.Int)
 	setSignatureValues(chainID, v, r, s *big.Int)
+
+	// effectiveGasPrice computes the gas price paid by the transaction, given
+	// the inclusion block baseFee.
+	//
+	// Unlike other TxData methods, the returned *big.Int should be an independent
+	// copy of the computed value, i.e. callers are allowed to mutate the result.
+	// Method implementations can use 'dst' to store the result.
+	effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int
+
 	// fee delegation
 	feePayer() *common.Address
 	rawFeePayerSignatureValues() (v, r, s *big.Int)

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -112,6 +112,10 @@ func (tx *AccessListTx) rawFeePayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
 }
 
+func (tx *AccessListTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	return dst.Set(tx.GasPrice)
+}
+
 func (tx *AccessListTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S
 }

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -351,6 +351,17 @@ func (tx *BlobTx) blobGasCost() *big.Int {
 	return new(big.Int).Mul(tx.MaxFeePerBlobGas.ToBig(), new(big.Int).SetUint64(uint64(len(tx.BlobHashes)*131072)))
 }
 
+func (tx *BlobTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	if baseFee == nil {
+		return dst.Set(tx.GasFeeCap.ToBig())
+	}
+	tip := dst.Sub(tx.GasFeeCap.ToBig(), baseFee)
+	if tip.Cmp(tx.GasTipCap.ToBig()) > 0 {
+		tip.Set(tx.GasTipCap.ToBig())
+	}
+	return tip.Add(tip, baseFee)
+}
+
 func (tx *BlobTx) rawSignatureValues() (*big.Int, *big.Int, *big.Int) {
 	return tx.V.ToBig(), tx.R.ToBig(), tx.S.ToBig()
 }

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -100,6 +100,17 @@ func (tx *DynamicFeeTx) rawFeePayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
 }
 
+func (tx *DynamicFeeTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	if baseFee == nil {
+		return dst.Set(tx.GasFeeCap)
+	}
+	tip := dst.Sub(tx.GasFeeCap, baseFee)
+	if tip.Cmp(tx.GasTipCap) > 0 {
+		tip.Set(tx.GasTipCap)
+	}
+	return tip.Add(tip, baseFee)
+}
+
 func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S
 }

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -108,6 +108,10 @@ func (tx *LegacyTx) feePayer() *common.Address { return nil }
 func (tx *LegacyTx) rawFeePayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
 }
+func (tx *LegacyTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	return dst.Set(tx.GasPrice)
+}
+
 func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S
 }

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-blob-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-blob-tx.json
@@ -4,7 +4,7 @@
     "blockNumber": "0x6",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5208",
-    "effectiveGasPrice": null,
+    "effectiveGasPrice": "0x1b09d63a",
     "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
     "gasUsed": "0x5208",
     "logs": [],

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-contract-create-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-contract-create-tx.json
@@ -4,7 +4,7 @@
     "blockNumber": "0x2",
     "contractAddress": "0xae9bea628c4ce503dcfd7e305cab4e29e7476592",
     "cumulativeGasUsed": "0xcf50",
-    "effectiveGasPrice": null,
+    "effectiveGasPrice": "0x2db16291",
     "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
     "gasUsed": "0xcf50",
     "logs": [],

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-dynamic-fee-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-dynamic-fee-tx.json
@@ -4,7 +4,7 @@
     "blockNumber": "0x4",
     "contractAddress": null,
     "cumulativeGasUsed": "0x538d",
-    "effectiveGasPrice": null,
+    "effectiveGasPrice": "0x2325c42f",
     "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
     "gasUsed": "0x538d",
     "logs": [],

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-contract-call-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-contract-call-tx.json
@@ -4,7 +4,7 @@
     "blockNumber": "0x3",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5e28",
-    "effectiveGasPrice": null,
+    "effectiveGasPrice": "0x281c2585",
     "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
     "gasUsed": "0x5e28",
     "logs": [

--- a/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-transfer-tx.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-block-with-legacy-transfer-tx.json
@@ -4,7 +4,7 @@
     "blockNumber": "0x1",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5208",
-    "effectiveGasPrice": null,
+    "effectiveGasPrice": "0x342770c0",
     "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
     "gasUsed": "0x5208",
     "logs": [],

--- a/internal/ethapi/testdata/eth_getBlockReceipts-tag-latest.json
+++ b/internal/ethapi/testdata/eth_getBlockReceipts-tag-latest.json
@@ -4,7 +4,7 @@
     "blockNumber": "0x6",
     "contractAddress": null,
     "cumulativeGasUsed": "0x5208",
-    "effectiveGasPrice": null,
+    "effectiveGasPrice": "0x1b09d63a",
     "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
     "gasUsed": "0x5208",
     "logs": [],

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-tx.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-tx.json
@@ -3,7 +3,7 @@
   "blockNumber": "0x2",
   "contractAddress": "0xae9bea628c4ce503dcfd7e305cab4e29e7476592",
   "cumulativeGasUsed": "0xcf50",
-  "effectiveGasPrice": null,
+  "effectiveGasPrice": "0x2db16291",
   "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
   "gasUsed": "0xcf50",
   "logs": [],

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-with-access-list.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-create-contract-with-access-list.json
@@ -3,7 +3,7 @@
   "blockNumber": "0x5",
   "contractAddress": "0xfdaa97661a584d977b4d3abb5370766ff5b86a18",
   "cumulativeGasUsed": "0xe01c",
-  "effectiveGasPrice": null,
+  "effectiveGasPrice": "0x1ecb3fb4",
   "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
   "gasUsed": "0xe01c",
   "logs": [],

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-dynamic-tx-with-logs.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-dynamic-tx-with-logs.json
@@ -3,7 +3,7 @@
   "blockNumber": "0x4",
   "contractAddress": null,
   "cumulativeGasUsed": "0x538d",
-  "effectiveGasPrice": null,
+  "effectiveGasPrice": "0x2325c42f",
   "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
   "gasUsed": "0x538d",
   "logs": [],

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-legacy-tx-placeholder.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-legacy-tx-placeholder.json
@@ -3,7 +3,7 @@
   "blockNumber": "0x6",
   "contractAddress": null,
   "cumulativeGasUsed": "0x5208",
-  "effectiveGasPrice": null,
+  "effectiveGasPrice": "0x1b09d63a",
   "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
   "gasUsed": "0x5208",
   "logs": [],

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-normal-transfer-tx.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-normal-transfer-tx.json
@@ -3,7 +3,7 @@
   "blockNumber": "0x1",
   "contractAddress": null,
   "cumulativeGasUsed": "0x5208",
-  "effectiveGasPrice": null,
+  "effectiveGasPrice": "0x342770c0",
   "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
   "gasUsed": "0x5208",
   "logs": [],

--- a/internal/ethapi/testdata/eth_getTransactionReceipt-with-logs.json
+++ b/internal/ethapi/testdata/eth_getTransactionReceipt-with-logs.json
@@ -3,7 +3,7 @@
   "blockNumber": "0x3",
   "contractAddress": null,
   "cumulativeGasUsed": "0x5e28",
-  "effectiveGasPrice": null,
+  "effectiveGasPrice": "0x281c2585",
   "from": "0x703c4b2bd70c169f5717101caee543299fc946c7",
   "gasUsed": "0x5e28",
   "logs": [


### PR DESCRIPTION
Fixes #105.

## What this changes

`eth_getTransactionReceipt` and `eth_getBlockReceipts` return `effectiveGasPrice: null` for every transaction on every network, so anything computing a fee as `gasUsed × effectiveGasPrice` gets zero — which is what the block explorer shows today. The chain is right and the fee is charged: mainnet tx `0x34c82b81…07fe`'s sender balance fell by exactly `value + 21000 × 80 gwei` across its block. Only the reported number is missing.

The cause is that `Receipts.DeriveFields` never assigns `EffectiveGasPrice`. Upstream v1.13.14 does, in the same loop, from a `baseFee` parameter this tree's copy dropped along with the assignment — `core/blockchain.go` still carried the stub comment marking the removal. `marshalReceipt` then serializes the never-populated field as `null`. 0.10.x was correct because it computed the price in the API layer; the rebase took upstream's `marshalReceipt`, which reads the receipt field, without the derivation that fills it. The tell is that one method on the same node disagrees with the other two, because `eth_getReceiptsByHash` still computes in the API layer:

| method | `effectiveGasPrice` for that tx |
|---|---|
| `eth_getReceiptsByHash` | `0x12a05f2000` |
| `eth_getTransactionReceipt` | `null` |
| `eth_getBlockReceipts` | `null` |

**The fix restores the upstream shape.** `effectiveGasPrice` returns to the `TxData` interface and each transaction type (upstream's implementations verbatim for the four shared types), `DeriveFields` takes the base fee and blob gas price and assigns `EffectiveGasPrice`, `BlobGasUsed` and `BlobGasPrice`, and the three call sites hand them in from the header they already have. Two points specific to this tree:

- **`FeeDelegateDynamicFeeTx`** follows the dynamic-fee rule over its `SenderTx` fields, since that is the price state processing charges the feePayer.
- The formula agrees with what `eth_getReceiptsByHash` already returns (`baseFee + EffectiveGasTipValue(baseFee)` ≡ `min(feeCap, baseFee + tip)`), so the two paths now match instead of disagreeing in the other direction.

**The blob receipt fields close the same hole.** Camellia activated EIP-4844, and a blob transaction's receipt reported `blobGasUsed: 0` and `blobGasPrice: null` for the same reason — same loop, same missing assignments.

**The golden files were pinning the bug.** Every ethapi receipt golden expected `null`; they were generated after the regression existed, so the test suite certified the wrong answer. Regenerated via `WRITE_TEST_FILES` — all 11 changes are `null` becoming a value, nothing else moves.

Deliberately not touched: `DeriveFields` calls `MakeSigner` with a zero time where upstream passes the block time. Forks here are block-numbered so signer selection does not depend on it, and changing sender derivation does not belong in a receipts fix. Noted in #105.

## Compatibility tier

- [x] **C4 — RPC/API.**

**Why this tier:** the response shape of two standard methods changes — a field that has been `null` becomes a quantity. It is strictly restorative: the field is required by the spec, 0.10.x returned it, and no consumer can have depended on `null` except by treating the fee as zero, which is the bug. A node that stays put sees nothing (its own RPC is unchanged until its operator upgrades); an operator who upgrades gets the field back with no action required. No deprecation window applies because nothing is removed. No consensus, wire, or database surface — receipts on disk are untouched; these fields are derived at read time, which also means the fix applies retroactively to every historical transaction with no resync.

## Rollout

Ships in a binary, so the standing gate applies even though nothing here affects consensus:

- [ ] **Testnet BPs first, then verify the rest of the testnet on the old build**
- [ ] Remaining testnet nodes upgraded and soaked
- [ ] Mainnet BPs rolled one at a time (PoA: never stop two at once, never `kill -9`)
- [x] C1 only — not applicable
- [x] C0 only — not applicable

Two rollout notes beyond the checklist. The nodes that matter first are the RPC-serving ones (api/PN), since that is where the symptom lives, and the fix is visible immediately on restart — re-query the tx above and expect `0x12a05f2000`. And external operators who run their own nodes serve the same `null` from the same code; they follow the chain fine without upgrading, but their fee reporting stays zero until they take the release that carries this. That belongs in the release notes and the operator notice, scoped to "affects you only if you read `effectiveGasPrice` from receipts; unaffected if you compute fees from the transaction's own gas price."

## Verification

Built in a container (`golang:1.21`, `-buildvcs=false`); this workstation has no Go toolchain.

**The extended test fails without the change, on every path.** `TestDeriveFields` now runs seven transactions — two legacy, one access-list, two dynamic-fee (one on each side of `min(feeCap, baseFee+tip)`), one blob, one fee-delegation — with the expected prices stated as literals rather than recomputed through the code under test. With the assignments removed, all seven fail on `EffectiveGasPrice = nil` and the blob receipt additionally fails on both blob fields; with them, the package is green.

- `go test -short ./core/ ./core/rawdb/ ./core/types/ ./internal/ethapi/ ./eth/ ./eth/filters/ ./graphql/` — all ok
- `go build ./...`, `go vet` over the touched packages, `gofmt -l core/` — clean

- [x] Affected packages pass
- [ ] Both engines build — `CGO_ENABLED=0` full build done; no `-tags rocksdb` link was run. The change is pure Go in `core/types`, `core/rawdb`, `core` with no storage or cgo surface.
- [ ] SPoA private network run — not run for this PR. The e2e suites read receipts and would exercise this live; worth including whenever the next SPoA round happens, but the property is fully pinned by the unit tests above.
- [ ] Clean sync — not applicable; nothing about block validity changes.
