### PR TITLE
miner, cmd/geth: restore the build deadline, stop leaking prefetchers (#65 items 1–3)

### DIFF
--- a/cmd/geth/governancedeploy.go
+++ b/cmd/geth/governancedeploy.go
@@ -122,7 +122,9 @@ func deployGovernanceContracts(cliCtx *cli.Context) error {
 	)
 	membersAndNodes, stakes, rewardPoolAccount, maintenanceAccount, err = getInitialGovernanceMembersAndNodes(configJsFile)
 	if err != nil {
-		return nil
+		// Was "return nil", which is exit 0: the command reported a successful
+		// deployment on a missing or malformed config (issue #65).
+		return err
 	}
 
 	// cli connection
@@ -148,7 +150,9 @@ func deployGovernanceContracts(cliCtx *cli.Context) error {
 	} else {
 		defer fin.Close()
 		if contracts, err = metclient.LoadJsContract(fin); err != nil {
-			return nil
+			// Same typo as above: a contract file that fails to load must not
+			// report success.
+			return err
 		}
 	}
 

--- a/miner/build_deadline_metadium_test.go
+++ b/miner/build_deadline_metadium_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package miner
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// TestCommitTransactionsHonoursBuildDeadline pins the per-transaction deadline
+// guard. The deadline used to be consulted only between whole Pending()
+// batches, so a batch could run past the block's slot and
+// --miner.blockminbuildtxs had no effect at all (issue #65).
+//
+// The guard has two conditions and the cases below separate them: the slot has
+// to have elapsed, and the block has to already carry BlockMinBuildTxs
+// transactions. Stopping on time alone would produce empty blocks under load.
+func TestCommitTransactionsHonoursBuildDeadline(t *testing.T) {
+	oldMin := params.BlockMinBuildTxs
+	params.BlockMinBuildTxs = 2
+	defer func() { params.BlockMinBuildTxs = oldMin }()
+
+	// The pending set has to be larger than the minimum, or reaching the
+	// minimum and running out of transactions would be indistinguishable.
+	const pending = 6
+
+	commit := func(t *testing.T, till *time.Time) int {
+		t.Helper()
+
+		w, b := newTestWorker(t, ethashChainConfig, ethash.NewFaker(), rawdb.NewMemoryDatabase(), 0)
+		defer w.close()
+
+		// newTestWorker already seeded nonce 0 from this account (pendingTxs), so
+		// start after it and count it in the expectations below.
+		txs := make([]*types.Transaction, 0, pending)
+		for i := len(pendingTxs); i < len(pendingTxs)+pending; i++ {
+			tx, _ := types.SignTx(types.NewTransaction(uint64(i), common.Address{0x01},
+				big.NewInt(1000), params.TxGas, big.NewInt(params.InitialBaseFee), nil),
+				types.HomesteadSigner{}, testBankKey)
+			txs = append(txs, tx)
+		}
+		if errs := b.txPool.Add(txs, true, true); errs[0] != nil {
+			t.Fatalf("adding the test transactions: %v", errs[0])
+		}
+
+		env, err := w.prepareWork(&generateParams{timestamp: uint64(time.Now().Unix()), coinbase: testBankAddress})
+		if err != nil {
+			t.Fatalf("preparing the environment: %v", err)
+		}
+		defer env.discard()
+		env.till = till
+
+		filter := txpool.PendingFilter{BaseFee: nil, OnlyPlainTxs: true}
+		plain := w.pool.Pending(filter)
+		if len(plain) == 0 {
+			t.Fatal("no pending transactions to commit")
+		}
+		plainTxs := newTransactionsByPriceAndNonce(env.signer, plain, env.header.BaseFee)
+		blobTxs := newTransactionsByPriceAndNonce(env.signer, nil, env.header.BaseFee)
+		if err := w.commitTransactions(env, plainTxs, blobTxs, nil); err != nil {
+			t.Fatalf("committing: %v", err)
+		}
+		return env.tcount
+	}
+
+	t.Run("deadline passed", func(t *testing.T) {
+		past := time.Now().Add(-time.Second)
+		if got := commit(t, &past); got != int(params.BlockMinBuildTxs) {
+			t.Errorf("filled %d transactions past the deadline, want the minimum %d",
+				got, params.BlockMinBuildTxs)
+		}
+	})
+
+	t.Run("deadline ahead", func(t *testing.T) {
+		future := time.Now().Add(time.Minute)
+		if got := commit(t, &future); got <= int(params.BlockMinBuildTxs) {
+			t.Errorf("filled only %d transactions with time to spare, want more than %d",
+				got, params.BlockMinBuildTxs)
+		}
+	})
+
+	t.Run("no deadline set", func(t *testing.T) {
+		if got := commit(t, nil); got <= int(params.BlockMinBuildTxs) {
+			t.Errorf("filled only %d transactions with no deadline, want more than %d",
+				got, params.BlockMinBuildTxs)
+		}
+	})
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -936,6 +936,17 @@ func (w *worker) commitTransactions(env *environment, plainTxs, blobTxs *transac
 			log.Trace("Transaction count limit reached", "have", env.tcount, "max", params.MaxTxsPerBlock)
 			break
 		}
+		// Metadium: stop filling once this block's slot has elapsed, as long as
+		// it already carries enough transactions to be worth sealing. Without
+		// this the deadline is only consulted between whole Pending() batches
+		// (commitTransactionsEx), so a burst can push a single batch past the
+		// slot -- and --miner.blockminbuildtxs, which exists to tune exactly
+		// this, has no effect at all. Restores old master's per-tx guard,
+		// which the v1.13.14 rebase dropped (issue #65).
+		if env.till != nil && int64(env.tcount) >= params.BlockMinBuildTxs && time.Now().After(*env.till) {
+			log.Trace("Block build deadline passed", "txs", env.tcount, "min", params.BlockMinBuildTxs)
+			break
+		}
 		// If we don't have enough blob space for any further blob transactions,
 		// skip that list altogether
 		if !blobTxs.Empty() && env.blobs*params.BlobTxBlobGasPerBlob >= params.MaxBlobGasPerBlock {
@@ -1676,6 +1687,14 @@ func (w *worker) commitWork(interrupt *atomic.Int32, timestamp int64) {
 	}
 
 	if !metaminer.IsPoW() { // Metadium
+		// This path never swaps the environment into w.current, so nothing
+		// downstream stops the prefetcher that makeEnv started -- and every
+		// round that commits a transaction leaked its subfetcher goroutines.
+		// commitEx works on a copy for assembly and updateSnapshot copies the
+		// state, so discarding here releases only this round's prefetcher
+		// (issue #65).
+		defer work.discard()
+
 		if !w.commitTransactionsEx(work, interrupt, start) {
 			w.commitEx(work, w.fullTaskHook, true, start)
 		}


### PR DESCRIPTION
## What this changes

Closes the three findings parked in #65 that needed code (items 1–3; item 4
landed in #64, item 5 is the release-check PR in the release-pipeline split):

1. **The per-transaction build deadline was lost in the rebase.** Old master
   broke out of the fill loop once the block's slot had elapsed and the block
   already carried `BlockMinBuildTxs` transactions. In this tree `env.till`
   was only consulted between whole `Pending()` batches, so a burst could push
   one batch past the slot, and `--miner.blockminbuildtxs` — which exists to
   tune exactly this — had no effect whatsoever. The guard is back in
   `commitTransactions`, with both of its original conditions: stopping on
   time alone would produce empty blocks under load, which is why the minimum
   is part of it.
2. **The PoA path never discarded its environment.** `environment.discard()`
   documents itself as something that "must always be called … otherwise the
   go-routine leak can happen", and the Metadium branch of `commitWork`
   returned before reaching it; that path does not swap the environment into
   `w.current` either, so nothing downstream stopped the prefetcher `makeEnv`
   started. Every round that committed a transaction leaked its subfetcher
   goroutines. Long-standing — on old master too.
3. **`gmet deploy-governance` reported success on a bad config.** Two paths
   returned nil where the error was intended (failed config read, failed
   contract load), and a nil action return is exit 0.

## Compatibility tier

- [x] **C7 — internal only.** Tests, docs, tooling, or producer-side behaviour
      that does not change block validity.

**Why this tier:** producer-side only. The deadline guard changes when a
sealing node stops *adding* transactions to the block it is building — block
validity, wire format, and what a validating node accepts are untouched. The
prefetcher discard releases goroutines on the sealing node. The
deploy-governance fix is a one-shot CLI exit code.

## Rollout

No fleet gate. Producer-side, so it reaches mainnet with a normal rolling
restart whenever the next release ships; no lockstep, no exchange window.

## Verification

Unit (re-run 2026-09-01 on the rebased branch, Go 1.22.5):

- `go test ./miner/ ./cmd/geth/` pass.
- Deadline A/B: reverting `miner/worker.go` to dev fails
  `TestCommitTransactionsHonoursBuildDeadline/deadline_passed` ("filled 7
  transactions past the deadline"); all three states (elapsed / ahead / unset)
  covered.

SPoA gate (2026-09-01, local 3-node net, governance deployed via
`deploy.sh`, all three nodes sealing — the prefetcher leak has no unit test
because the PoA path needs live governance):

- **Leak A/B on real mining rounds**, 120 txs to fresh addresses each,
  subfetcher goroutines sampled on node1 via `debug_stacks`:
  - dev binary (`f1944ae4a`): subfetcher **14 → 62 (+48, monotonic)**,
    total goroutines +150, over 125 blocks — the leak, live;
  - this branch (`bbd351e27`): subfetcher **0 for the entire run (+0)**,
    total goroutines plateau (steady-state churn), over 122 blocks.
- Round suite on the fixed binary: camellia-test 16/0/2 (fee-delegation
  I-08/I-09 exercised with the feePayer key unlocked; sealer rotation
  confirmed — I-11 saw node2 mining), blob-tx-e2e ALL PASS, mixed-tx-e2e
  ALL PASS.
- `applepieBlock: 0` still in the private-net genesis — the deadline guard's
  interaction surface with the Applepie gate is exercised by the e2e runs.
