### PR TITLE
ci: collapse the three amd64 pipelines into one reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: ci
+
+# The amd64 pipeline, in one place. dev-ci, dev-cron and master-ci were three
+# near-identical copies of it, which is why the toolchain bump had to be applied
+# per file and why drift had already appeared: one build job was still named
+# "Go-MetadiumX", and go.yml pins a different Go patch release (issue #65).
+#
+# Callers differ in exactly three things, which are the inputs below: which ref
+# to check out, which make target runs the tests, and the Go version.
+#
+# Note for whoever compares check names across runs: jobs called through
+# workflow_call appear as "<caller job>/<job>", so these are reported as
+# "ci / build_test" and so on rather than "build_test". Nothing required them by
+# name — master's protection lists no required status checks and dev is
+# unprotected — so this rename does not gate any merge.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Ref to check out. Empty means the ref that triggered the caller.'
+        required: false
+        type: string
+        default: ''
+      test-target:
+        description: 'make target for the unit test job (test-short or test).'
+        required: false
+        type: string
+        default: test-short
+      go-version:
+        description: 'Go toolchain for every job here.'
+        required: false
+        type: string
+        default: '1.21'
+
+jobs:
+  build_test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Build Go-Metadium
+        env:
+          CFLAGS: "-Wno-error=unused-parameter"
+          CXXFLAGS: "-Wno-error=unused-parameter"
+        run: make metadium
+
+      - name: Check Build
+        run: ls -al build/metadium.tar.gz
+
+  lint_test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Check Lint
+        run: make lint
+
+  unit_test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Check golang Test Cases
+        run: |
+          unset ANDROID_HOME
+          make ${{ inputs.test-target }}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -9,48 +9,7 @@ on:
       - dev
 
 jobs:
-  build_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Build Go-MetadiumX
-      env:
-        CFLAGS: "-Wno-error=unused-parameter"
-        CXXFLAGS: "-Wno-error=unused-parameter"
-      run: make metadium
-    - name: Check Build
-      run: ls -al build/metadium.tar.gz
-
-  lint_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Check Lint
-      run: make lint
-
-  unit_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Check golang Test Cases
-      run: |
-        unset ANDROID_HOME
-        make test-short
+  ci:
+    # Pipeline in .github/workflows/ci.yml. Pull requests run the short test
+    # target; dev-cron runs the full one nightly.
+    uses: ./.github/workflows/ci.yml

--- a/.github/workflows/dev-cron.yml
+++ b/.github/workflows/dev-cron.yml
@@ -5,54 +5,10 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  build_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: dev
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Build Go-Metadium
-      env:
-        CFLAGS: "-Wno-error=unused-parameter"
-        CXXFLAGS: "-Wno-error=unused-parameter"
-      run: make metadium
-    - name: Check Build
-      run: ls -al build/metadium.tar.gz
-
-  lint_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: dev
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Check Lint
-      run: make lint
-
-  unit_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: dev
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Check golang Test Cases
-      run: |
-        unset ANDROID_HOME
-        make test
+  ci:
+    # Nightly run of the full test suite against dev. A scheduled run has no
+    # ref of its own, so dev is named explicitly.
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: dev
+      test-target: test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
+          # Left as an exact patch pin, unlike the amd64 pipelines, which take
+          # '1.21' from ci.yml. Whether that exactness is deliberate is not
+          # recorded anywhere; if it is not, align it there so both move
+          # together (issue #65 noted the difference as drift).
           go-version: 1.21.4
       - name: Compile everything (including test binaries)
         run: |

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -5,58 +5,11 @@ on:
     branches:
       - master
 
-# master carries the Camellia (go-ethereum v1.13.14) tree, which needs the
-# same toolchain as dev-ci; the old 1.17-1.19 matrix predates the rebase and
-# cannot build this codebase.
 jobs:
-  build_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Build Go-Metadium
-      env:
-        CFLAGS: "-Wno-error=unused-parameter"
-        CXXFLAGS: "-Wno-error=unused-parameter"
-      run: make metadium
-    - name: Check Build
-      run: ls -al build/metadium.tar.gz
-
-  lint_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Check Lint
-      run: make lint
-
-  unit_test:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.21'
-
-    - name: Check golang Test Cases
-      run: |
-        unset ANDROID_HOME
-        make test-short
+  ci:
+    # master carries the same tree as dev, so it runs the same pipeline. The
+    # head SHA is checked out explicitly rather than the merge commit, which is
+    # what a release-promotion PR is reviewed against.
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What this changes

Closes #85. Second of five PRs in the release-pipeline split (#65-5 → #85 →
#84 → #86 → #87); the first landed as #112, so this is a single commit on top
of `dev`.

`dev-ci`, `dev-cron` and `master-ci` were near-identical copies of the same
pipeline. That is why the toolchain bump had to be applied per file, and the
drift it predicts had already arrived: one build job was still named
"Go-MetadiumX" while the other two said "Go-Metadium".

The pipeline now lives in `ci.yml` behind `workflow_call`, and the three
triggers are callers that differ only in what actually differs between them:
which ref to check out, and whether the unit job runs `test-short` or `test`.
213 lines of workflow become 168, with the toolchain named once.

Check names change: a job reached through `workflow_call` is reported as
"ci / build_test" rather than "build_test". That is safe here and was verified
rather than assumed — master's protection lists no required status checks (it
requires one approving review) and dev is not protected at all, so no merge
gate refers to these names.

`go.yml` is left alone beyond a comment: it is a different pipeline
(self-hosted, GOARCH=386, compile-everything) and only runs on master, so
changing it here would surface a break a release later rather than on this PR.

## Compatibility tier

- [x] **C7 — internal only.** Tests, docs, tooling, or producer-side behaviour
      that does not change block validity.

**Why this tier:** CI workflow structure only. The toolchain version CI runs
is unchanged by this PR (that move is the next PR in the stack).

## Rollout

No gate — nothing deploys.

## Verification

- All five workflow files parse (`yaml.safe_load`), re-run 2026-09-01 at this
  commit.
- The check names this PR's own CI run reports are the proof of the
  `workflow_call` wiring — inspect them on this PR.
- Branch-protection audit: master requires a review, not named checks; dev has
  no protection. No gate references the old check names.
