### PR TITLE
consensus/ethash: report reward failures and verify the Camellia header fields

### DIFF
--- a/consensus/ethash/camellia_header_metadium_test.go
+++ b/consensus/ethash/camellia_header_metadium_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The go-metadium Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethash
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// TestVerifyCamelliaHeaderFields covers the header rules Camellia brings in.
+// Before them, the fields were permitted but never value-checked, so a sealer
+// could put an arbitrary blob fee market into a block and every node would
+// accept it (issue #70).
+func TestVerifyCamelliaHeaderFields(t *testing.T) {
+	empty := types.EmptyWithdrawalsHash
+	other := common.HexToHash("0xdead")
+
+	// A parent that used one blob, so the expected excessBlobGas is not zero and
+	// a wrong value cannot pass by accident.
+	parentBlobGasUsed := uint64(params.BlobTxBlobGasPerBlob)
+	parent := &types.Header{
+		Number:        big.NewInt(100),
+		ExcessBlobGas: new(big.Int).SetUint64(params.BlobTxTargetBlobGasPerBlock),
+		BlobGasUsed:   new(big.Int).SetUint64(parentBlobGasUsed),
+	}
+	wantExcess := types.CalcExcessBlobGas(parent.ExcessBlobGas, parentBlobGasUsed)
+	if wantExcess.Sign() == 0 {
+		t.Fatal("the fixture produces a zero expectation, which would not catch a wrong value")
+	}
+
+	header := func(mutate func(*types.Header)) *types.Header {
+		h := &types.Header{
+			Number:          big.NewInt(101),
+			WithdrawalsHash: &empty,
+			ExcessBlobGas:   new(big.Int).Set(wantExcess),
+			BlobGasUsed:     new(big.Int),
+		}
+		if mutate != nil {
+			mutate(h)
+		}
+		return h
+	}
+
+	for _, tt := range []struct {
+		name   string
+		header *types.Header
+		want   string // substring of the expected error, empty for success
+	}{
+		{"well formed", header(nil), ""},
+		{"withdrawals hash missing", header(func(h *types.Header) { h.WithdrawalsHash = nil }), "missing withdrawalsHash"},
+		{"withdrawals hash not empty", header(func(h *types.Header) { h.WithdrawalsHash = &other }), "invalid withdrawalsHash"},
+		{"excess blob gas missing", header(func(h *types.Header) { h.ExcessBlobGas = nil }), "missing excessBlobGas"},
+		{"blob gas used missing", header(func(h *types.Header) { h.BlobGasUsed = nil }), "missing blobGasUsed"},
+		{
+			"excess blob gas inflated",
+			header(func(h *types.Header) { h.ExcessBlobGas = new(big.Int).Mul(wantExcess, big.NewInt(1000)) }),
+			"invalid excessBlobGas",
+		},
+		{
+			"excess blob gas zeroed",
+			header(func(h *types.Header) { h.ExcessBlobGas = new(big.Int) }),
+			"invalid excessBlobGas",
+		},
+	} {
+		err := verifyCamelliaHeaderFields(tt.header, parent)
+		switch {
+		case tt.want == "" && err != nil:
+			t.Errorf("%s: rejected a valid header: %v", tt.name, err)
+		case tt.want != "" && err == nil:
+			t.Errorf("%s: accepted, want an error containing %q", tt.name, tt.want)
+		case tt.want != "" && !strings.Contains(err.Error(), tt.want):
+			t.Errorf("%s: want an error containing %q, got %v", tt.name, tt.want, err)
+		}
+	}
+}
+
+// TestVerifyCamelliaExcessBlobGasAtFork covers the fork block itself, whose
+// parent predates Camellia and therefore carries neither field. The builder
+// treats both as zero (miner.initExcessBlobGas), so the first Camellia block
+// must carry exactly zero.
+func TestVerifyCamelliaExcessBlobGasAtFork(t *testing.T) {
+	preFork := &types.Header{Number: big.NewInt(199)}
+	empty := types.EmptyWithdrawalsHash
+
+	first := &types.Header{
+		Number:          big.NewInt(200),
+		WithdrawalsHash: &empty,
+		ExcessBlobGas:   new(big.Int),
+		BlobGasUsed:     new(big.Int),
+	}
+	if err := verifyCamelliaHeaderFields(first, preFork); err != nil {
+		t.Fatalf("the fork block was rejected: %v", err)
+	}
+
+	first.ExcessBlobGas = big.NewInt(1)
+	if err := verifyCamelliaHeaderFields(first, preFork); err == nil {
+		t.Fatal("a non-zero excessBlobGas was accepted at the fork block")
+	}
+}

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	metaminer "github.com/ethereum/go-ethereum/metadium/miner"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -289,6 +290,8 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		case header.ParentBeaconRoot != nil:
 			return fmt.Errorf("invalid parentBeaconRoot, have %#x, expected nil", header.ParentBeaconRoot)
 		}
+	} else if err := verifyCamelliaHeaderFields(header, parent); err != nil {
+		return err
 	}
 	// Add some fake checks for tests
 	if ethash.fakeDelay != nil {
@@ -524,10 +527,66 @@ func (ethash *Ethash) Prepare(chain consensus.ChainHeaderReader, header *types.H
 	return nil
 }
 
+// verifyCamelliaHeaderFields checks the values of the header fields Camellia
+// permits. Allowing a field and validating it are two different things, and
+// until this existed only the first was done: upstream verifies these in the
+// beacon wrapper, and Metadium's PoA engine is not wrapped by it, so nothing
+// checked them at all (issue #70).
+//
+// What that left open was not a split between honest nodes -- execution is
+// self-consistent, every node reads the same value out of the header -- but a
+// single sealer setting the blob fee market to whatever it liked, with the next
+// block deriving from it, and every node accepting the result. BPs are
+// permissioned, which caps the severity; header rules exist so that a single BP
+// does not have to be trusted.
+//
+// ⚠ This is a consensus rule and it applies to history as well as to new blocks.
+// A node running it cannot import a Camellia block that violates it, so a full
+// clean sync over the whole post-Camellia range has to pass before this is
+// deployed. The failure message carries the block, the parent and both values so
+// that a violation found that way is diagnosable rather than just a stall.
+func verifyCamelliaHeaderFields(header, parent *types.Header) error {
+	// Metadium PoA has no withdrawals; FinalizeAndAssemble pins the hash to the
+	// empty root, so anything else is a header that was not built by this code.
+	if header.WithdrawalsHash == nil {
+		return fmt.Errorf("missing withdrawalsHash in camellia block %v (parent %x): expected %x",
+			header.Number, parent.Hash(), types.EmptyWithdrawalsHash)
+	}
+	if *header.WithdrawalsHash != types.EmptyWithdrawalsHash {
+		return fmt.Errorf("invalid withdrawalsHash in block %v (parent %x): have %x, want %x",
+			header.Number, parent.Hash(), *header.WithdrawalsHash, types.EmptyWithdrawalsHash)
+	}
+	// The blob fee market: excessBlobGas is a pure function of the parent, so it
+	// is the field a sealer could otherwise choose freely.
+	if header.ExcessBlobGas == nil {
+		return fmt.Errorf("missing excessBlobGas in camellia block %v (parent %x)", header.Number, parent.Hash())
+	}
+	if header.BlobGasUsed == nil {
+		return fmt.Errorf("missing blobGasUsed in camellia block %v (parent %x)", header.Number, parent.Hash())
+	}
+	var parentBlobGasUsed uint64
+	if parent.BlobGasUsed != nil {
+		parentBlobGasUsed = parent.BlobGasUsed.Uint64()
+	}
+	// types.CalcExcessBlobGas is the same formula the block builder applies in
+	// miner.initExcessBlobGas, including the nil-parent case at the fork block.
+	if want := types.CalcExcessBlobGas(parent.ExcessBlobGas, parentBlobGasUsed); header.ExcessBlobGas.Cmp(want) != 0 {
+		return fmt.Errorf("invalid excessBlobGas in block %v (parent %x): have %v, want %v",
+			header.Number, parent.Hash(), header.ExcessBlobGas, want)
+	}
+	return nil
+}
+
 // Finalize implements consensus.Engine, accumulating the block and uncle rewards.
 func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, withdrawals []*types.Withdrawal) {
-	// Accumulate any block and uncle rewards
-	accumulateRewards(chain.Config(), state, header, uncles)
+	// Accumulate any block and uncle rewards. On this path the error is
+	// reported rather than propagated: the signature is fixed by
+	// consensus.Engine, and a wrong reward state is caught by the state-root
+	// comparison in the block validator. Logging it is what the block-18
+	// incident showed was missing.
+	if err := accumulateRewards(chain.Config(), state, header, uncles); err != nil {
+		log.Error("Reward calculation failed", "number", header.Number, "parent", header.ParentHash, "err", err)
+	}
 }
 
 // FinalizeAndAssemble implements consensus.Engine, accumulating the block and
@@ -536,8 +595,12 @@ func (ethash *Ethash) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	if len(withdrawals) > 0 {
 		return nil, errors.New("ethash does not support withdrawals")
 	}
-	// Finalize block
-	ethash.Finalize(chain, header, state, txs, uncles, nil)
+	// Finalize block. Unlike the verifying path, refuse to build on a failed
+	// reward calculation: the block would be signed and published with no
+	// payouts credited (issue #70).
+	if err := accumulateRewards(chain.Config(), state, header, uncles); err != nil {
+		return nil, fmt.Errorf("reward calculation failed for block %v: %w", header.Number, err)
+	}
 
 	// Assign the final state root to header.
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
@@ -615,7 +678,18 @@ var (
 // AccumulateRewards credits the coinbase of the given block with the mining
 // reward. The total reward consists of the static block reward and rewards for
 // included uncles. The coinbase of each uncle block is also rewarded.
-func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
+// accumulateRewards credits the block's payouts. It returns an error only for a
+// reward calculation that failed unexpectedly: ErrNotInitialized is a normal
+// state (governance not deployed yet, e.g. while syncing early blocks) and is
+// handled here by crediting the fees alone.
+//
+// The error matters on the producing side. Before it was returned, an unexpected
+// failure fell through this function silently: a sealing node assembled and
+// signed a block with no payouts credited, and nothing said so. The verifying
+// side is already protected — the state root will not match — which is why
+// Finalize logs and continues while FinalizeAndAssemble refuses to sign
+// (issue #70).
+func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) error {
 	// Select the correct block reward based on chain progression
 	blockReward := FrontierBlockReward
 	if config.IsByzantium(header.Number) {
@@ -658,8 +732,12 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 				feeReward = new(uint256.Int)
 			}
 			state.AddBalance(header.Coinbase, feeReward)
+		} else {
+			// Unexpected: only the legacy governance path returns a raw error
+			// here, and it means no payout was credited for this block.
+			return err
 		}
-		return
+		return nil
 	}
 	// Accumulate the rewards for the miner and any included uncles
 	reward := new(uint256.Int).Set(blockReward)
@@ -677,4 +755,5 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		reward.Add(reward, r)
 	}
 	state.AddBalance(header.Coinbase, reward)
+	return nil
 }

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -597,11 +597,15 @@ func testReorg(t *testing.T, first, second []int64, td int64, full bool, scheme 
 	}
 	defer blockchain.Stop()
 
-	// Insert an easy and a difficult chain afterwards
-	easyBlocks, _ := GenerateChain(params.TestChainConfig, blockchain.GetBlockByHash(blockchain.CurrentBlock().Hash()), ethash.NewFaker(), genDb, len(first), func(i int, b *BlockGen) {
+	// Insert an easy and a difficult chain afterwards. Generate with the chain's
+	// own config: generating with a different one produced blocks that the chain
+	// does not consider well-formed once a fork applies header rules -- Camellia
+	// requires withdrawalsHash and the blob-gas fields, and TestChainConfig does
+	// not activate it while the chain above does (issue #70).
+	easyBlocks, _ := GenerateChain(blockchain.Config(), blockchain.GetBlockByHash(blockchain.CurrentBlock().Hash()), ethash.NewFaker(), genDb, len(first), func(i int, b *BlockGen) {
 		b.OffsetTime(first[i])
 	})
-	diffBlocks, _ := GenerateChain(params.TestChainConfig, blockchain.GetBlockByHash(blockchain.CurrentBlock().Hash()), ethash.NewFaker(), genDb, len(second), func(i int, b *BlockGen) {
+	diffBlocks, _ := GenerateChain(blockchain.Config(), blockchain.GetBlockByHash(blockchain.CurrentBlock().Hash()), ethash.NewFaker(), genDb, len(second), func(i int, b *BlockGen) {
 		b.OffsetTime(second[i])
 	})
 	if full {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -446,10 +446,21 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		}
 	}
 	// Set blob gas fields for Cancun or Camellia (Metadium EIP-4844 fork).
-	// For Camellia, only set on post-merge (PoS) blocks — pre-merge PoW blocks
-	// use the ethash consensus which does not accept these fields.
-	isPoS := header.Difficulty != nil && header.Difficulty.BitLen() == 0
-	if cm.config.IsCancun(header.Number, header.Time) || (cm.config.IsCamellia(header.Number) && isPoS) {
+	// Under Camellia these fields belong on every block, not only on post-merge
+	// ones: the PoA engine now verifies them against the parent, exactly as the
+	// block builder computes them (miner.initExcessBlobGas). The earlier
+	// difficulty-based condition left generated Camellia chains without the
+	// fields, which the engine's verification rejects (issue #70).
+	if cm.config.IsCamellia(header.Number) {
+		var parentBlobGasUsed uint64
+		parentHeader := parent.Header()
+		if parentHeader.BlobGasUsed != nil {
+			parentBlobGasUsed = parentHeader.BlobGasUsed.Uint64()
+		}
+		header.ExcessBlobGas = types.CalcExcessBlobGas(parentHeader.ExcessBlobGas, parentBlobGasUsed)
+		header.BlobGasUsed = new(big.Int)
+		// ParentBeaconRoot is not in Metadium header format
+	} else if cm.config.IsCancun(header.Number, header.Time) {
 		var (
 			parentExcessBlobGas uint64
 			parentBlobGasUsed   uint64
@@ -464,7 +475,6 @@ func (cm *chainMaker) makeHeader(parent *types.Block, state *state.StateDB, engi
 		excessBlobGas := eip4844.CalcExcessBlobGas(parentExcessBlobGas, parentBlobGasUsed)
 		header.ExcessBlobGas = new(big.Int).SetUint64(excessBlobGas)
 		header.BlobGasUsed = new(big.Int)
-		// ParentBeaconRoot is not in Metadium header format
 	}
 	return header
 }

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -344,6 +344,12 @@ func testHeader(t *testing.T, chain []*types.Block, client *rpc.Client) {
 				if got.ExcessBlobGas != nil && got.ExcessBlobGas.Sign() == 0 {
 					got.ExcessBlobGas = nil
 				}
+				// BlobGasUsed is set on every Camellia block by the chain maker (as by
+				// the miner); a zero that went through the RPC hex round-trip is not
+				// DeepEqual to an in-memory new(big.Int), so normalize it the same way.
+				if got.BlobGasUsed != nil && got.BlobGasUsed.Sign() == 0 {
+					got.BlobGasUsed = nil
+				}
 				// Metadium Camellia sets WithdrawalsHash on all post-fork blocks,
 				// but PoW-mode test headers may not persist it. Normalize for comparison.
 				got.WithdrawalsHash = nil
@@ -353,6 +359,9 @@ func testHeader(t *testing.T, chain []*types.Block, client *rpc.Client) {
 				// Also normalize the want side for PoW-mode legacy headers.
 				if wantCopy.ExcessBlobGas != nil && wantCopy.ExcessBlobGas.Sign() == 0 {
 					wantCopy.ExcessBlobGas = nil
+				}
+				if wantCopy.BlobGasUsed != nil && wantCopy.BlobGasUsed.Sign() == 0 {
+					wantCopy.BlobGasUsed = nil
 				}
 				wantCopy.WithdrawalsHash = nil
 				tt.want = &wantCopy


### PR DESCRIPTION
## What this changes

Closes #70 — two post-Camellia hardening items from the pre-#58
consensus-surface audit.

1. **Reward failures were silent on the producing path.** Old master's
   Finalize returned an error and block production aborted on an unexpected
   `CalculateRewards` failure; dev's Finalize is void (the upstream v1.13
   signature) and the unexpected-error branch fell through with no log at all —
   a sealing BP would assemble and sign a block with no payouts credited, and
   nothing would say so (the same failure family as the testnet block-18
   incident, where the absence of a log is what made diagnosis slow).
   `accumulateRewards` now returns the error; `ErrNotInitialized` keeps its
   meaning (normal while syncing before governance exists, fees only).
   Finalize logs the unexpected case and continues (fixed signature; the
   verifying side is already protected by the state-root comparison);
   `FinalizeAndAssemble` refuses to build the block — the case that mattered.
2. **Camellia header fields were permitted but never value-checked.** Upstream
   verifies `excessBlobGas` and `withdrawalsHash` in the beacon wrapper, and
   the PoA engine is not wrapped by it. Honest nodes do not split over this,
   but a single sealer could set the blob fee market to any value it liked,
   with every node accepting it. `verifyHeader` now requires
   `withdrawalsHash == EmptyWithdrawalsHash` and
   `excessBlobGas == types.CalcExcessBlobGas(parent)` — the same formula the
   builder applies — including the nil-parent case at the fork block.

Two in-tree producers did not conform and are fixed rather than excused:
`core/chain_makers` set the blob fields only on post-merge blocks (generated
Camellia chains lacked them), and four reorg tests generated blocks with
`params.TestChainConfig` while the chain under test uses
`AllEthashProtocolChanges`, which does activate Camellia. Generating with the
chain's own config is what those tests meant; the mismatch was invisible until
a fork started applying header rules.

## Compatibility tier

- [x] **C1 — consensus-adjacent narrowing.** A validity rule is tightened;
      every block the network has actually produced must already satisfy it.

**Why this tier:** the header rule applies to history. A node running it
cannot import a Camellia block that violates it — which is why the rollout
gate below exists. It is a narrowing: no block a correct m1.1.x sealer
produces is affected (the builder already computes exactly these values), so
un-upgraded nodes are unaffected and no exchange window is needed.

## Rollout

⚠️ **Deploy gate: a full clean sync over the entire post-Camellia range must
pass with this binary before it ships** (testnet first, then mainnet range).
The error messages carry the block, the parent and both values, so a
violation surfaces as a diagnosable failure rather than a stall. Per the
PR-template rollout rule, testnet BPs go first and the mixed fleet is observed
before anything else moves.

## Verification

Unit (re-run 2026-09-02 on the rebased branch, Go 1.22.5):

- `go test ./consensus/... ./core/ ./miner/` all pass (core 132s).
- Header-rule tests cover: well-formed, each field missing, inflated and
  zeroed `excessBlobGas`, and the fork block whose parent predates Camellia.

SPoA gate (2026-09-02, local 3-node net built from this branch
(`3ec92b3e6`), governance deployed, all three nodes sealing):

- 50 post-fork blocks produced and cross-verified under the new header rules —
  every block sealed by one node passes the other two nodes' `verifyHeader`
  with the `excessBlobGas`/`withdrawalsHash` checks live; blob transactions
  included (blob-tx-e2e), so the blob fields are exercised with non-trivial
  values.
- Zero `BAD BLOCK`, zero verify/import failures, zero unexpected-reward log
  lines across all three nodes' logs.
- camellia-test 16/0/2, blob-tx-e2e ALL PASS, mixed-tx-e2e ALL PASS.
- The `ErrNotInitialized` reward path (pre-governance phase, blocks 1–117)
  ran silently and credited fees only, as intended.

**Not yet run: the clean-sync deploy gate** — this PR is reviewable and
mergeable to dev on the evidence above, but the binary must not ship until
the post-Camellia clean sync passes (tracked as the rollout gate).
