### PR TITLE
cmd/geth: downloadGenesis — whole-body read, closed body, byte-preserving config splice, checked writes

### DIFF
--- a/cmd/geth/metadium_genesis_test.go
+++ b/cmd/geth/metadium_genesis_test.go
@@ -17,11 +17,20 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/urfave/cli/v2"
 )
 
 // asPoA switches the process-wide consensus method for one test. Without it
@@ -160,5 +169,134 @@ func TestCanonicalGenesisConfigPassesPrivateNet(t *testing.T) {
 	}
 	if string(out) != string(doc) {
 		t.Fatal("a private genesis was rewritten")
+	}
+}
+
+// unsortedGenesis renders a genesis document with its top-level keys in
+// reverse-sorted order, the way no Go map marshal would ever produce it. A
+// rewrite that round-trips the document through a map re-sorts these keys, so
+// byte-exact assertions against this fixture pin the splice behaviour (#102).
+func unsortedGenesis(t *testing.T, doc []byte, config json.RawMessage) []byte {
+	t.Helper()
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(doc, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if config != nil {
+		raw["config"] = config
+	}
+	keys := make([]string, 0, len(raw))
+	for k := range raw {
+		keys = append(keys, k)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+	var out bytes.Buffer
+	out.WriteString("{")
+	for i, k := range keys {
+		if i > 0 {
+			out.WriteString(",")
+		}
+		fmt.Fprintf(&out, "%q: %s", k, raw[k])
+	}
+	out.WriteString("}")
+	return out.Bytes()
+}
+
+// TestCanonicalGenesisConfigPreservesServedBytes is item 3 of #102: the
+// replacement branch must leave every byte it does not replace exactly as
+// served -- same key order, same spacing -- so that all three of the command's
+// paths stay diffable against the peer's document.
+func TestCanonicalGenesisConfigPreservesServedBytes(t *testing.T) {
+	asPoA(t)
+
+	stale := *params.MetadiumMainnetChainConfig
+	stale.CamelliaBlock = nil
+	staleRaw, err := json.Marshal(&stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := json.Marshal(params.MetadiumMainnetChainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := servedGenesis(t, "mainnet", nil)
+	doc := unsortedGenesis(t, base, staleRaw)
+
+	out, network, replaced, err := canonicalGenesisConfig(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != "mainnet" || !replaced {
+		t.Fatalf("network=%q replaced=%v", network, replaced)
+	}
+	expected := unsortedGenesis(t, base, want)
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("the rewritten document does not match the served bytes outside config:\nhave %s\nwant %s",
+			out, expected)
+	}
+}
+
+// TestSpliceConfigAddsMissingKey covers the served document that carries no
+// config at all: the compiled config has to be added, and the rest of the
+// document still passes through untouched.
+func TestSpliceConfigAddsMissingKey(t *testing.T) {
+	doc := []byte(`{"nonce": "0x42","alloc": {}}`)
+	out, err := spliceConfig(doc, []byte(`{"chainId":11}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"nonce": "0x42","alloc": {},"config": {"chainId":11}}`
+	if string(out) != want {
+		t.Fatalf("have %s\nwant %s", out, want)
+	}
+}
+
+// TestReadGenesisEnvelopeDrainsBody is item 1 of #102: one Read is not one
+// body. The one-byte reader forces the transport-may-return-less case that a
+// single Read into a large buffer silently truncates.
+func TestReadGenesisEnvelopeDrainsBody(t *testing.T) {
+	inner := strings.Repeat("x", 64*1024)
+	envelope, err := json.Marshal(map[string]string{"result": inner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readGenesisEnvelope(iotest.OneByteReader(bytes.NewReader(envelope)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(doc) != inner {
+		t.Fatalf("the envelope was not drained: got %d bytes, want %d", len(doc), len(inner))
+	}
+}
+
+// TestReadGenesisEnvelopeRejectsOversize pins the explicit ceiling: a response
+// larger than the old implicit 1MB bound errors out loudly instead of being
+// cut short.
+func TestReadGenesisEnvelopeRejectsOversize(t *testing.T) {
+	huge := strings.NewReader("[" + strings.Repeat("0,", maxGenesisDocument/2) + "0]")
+	if _, err := readGenesisEnvelope(huge); err == nil {
+		t.Fatal("an oversized response was accepted")
+	}
+}
+
+// TestEmitGenesisReportsWriteFailure is item 4 of #102: a write the disk
+// refuses must fail the command, not leave a truncated genesis behind an
+// exit status of 0. /dev/full is the kernel's deterministic full disk.
+func TestEmitGenesisReportsWriteFailure(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("/dev/full is a Linux device")
+	}
+	if _, err := os.Stat("/dev/full"); err != nil {
+		t.Skip("/dev/full is not available")
+	}
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String(outFlag.Name, "", "")
+	if err := set.Set(outFlag.Name, "/dev/full"); err != nil {
+		t.Fatal(err)
+	}
+	ctx := cli.NewContext(nil, set, nil)
+	if err := emitGenesis(ctx, []byte(`{"nonce":"0x42"}`)); err == nil {
+		t.Fatal("a failed write went unreported")
 	}
 }

--- a/cmd/geth/metadiumcmd.go
+++ b/cmd/geth/metadiumcmd.go
@@ -614,16 +614,67 @@ func canonicalGenesisConfig(doc []byte) ([]byte, string, bool, error) {
 		return doc, network, false, nil
 	}
 	// Replace the config key only, leaving the rest of the document untouched.
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(doc, &raw); err != nil {
-		return nil, network, false, err
-	}
-	raw["config"] = want
-	out, err := json.MarshalIndent(raw, "", "    ")
+	// Rebuilding the document through a map would re-sort its keys, and this
+	// command's output is meant to stay diffable against what the peer serves
+	// on every path, not just the two pass-through ones (#102).
+	out, err := spliceConfig(doc, want)
 	if err != nil {
 		return nil, network, false, err
 	}
-	return append(out, '\n'), network, true, nil
+	return out, network, true, nil
+}
+
+// spliceConfig replaces the value of the top-level "config" key in doc with
+// val, leaving every other byte of the document as served. Values are skipped
+// whole, so a nested "config" key inside some other object is never touched.
+func spliceConfig(doc, val []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(doc))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("the genesis document is not a JSON object")
+	}
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected %v where a genesis key was expected", tok)
+		}
+		start := dec.InputOffset() // just past the key, before the colon
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return nil, err
+		}
+		if key != "config" {
+			continue
+		}
+		end := dec.InputOffset() // just past the value
+		var out bytes.Buffer
+		out.Grow(len(doc) - int(end-start) + len(val) + 2)
+		out.Write(doc[:start])
+		out.WriteString(": ")
+		out.Write(val)
+		out.Write(doc[end:])
+		return out.Bytes(), nil
+	}
+	// The served document has no config key at all; add one. The object is
+	// known to be non-empty -- its block fields are what matched the canonical
+	// hash -- so a separating comma is always right.
+	last := bytes.LastIndexByte(doc, '}')
+	if last < 0 {
+		return nil, fmt.Errorf("the genesis document has no closing brace")
+	}
+	var out bytes.Buffer
+	out.Write(doc[:last])
+	out.WriteString(`,"config": `)
+	out.Write(val)
+	out.Write(doc[last:])
+	return out.Bytes(), nil
 }
 
 func downloadGenesis(ctx *cli.Context) error {
@@ -637,19 +688,14 @@ func downloadGenesis(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer rsp.Body.Close()
 
-	buf := make([]byte, 1024*1024)
-	n, err := rsp.Body.Read(buf)
-	if err != nil && err != io.EOF {
+	served, err := readGenesisEnvelope(rsp.Body)
+	if err != nil {
 		return err
 	}
 
-	var genesis genesisReturn
-	if err := json.Unmarshal(buf[:n], &genesis); err != nil {
-		return err
-	}
-
-	doc, network, replaced, err := canonicalGenesisConfig([]byte(genesis.Result))
+	doc, network, replaced, err := canonicalGenesisConfig(served)
 	if err != nil {
 		return err
 	}
@@ -663,17 +709,53 @@ func downloadGenesis(ctx *cli.Context) error {
 		log.Info("Genesis matches the canonical network and its compiled config", "network", network)
 	}
 
-	w := os.Stdout
-	if fn := ctx.String(outFlag.Name); fn != "" {
-		w, err = os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-		if err != nil {
-			utils.Fatalf("%v", err)
-		}
-		defer w.Close()
-	}
+	return emitGenesis(ctx, doc)
+}
 
-	w.Write(doc)
-	return nil
+// maxGenesisDocument bounds the eth_genesis response, as the old fixed read
+// buffer did implicitly. A response that hits the ceiling errors out instead of
+// being cut short.
+const maxGenesisDocument = 1024 * 1024
+
+// readGenesisEnvelope drains an eth_genesis response and returns the genesis
+// document it carries. One Read is not one body -- the transport may return
+// fewer bytes than are available even when everything fits in the buffer -- so
+// the body has to be read in full (#102).
+func readGenesisEnvelope(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxGenesisDocument+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxGenesisDocument {
+		return nil, fmt.Errorf("the genesis response exceeds %d bytes", maxGenesisDocument)
+	}
+	var genesis genesisReturn
+	if err := json.Unmarshal(body, &genesis); err != nil {
+		return nil, err
+	}
+	return []byte(genesis.Result), nil
+}
+
+// emitGenesis writes the genesis document to the file named by --out, or to
+// stdout without one. The write and the close are both checked: a full disk
+// fails the write or the final flush, and exiting 0 after leaving a truncated
+// genesis behind is the failure mode most likely to be found much later, by
+// whatever tries to use the file (#102).
+func emitGenesis(ctx *cli.Context, doc []byte) error {
+	fn := ctx.String(outFlag.Name)
+	if fn == "" {
+		_, err := os.Stdout.Write(doc)
+		return err
+	}
+	w, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		utils.Fatalf("%v", err)
+	}
+	if _, err := w.Write(doc); err != nil {
+		w.Close()
+		return err
+	}
+	return w.Close()
 }
 
 // ignoreSIGPIPE keeps a closed log pipe from taking the node down.


### PR DESCRIPTION
## What this changes

Closes the four `downloadGenesis` defects recorded in #102 — all pre-existing,
split out of the #99 review so that PR could merge on the approval it had:

1. **Whole-body read.** A single `rsp.Body.Read` could truncate a large
   genesis; the body is now drained with `io.ReadAll` behind an explicit 1MB
   ceiling (the old buffer's implicit bound), and a response that hits the
   ceiling errors out loudly instead of being cut short.
2. **The response body is closed.**
3. **Byte-preserving config replacement.** The replacement branch no longer
   round-trips the document through a map (which re-sorts top-level keys);
   `spliceConfig` swaps the `config` value inside the original bytes, so all
   three output paths stay diffable against what the peer served. A served
   document with no `config` key gets one appended.
4. **Checked write and close.** A full disk now fails the command instead of
   leaving a truncated genesis behind exit status 0. The close is checked
   explicitly because a deferred close swallows the error a final flush can
   surface.

The output-writing tail of `downloadGenesis` moved into `emitGenesis` so item
4 is testable; behaviour is otherwise unchanged.

## Compatibility tier

- [x] **C7 — internal only.** Tests, docs, tooling, or producer-side behaviour
      that does not change block validity.

**Why this tier:** local to one one-shot CLI command (`gmet metadium
download-genesis`). No consensus, wire, database, or RPC surface. The only
operator-visible output change is deliberate: the config-replacement path now
preserves the served document's key order and spacing instead of re-sorting it.

## Rollout

No gate — nothing deploys; the command runs at node-setup time only.

## Verification

- `gofmt` and `go vet` clean; `go test ./cmd/geth` — the three #99 regression
  tests still pass, plus five new ones, each of which fails without its change:
  - `TestReadGenesisEnvelopeDrainsBody` — `iotest.OneByteReader` forces the
    transport-returns-less case the old single `Read` truncated.
  - `TestReadGenesisEnvelopeRejectsOversize` — the explicit ceiling errors
    instead of truncating.
  - `TestCanonicalGenesisConfigPreservesServedBytes` — a reverse-sorted-key
    fixture asserts byte-exact output outside the replaced value; any map
    round-trip fails it.
  - `TestSpliceConfigAddsMissingKey` — the no-config-key fallback.
  - `TestEmitGenesisReportsWriteFailure` — `/dev/full` as the deterministic
    full disk (skips on non-Linux).
