### PR TITLE
build: make release-check fail instead of passing silently (#65 item 5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,18 @@ endif
 
 # gmet-linux always compiles inside a Linux container, so the host's uname must
 # not pick the engine for it. Default to RocksDB there and honour USE_ROCKSDB
-# only when it was given explicitly on the command line.
-ifeq ($(origin USE_ROCKSDB), command line)
+# only when a person set it — on the command line or in the environment. The
+# assignment above is uname-driven and must not leak into the container build,
+# which is why the file origin is excluded. The environment is accepted because
+# this repository configures builds that way elsewhere (dev-ci.yml passes
+# CFLAGS/CXXFLAGS through the environment), and silently building the other
+# engine is worse than either honouring or rejecting the variable.
+USE_ROCKSDB_ORIGIN := $(origin USE_ROCKSDB)
+ifeq ($(USE_ROCKSDB_ORIGIN),command line)
+GMET_LINUX_USE_ROCKSDB = $(USE_ROCKSDB)
+else ifeq ($(USE_ROCKSDB_ORIGIN),environment)
+GMET_LINUX_USE_ROCKSDB = $(USE_ROCKSDB)
+else ifeq ($(USE_ROCKSDB_ORIGIN),environment override)
 GMET_LINUX_USE_ROCKSDB = $(USE_ROCKSDB)
 else
 GMET_LINUX_USE_ROCKSDB = YES
@@ -163,16 +173,41 @@ gmet-linux:
 # Refuse artifacts that cannot run on the oldest distribution in the fleet.
 # Checks every ELF in $(GOBIN), not just gmet: the bundle also ships logrot,
 # which is built with cgo and carries a glibc floor of its own.
+# This is the last gate before publishing, so silence must never read as a pass.
+# Three ways it used to report OK without having checked anything:
+#   - objdump errors went to /dev/null, so an unreadable file produced empty
+#     output that was indistinguishable from a clean one ("GLIBC=none");
+#   - a non-GNU objdump (llvm-objdump on macOS) satisfies `command -v` and then
+#     prints a format this recipe does not parse;
+#   - an empty $(GOBIN) checked zero binaries and still printed OK.
+# Note that `objdump -T` legitimately fails on a statically linked binary
+# ("not a dynamic object"), which is why readability is probed with -f and a
+# missing dynamic symbol table is reported as such rather than as "none".
 release-check:
 	@command -v objdump > /dev/null 2>&1 || { echo "release-check: objdump not found" >&2; exit 1; }
-	@fail=0;							\
+	@objdump --version 2>/dev/null | head -1 | grep -q GNU || {		\
+		echo "release-check: objdump is not GNU binutils, whose output this check parses" >&2; \
+		echo "  found: `objdump --version 2>/dev/null | head -1`" >&2;	\
+		exit 1;								\
+	}
+	@fail=0; checked=0;						\
 	for f in $(GOBIN)/*; do						\
 		[ -f "$$f" ] || continue;				\
 		head -c 4 "$$f" | grep -q 'ELF' || continue;		\
-		glibc=`objdump -T "$$f" 2>/dev/null | sed -n 's/.*GLIBC_\([0-9][0-9.]*\).*/\1/p' | sort -V | tail -1`; \
-		gxx=`objdump -T "$$f" 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+' | sort -V | tail -1`; \
-		cxxabi=`objdump -T "$$f" 2>/dev/null | grep -oE 'CXXABI_[0-9.]+' | sort -V | tail -1`; \
-		echo "  $$f: GLIBC=$${glibc:-none} GLIBCXX=$${gxx:-none} CXXABI=$${cxxabi:-none}"; \
+		checked=`expr $$checked + 1`;				\
+		if ! objdump -f "$$f" > /dev/null 2>&1; then		\
+			echo "  $$f: FAIL: objdump cannot read this file" >&2; \
+			fail=1; continue;				\
+		fi;							\
+		if syms=`objdump -T "$$f" 2>/dev/null`; then		\
+			glibc=`echo "$$syms" | sed -n 's/.*GLIBC_\([0-9][0-9.]*\).*/\1/p' | sort -V | tail -1`; \
+			gxx=`echo "$$syms" | grep -oE 'GLIBCXX_[0-9.]+' | sort -V | tail -1`; \
+			cxxabi=`echo "$$syms" | grep -oE 'CXXABI_[0-9.]+' | sort -V | tail -1`; \
+			echo "  $$f: GLIBC=$${glibc:-none} GLIBCXX=$${gxx:-none} CXXABI=$${cxxabi:-none}"; \
+		else							\
+			glibc=; gxx=; cxxabi=;				\
+			echo "  $$f: no dynamic symbol table (statically linked)"; \
+		fi;							\
 		if [ -n "$$glibc" ] && [ "`printf '%s\n%s\n' "$$glibc" "$(MAX_GLIBC)" | sort -V | tail -1`" != "$(MAX_GLIBC)" ]; then \
 			echo "    FAIL: needs GLIBC_$$glibc > $(MAX_GLIBC)" >&2; fail=1; \
 		fi;							\
@@ -181,11 +216,15 @@ release-check:
 		fi;							\
 		objdump -p "$$f" 2>/dev/null | awk '/NEEDED/ {printf "    NEEDED %s\n", $$2}'; \
 	done;								\
+	if [ $$checked = 0 ]; then					\
+		echo "release-check: FAILED — no ELF binary found in $(GOBIN), nothing was checked" >&2; \
+		exit 1;							\
+	fi;								\
 	if [ $$fail != 0 ]; then					\
 		echo "release-check: FAILED — do not publish these artifacts" >&2; \
 		exit 1;							\
 	fi;								\
-	echo "release-check: OK (ceiling GLIBC_$(MAX_GLIBC))"
+	echo "release-check: OK ($$checked binaries, ceiling GLIBC_$(MAX_GLIBC))"
 	@echo "  NEEDED entries above must be present on target hosts (snappy, lz4, zstd, jemalloc)."
 
 ifneq ($(USE_ROCKSDB), YES)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ container target, never on the build host directly:
 ```bash
 make gmet-linux                     # RocksDB
 make gmet-linux USE_ROCKSDB=NO      # LevelDB
+USE_ROCKSDB=NO make gmet-linux      # LevelDB, from the environment
 ```
+
+The container build defaults to RocksDB regardless of the build host, because
+the host's `uname` must not pick the engine for a Linux container. `USE_ROCKSDB`
+is honoured when you set it explicitly, either on the command line or in the
+environment.
 
 `make gmet-linux` builds `Dockerfile.metadium` and compiles inside it. Two
 properties come from that image and nothing else guarantees them:
@@ -85,7 +91,12 @@ make release-check                  # ceiling from MAX_GLIBC (default 2.31)
 ```
 
 It covers every ELF in `build/bin` — `logrot` ships in the same bundle and has
-its own glibc floor — and prints each artifact's `NEEDED` list. Those shared
+its own glibc floor — and prints each artifact's `NEEDED` list. It refuses to
+report success without having checked something: a file `objdump` cannot read,
+an `objdump` that is not GNU binutils, and an empty `build/bin` are all
+failures rather than quiet passes. A statically linked artifact is reported as
+having no dynamic symbol table, which is a different line from a clean dynamic
+one. Those shared
 libraries (snappy, lz4, zstd, jemalloc) must exist on the target host; the
 symbol-version checks passing does not by itself make an artifact runnable on a
 freshly installed machine.


### PR DESCRIPTION
## What this changes

Item 5 of #65 (the release-check gate), first of five PRs splitting the
release-pipeline track (#65-5 → #85 → #84 → #86 → #87; each later PR builds on
this one).

`release-check` is the last gate before publishing, and it reported OK in
three situations where it had checked nothing:

- every objdump call sent errors to /dev/null, so a truncated ELF printed
  `GLIBC=none GLIBCXX=none CXXABI=none` and then "release-check: OK";
- a non-GNU objdump (macOS llvm-objdump) satisfies `command -v objdump` and
  prints a format the recipe does not parse;
- an empty `build/bin` iterated over nothing and still printed OK.

Readability is now probed with `objdump -f` (which succeeds on any valid
object file — `objdump -T` legitimately fails on a statically linked binary,
the normal case for logrot, so that case is labelled static instead of looking
unreadable). The symbol table is read once per artifact instead of three
times, and the OK line states how many binaries were checked.

Second item, same gate: `gmet-linux` honoured `USE_ROCKSDB` only from the
command line, so `USE_ROCKSDB=NO make gmet-linux` silently built RocksDB.
Both origins are now honoured, and the README documents it.

## Compatibility tier

- [x] **C7 — internal only.** Tests, docs, tooling, or producer-side behaviour
      that does not change block validity.

**Why this tier:** build tooling only — no node code. It changes what the
release pipeline refuses to publish, not what a published binary does.

## Rollout

No gate — nothing deploys.

## Verification

Re-run 2026-09-01 on this commit alone (not just the full stack):

- truncated ELF in `build/bin` → "FAIL: objdump cannot read this file" +
  "release-check: FAILED — do not publish these artifacts" (this passed
  silently before the change);
- empty `build/bin` → "FAILED — no ELF binary found in ./build/bin, nothing
  was checked";
- a real dynamic binary is measured as before, and `make release-check` at the
  full-stack tip passes against the m1.1.3 release artifacts' layout.

All four fixture paths (dynamic / static / truncated / stub llvm-objdump) were
exercised when the commit was written; the fixtures are described in the
commit message.
