### PR TITLE
tests/private-net-poa: camellia-test I-09 — assert the tx feePayer field, not a balance the feePayer earns back

### DIFF
--- a/tests/private-net-poa/camellia-test.sh
+++ b/tests/private-net-poa/camellia-test.sh
@@ -336,10 +336,6 @@ FEE_PAYER="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 # shellcheck disable=SC2034  # TO_ADDR used in heredoc/python blocks below
 TO_ADDR="0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
 
-# Record feePayer balance (before)
-FEEPAYER_BEFORE=$(rpc "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBalance\",\"params\":[\"$FEE_PAYER\",\"latest\"],\"id\":1}" | \
-  python3 -c "import sys,json; d=json.load(sys.stdin); print(int(d.get('result','0x0'),16))" 2>/dev/null || echo "0")
-
 # Record sender balance (before)
 SENDER_BEFORE=$(rpc "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBalance\",\"params\":[\"$SENDER\",\"latest\"],\"id\":1}" | \
   python3 -c "import sys,json; d=json.load(sys.stdin); print(int(d.get('result','0x0'),16))" 2>/dev/null || echo "0")
@@ -417,17 +413,20 @@ else
             fail "I-08: Fee Delegation tx failed (status=$STATUS)"
           fi
 
-          # I-09: Verify feePayer balance decreased
-          FEEPAYER_AFTER=$(rpc "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBalance\",\"params\":[\"$FEE_PAYER\",\"latest\"],\"id\":1}" | \
-            python3 -c "import sys,json; d=json.load(sys.stdin); print(int(d.get('result','0x0'),16))" 2>/dev/null || echo "0")
-
+          # I-09: Verify feePayer field is set in the mined tx (= FEE_PAYER, not sender).
+          # Balance check is unreliable since FEE_PAYER is node2's etherbase: on a
+          # rewarded network sealing income in the same window can exceed the gas
+          # just paid, and the balance rises (issue #100; same fix as spoa-test.sh).
           SENDER_AFTER=$(rpc "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBalance\",\"params\":[\"$SENDER\",\"latest\"],\"id\":1}" | \
             python3 -c "import sys,json; d=json.load(sys.stdin); print(int(d.get('result','0x0'),16))" 2>/dev/null || echo "0")
 
-          if [[ "$FEEPAYER_AFTER" -lt "$FEEPAYER_BEFORE" ]]; then
-            pass "I-09: feePayer balance decreased (before=$FEEPAYER_BEFORE after=$FEEPAYER_AFTER)"
+          FP_IN_TX=$(rpc "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionByHash\",\"params\":[\"$FD_HASH\"],\"id\":1}" | \
+            python3 -c "import sys,json; d=json.load(sys.stdin); print((d.get('result') or {}).get('feePayer') or '')" 2>/dev/null || echo "")
+
+          if [[ -n "$FP_IN_TX" && "${FP_IN_TX,,}" == "${FEE_PAYER,,}" && "${FP_IN_TX,,}" != "${SENDER,,}" ]]; then
+            pass "I-09: feePayer correctly set in tx (feePayer=$FP_IN_TX ≠ sender)"
           else
-            fail "I-09: feePayer balance not decreased — gas not deducted from feePayer"
+            fail "I-09: feePayer not set correctly in tx (got: ${FP_IN_TX:-<missing>})"
           fi
 
           if [[ "$SENDER_AFTER" -eq "$SENDER_BEFORE" ]]; then


### PR DESCRIPTION
## What this changes

Closes #100. `camellia-test.sh` check I-09 asserted that the feePayer's
balance fell after paying gas for the Type 22 fee-delegation tx. The feePayer
account (`0x7099…79C8`) is node2's `--miner.etherbase`, so on any network
where sealing pays, rewards collected in the same window can exceed the gas
just paid and the check fails against a node that did nothing wrong. It has
not fired so far only because rewards are zero on this private network.

The assertion is replaced with the same fix already applied in the two
sibling harnesses (`spoa-test.sh` I-09, `mixed-tx-e2e` via #101): assert on
the `feePayer` field of the mined tx returned by `eth_getTransactionByHash` —
the property fee delegation has to get right, and one no reward moves. The
check requires the field to be present, equal to the configured feePayer, and
distinct from the sender. The now-unused feePayer balance reads are removed;
the sender-side I-09-b informational check is untouched.

One pass/fail slot is consumed either way, so the suite's recorded
14/0/3 baseline shape is unchanged.

## Compatibility tier

- [x] **C7 — internal only.** Tests, docs, tooling, or producer-side behaviour
      that does not change block validity.

**Why this tier:** test harness only — no node code, no consensus, wire,
database, or RPC surface. Filed as its own PR (rather than folded into #101)
because `camellia-test.sh` is the Camellia verification suite with a recorded
14/0/3 baseline, and changing an assertion there deserves its own review and
its own re-run of that baseline.

## Rollout

No gate — nothing deploys.

## Verification

- `bash -n` and shellcheck clean (shellcheck delta vs `dev` = 0; the single
  pre-existing SC2329 info is unchanged).
- Full suite re-run on a fresh local 3-node PoA net built from `dev`
  (`f1944ae4a`, gmet 1.1.3-stable, CamelliaFork=100), two configurations:
  - As shipped (feePayer key not in node1's keystore): **14/0/3**, identical
    to the recorded baseline — I-08/I-09 skip at the signing step, exactly as
    they always have. The recorded baseline never actually exercised the old
    assertion.
  - With the feePayer test key imported and unlocked on node1 (so
    `eth_signRawFeeDelegateTransaction` can run): **16/0/2** — I-08 passes and
    the new I-09 passes via the field assertion.
- Mutation check: pointing the extraction at the tx's `from` field instead of
  `feePayer` makes I-09 fail (`got: 0xf39f…2266`, suite 15/1/2), confirming
  the assertion is live and would catch a wrong or missing feePayer.
- The live run also demonstrated the pollution the issue describes, one
  account over: in the same window the sender — node1's etherbase — gained
  exactly the 21000 × 1 gwei priority fee it mined from its own tx (logged by
  the informational I-09-b), even on this reward-less network. Balance
  invariants on etherbase accounts are not stable ground here either.
