### PR TITLE
miner, eth, cmd: seal a private-PoA block once the pool goes quiet

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -220,6 +220,7 @@ var (
 		utils.BlockMinBuildTime,
 		utils.BlockMinBuildTxs,
 		utils.BlockTrailTime,
+		utils.BlockIdleSealTime,
 		utils.BlobRetentionBlocks,
 	}
 )

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1023,6 +1023,11 @@ var (
 		Usage: "Time to leave for block data transfer in ms",
 		Value: params.BlockTrailTime,
 	}
+	BlockIdleSealTime = &cli.Int64Flag{
+		Name:  "metadium.block.idleseal",
+		Usage: "Private networks only: seal a non-empty block once no new transaction arrives for this many ms (0 = off, hold the full block interval)",
+		Value: params.BlockIdleSealTime,
+	}
 	BlobRetentionBlocks = &cli.Uint64Flag{
 		Name:  "blob.retention",
 		Usage: "Number of blocks to retain blob sidecars (0 = keep forever)",
@@ -2054,6 +2059,12 @@ func SetMetadiumConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	}
 	if ctx.IsSet(BlockTrailTime.Name) {
 		params.BlockTrailTime = ctx.Int64(BlockTrailTime.Name)
+	}
+	if ctx.IsSet(BlockIdleSealTime.Name) {
+		params.BlockIdleSealTime = ctx.Int64(BlockIdleSealTime.Name)
+		if params.BlockIdleSealTime < 0 {
+			Fatalf("Invalid %s: %d, must not be negative", BlockIdleSealTime.Name, params.BlockIdleSealTime)
+		}
 	}
 
 	if params.ConsensusMethod == params.ConsensusInvalid {

--- a/docs/enterprise-block-timing.md
+++ b/docs/enterprise-block-timing.md
@@ -150,6 +150,32 @@ deadline `timeIt` computes; nothing enforces it against an early seal. An
 `idleseal` below it (the 100ms above, against a 300ms `BlockMinBuildTime`) is
 honored as written.
 
+**`throttleMining` was removed here, and it is worth knowing why.**
+`miner/worker.go` carried `throttleMining`/`ancestorTimes` from `7ed4d8b27`
+(2019-03, "added block generation throttling"): a hard rate cap where 1000
+blocks must span 2000s, 500 blocks 500s, 100 blocks 50s, 50 blocks 10s, and a
+violation sleeps for the shortfall **in whole seconds**. It belonged to the
+era this document is restoring -- sealing happened as soon as the pool drained,
+there was no slot deadline, so block production needed a brake.
+
+The `f113fe913` go-wemix import (2023-07) brought `timeIt` and dropped the call
+site; the two overlap, and `timeIt` is the better-behaved of the pair. The dead
+definition survived the import and sat unreferenced through every release from
+`m0.10.0` (2023-10) to `m1.1.3`.
+
+| | `timeIt` (alive) | `throttleMining` (removed) |
+|---|---|---|
+| direction | both -- shortens the slot when behind, stretches it when ahead | brake only; does nothing when the chain is late |
+| bound | `interval + 800ms`, a fixed formula | none: up to `2000 - elapsed` **seconds** |
+| basis | block density vs the nominal interval | absolute counts over the last 1000 blocks |
+
+Restoring the brake would have been actively harmful here. On a chain sealing
+on idle at the 692ms/block measured above, the 1000-block rule alone would
+sleep `2000 - 692 = 1308s` -- **block production stops for ~22 minutes**, and
+the faster the chain, the longer the stall. Nothing is lost by removing it:
+catching up when the chain runs *late* was never its job, and that half is
+`timeIt`'s, which stays.
+
 **What disappears is the slot deadline acting as a ceiling on block rate.**
 Traffic arriving just slower than `idleseal` gives every transaction its own
 block. Nothing pathological appeared in testing -- steady traffic produced one

--- a/docs/enterprise-block-timing.md
+++ b/docs/enterprise-block-timing.md
@@ -1,0 +1,189 @@
+# Private-PoA block timing
+
+A private Metadium PoA deployment usually wants a different bargain than the
+public chain does. The public networks take a fixed cadence from governance and
+seal on that clock whether or not anyone sent a transaction. An enterprise chain
+is typically idle most of the time and then needs a transaction *confirmed*
+quickly -- waiting out the rest of a 5 second slot is the whole latency.
+
+One node flag restores the confirmation behavior early Metadium had
+(`11be6ec99`, 2018-06-29, "immediate block generation / empty blocks only after
+maxidleblockinterval"), without changing what the public networks do.
+
+| Flag | Unit | Default | Effect |
+|---|---|---|---|
+| `--metadium.block.idleseal` | ms | `0` (off) | Once the block being built holds at least one transaction, seal it as soon as no new transaction has arrived for this long, instead of holding the slot open to its deadline. |
+
+It defaults to off, which is exactly the behavior of a build without it. Empty
+blocks are untouched: with an empty pool the sealer still runs the slot to its
+deadline, so the on-chain interval remains the chain's heartbeat.
+
+## Configuring a private PoA network
+
+1. **Block interval is on-chain, not a flag.** The sealer reads
+   `EnvStorage.getBlockCreationTime` (milliseconds) through
+   `getBlockBuildParameters`. Queried on mainnet today it is `2000`, and testnet
+   paces identically (block spacing measured at exactly 2.000s over 1000-block
+   windows) -- **the 5s used throughout this document is the private test
+   chain's own setting**, not a public-network value. Set it when the
+   governance contracts are deployed
+   -- in `tests/private-net-poa` that is `BLOCK_CREATION_TIME=5000 ./deploy.sh`
+   -- or change it later by ballot. Note `timeIt` divides it by 1000, so the
+   interval has one-second granularity and anything under 1000ms falls back to
+   2 seconds.
+   `--metadium.block.interval` looks like the knob for this but is dead: the
+   value is stored in `params.BlockInterval` and never read.
+
+2. **Set the flag identically on every sealer.** It only takes effect on the
+   node that is building a block, so a fleet with mixed values simply gets
+   different latency depending on whose turn it is. Non-sealing RPC and full
+   nodes ignore it (`commitWork` returns before this code on a non-miner), so
+   passing it there is harmless but pointless.
+
+3. **Typical enterprise profile** -- 5 second heartbeat, ~100ms confirmation:
+
+   ```
+   # governance (once, at deploy time)
+   blockCreationTime = 5000
+
+   # every sealer
+   --metadium.block.idleseal 100
+   ```
+
+## Measured behavior
+
+3-node PoA private net (`tests/private-net-poa`, LevelDB, one host), governance
+`blockCreationTime = 5000`, all three nodes sealing. "Confirm" is wall clock
+from `eth_sendTransaction` returning to the receipt being available.
+
+| Configuration | Idle cadence | Confirm (single tx) | 40-tx burst |
+|---|---|---|---|
+| flag off (public-network behavior) | empty block every 4.3-5.8s | avg 2544ms (min 1962, max 2634) | 1 block, 5657ms |
+| `idleseal=100` | empty block every 4.3s | **avg 117ms** (min 117, max 118) | 1 block, **174ms** |
+
+A 10-minute soak with `idleseal=100` and one transaction every 3 seconds, to see
+whether latency ever spikes: 193 transactions, **min 107ms, p50 118ms, p90 128ms,
+p99 130ms, max 130ms**, nothing above 500ms. The gap between p50 and the maximum
+is 12ms -- there is no tail. That run also produced 193 blocks for 193
+transactions: with traffic this steady every slot closes on a transaction, so no
+empty blocks appear at all.
+
+Across the runs: three nodes stayed in lockstep at the same head, 40 sampled
+blocks had no parent-hash break, and the logs carried no `BAD BLOCK`, no panic
+and no seal failure. The only ERROR lines were the harness's pre-existing
+`static-nodes.json is deprecated` warnings.
+
+## Interactions worth knowing
+
+**Three governance values are easy to confuse, and one of them is inert.**
+`getBlockCreationTime` is the block interval and is read every block (mainnet
+`2000`). `getMaxIdleBlockInterval` is the idle heartbeat -- mainnet has it set
+to `5` -- and **nothing reads it for block production**: it is loaded into a
+struct and never consulted, the same fate as `throttleMining`'s call site. That
+is why an idle chain still mints an empty block every slot. Re-wiring it is not
+the small fix it looks like: mainnet has the value set to `5`, so honoring it
+would move mainnet's idle cadence from 2s to 5s. This flag deliberately leaves
+empty blocks alone and touches only the block that carries a transaction.
+
+**The drift correction still owns the empty-block cadence, and only that.**
+`timeIt` compares recent block density against the nominal interval and either
+shortens the next slot (behind: `(interval-1)s + BlockMinBuildTime`) or
+stretches it (ahead: `interval + BlockMinBuildTime + 500ms`). At a 5s interval
+that is 4300ms and 5800ms -- which is why the idle cadence above reads 4.3s or
+5.8s rather than a flat 5s. Both branches are **fixed formulas, not
+proportional to the drift**, so however far ahead the chain runs the empty-slot
+deadline never grows past `interval + 800ms`. There is no runaway.
+
+Early sealing does feed that loop: a busy chain produces blocks faster than the
+interval, so the correction settles on "ahead" and slows the *empty* slots to
+the 5.8s ceiling. It does not touch confirmation latency, because `idleseal`
+fires relative to the last transaction while the correction only moves the slot
+deadline, which is an upper bound. Measured: 45s of load at 10 tx/s produced 65
+blocks (692ms/block, ~7x the nominal rate) and left the chain firmly ahead;
+single-transaction confirmation immediately afterwards was **avg 123ms (min 116,
+max 128)**, the same as on an undrifted chain, while the idle gaps stretched to
+5821-5823ms. The sealer's own log shows both halves at once:
+
+```
+DEBUG time-it   ahead=1,788,860,385 duration=5800
+DEBUG Sealing early, transaction pool went quiet number=626 txs=1 idle-ms=100 slot-left=1.693s
+```
+
+The correction had set a 5800ms deadline; the idle seal closed the block with
+1.693s of it still unused.
+
+**How much late does an idle chain actually run after a fast burst?** The
+question an operator will ask, measured directly: 100 blocks were produced at
+122ms each, then transactions stopped and every subsequent gap was recorded.
+
+```
+#1099..#1119   5.8s each  (+829, +806, +813, ... , +829ms vs the nominal 5s)   21 blocks
+#1120..#1132   4.3s each  (-669, -709, -661, ... , -682ms)                     13 blocks
+#1133..        5.8s and 4.3s mixed
+n=43  min=4291  avg=5330  max=5846 ms
+```
+
+So the whole penalty is **+846ms at worst, for 21 blocks -- about 17 seconds of
+accumulated delay** -- and then the correction flips to `behind` and gives it
+back at 4.3s per block. Nothing accumulates beyond that, whatever the burst
+was: both branches are fixed values.
+
+All four numbers fall out of the judgement window rather than being incidental
+to the run. `timeIt` looks back over `1, 24, 240, 2400, 17280` blocks (24 =
+`BlockTimeAdjBlocks / interval`, then ten-fold, capped at `86400 / interval`)
+and calls the window `behind` once its elapsed time passes the nominal
+`24 x 5 = 120s`, stopping at the first window that says so. With k slow blocks
+in that window, `k*5.82 + (24-k)*0.122 > 120` gives k=20 -> 116.9s (still
+ahead), **k=21 -> 122.6s -> flip**. Coming back is the same arithmetic:
+with m blocks at 4.3s, `139.7 - 1.51m < 120` gives **m=13 -> 120.1s**. The two
+values then interleave because `dt` sits on the 120s boundary and header
+timestamps are whole seconds. On mainnet's 2s interval the window is
+`120 / 2 = 60` blocks and the deadlines become 1300 / 1700 / 2800ms -- which
+matches its measured spacing (1s 26.0%, 2s 55.8%, 3s 10.5%, 4s 7.7%).
+
+Only the empty heartbeat is affected. A block carrying a transaction is sealed
+by the idle rule long before either deadline -- the 10-minute soak above saw a
+maximum of 130ms.
+
+**`BlockMinBuildTime` is not a floor for idle sealing.** It only shapes the
+deadline `timeIt` computes; nothing enforces it against an early seal. An
+`idleseal` below it (the 100ms above, against a 300ms `BlockMinBuildTime`) is
+honored as written.
+
+**What disappears is the slot deadline acting as a ceiling on block rate.**
+Traffic arriving just slower than `idleseal` gives every transaction its own
+block. Nothing pathological appeared in testing -- steady traffic produced one
+block per transaction and dense traffic coalesced (40 transactions into one
+block) -- but if a deployment needs a floor under the block rate, the shape to
+add is a bounded minimum spacing since the parent.
+
+**Timestamps are seconds, and several blocks can share one.** PoA permits it --
+the `header.Time <= parent.Time` rejection in `consensus/ethash/consensus.go` is
+guarded by `metaminer.IsPoW()` -- so this is consensus-legal. Explorers and
+indexers that compute block time by subtracting timestamps will show 0s gaps.
+
+**Finality depth is measured in blocks, not seconds.**
+`GetFinalizedBlockNumber` returns `head - (govNodeCount/2 + 1)`. Empty blocks
+keep arriving on the on-chain interval, so that depth fills at the same rate as
+before; sealing early only brings it forward, never delays it.
+
+## Why mainnet and testnet are unaffected
+
+- **Off by default.** `params.BlockIdleSealTime` is 0, and every new path is
+  behind a `> 0` test. With the flag unset the sealer runs the same code it ran
+  before: the quiet timer is never created and the wait selects on a nil
+  channel, which never fires. Measured on the same binary with the flag
+  omitted: idle cadence and confirmation latency matched the pre-change
+  baseline.
+- **Refused outright on the public chains.** `eth.New` looks up the genesis hash
+  and returns an error -- the node exits rather than starting -- if the flag is
+  set on a chain whose genesis is `MetadiumMainnetGenesisHash` or
+  `MetadiumTestnetGenesisHash`. Keyed on genesis rather than chain id, because a
+  private chain may reuse a chain id but never the public genesis.
+- **No consensus rule is touched.** Block spacing is not validated by
+  `verifyHeader`; producer rotation is height-based
+  (`admin.go: ix := int(height/blocksPer) % len(nodes)`); rewards are per block.
+  A node running this flag produces blocks that any stock node accepts, and the
+  flag changes nothing about validation, so a mixed fleet stays in agreement --
+  the sealer just closes blocks sooner.
+- **Sealer-side only.** Nothing in the import, sync or RPC path reads the value.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -104,6 +104,19 @@ type Ethereum struct {
 
 // New creates a new Ethereum object (including the
 // initialisation of the common Ethereum object)
+// publicMetadiumNetwork names the public Metadium network the given genesis
+// hash belongs to, or "" for any other (private) chain.
+func publicMetadiumNetwork(genesis common.Hash) string {
+	switch genesis {
+	case params.MetadiumMainnetGenesisHash:
+		return "mainnet"
+	case params.MetadiumTestnetGenesisHash:
+		return "testnet"
+	default:
+		return ""
+	}
+}
+
 func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// Ensure configuration values are compatible and sane
 	if config.SyncMode == downloader.LightSync {
@@ -218,6 +231,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err
+	}
+	// The private-PoA idle seal changes when a sealer closes a block. Metadium
+	// mainnet and testnet take their cadence from governance and must keep the
+	// one behavior every node agrees on, so refuse to start rather than let a
+	// stray flag alter block production there. Keyed on the genesis hash, not
+	// the chain id, because a private chain may legitimately reuse a chain id
+	// but never the public genesis.
+	if params.BlockIdleSealTime > 0 {
+		if network := publicMetadiumNetwork(eth.blockchain.Genesis().Hash()); network != "" {
+			return nil, fmt.Errorf("--metadium.block.idleseal is for private networks only, but this node is on the Metadium %s", network)
+		}
 	}
 	eth.bloomIndexer.Start(eth.blockchain)
 

--- a/eth/backend_metadium_test.go
+++ b/eth/backend_metadium_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 The go-metadium Authors
+
+package eth
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// The private-PoA idle seal flag is refused on the public networks, and that
+// refusal is keyed on the genesis hash. Pin the mapping: a wrong or empty
+// answer here would either let the flag through on mainnet/testnet or block a
+// private chain that is entitled to it.
+func TestPublicMetadiumNetwork(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		genesis common.Hash
+		want    string
+	}{
+		{"mainnet", params.MetadiumMainnetGenesisHash, "mainnet"},
+		{"testnet", params.MetadiumTestnetGenesisHash, "testnet"},
+		{"private chain", common.HexToHash("0xdeadbeef"), ""},
+		{"zero hash", common.Hash{}, ""},
+		{"ethereum mainnet", params.MainnetGenesisHash, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := publicMetadiumNetwork(tt.genesis); got != tt.want {
+				t.Fatalf("publicMetadiumNetwork(%s) = %q, want %q", tt.genesis.Hex(), got, tt.want)
+			}
+		})
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1067,63 +1067,6 @@ func (w *worker) commitTransactions(env *environment, plainTxs, blobTxs *transac
 	return nil
 }
 
-// collects ancestors' block times for possible throttling
-func (w *worker) ancestorTimes(num *big.Int) []int64 {
-	ts := make([]int64, 6)
-	for i := 0; i < len(ts); i++ {
-		bn := num.Int64()
-		switch i {
-		case 0:
-			bn -= 1
-		case 1:
-			bn -= 10
-		case 2:
-			bn -= 50
-		case 3:
-			bn -= 100
-		case 4:
-			bn -= 500
-		case 5:
-			bn -= 1000
-		}
-		if bn <= 0 {
-			continue
-		}
-		if bh := w.chain.GetHeaderByNumber(uint64(bn)); bh != nil {
-			ts[i] = int64(bh.Time)
-		}
-	}
-	return ts
-}
-
-// returns throttle delay if necessary in seconds & seconds from the parent
-// blocks  seconds  seconds per
-//
-//	  10        1  0.1
-//	  50       10  0.2
-//	 100       50  0.5
-//	 500      500  1
-//	1000     2000  2
-func (w *worker) throttleMining(ts []int64) (int64, int64) {
-	t := time.Now().Unix()
-	dt, pt := int64(0), t-ts[0]
-
-	// 1000th
-	if dt = t - ts[5]; ts[5] > 0 && dt < 2000 {
-		return 2000 - dt, pt
-	}
-	if dt = t - ts[4]; ts[4] > 0 && dt < 500 {
-		return 500 - dt, pt
-	}
-	if dt = t - ts[3]; ts[3] > 0 && dt < 50 {
-		return 50 - dt, pt
-	}
-	if dt = t - ts[2]; ts[2] > 0 && dt < 10 {
-		return 10 - dt, pt
-	}
-	return 0, pt
-}
-
 // stopTimer stops t and drains its channel if it had already fired, so the
 // timer can be discarded without leaking a pending tick. A nil timer is a
 // no-op, which lets callers keep optional timers unset.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1124,6 +1124,21 @@ func (w *worker) throttleMining(ts []int64) (int64, int64) {
 	return 0, pt
 }
 
+// stopTimer stops t and drains its channel if it had already fired, so the
+// timer can be discarded without leaking a pending tick. A nil timer is a
+// no-op, which lets callers keep optional timers unset.
+func stopTimer(t *time.Timer) {
+	if t == nil {
+		return
+	}
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+}
+
 func (w *worker) commitTransactionsEx(env *environment, interrupt *atomic.Int32, tstart time.Time) bool {
 	// committed transactions (tracked by hash to avoid reprocessing)
 	committedTxHashes := map[common.Hash]struct{}{}
@@ -1207,30 +1222,43 @@ func (w *worker) commitTransactionsEx(env *environment, interrupt *atomic.Int32,
 
 		remaining := time.Until(*env.till)
 		timer := time.NewTimer(remaining)
+
+		// Metadium private PoA: once this block carries a transaction, close it
+		// as soon as the pool has stayed quiet for BlockIdleSealTime instead of
+		// holding the slot open until env.till. The quiet window starts after
+		// the fill above, which drained txCh, so an arrival during the wait
+		// resets it by taking the txCh branch. Off (0) on the public networks,
+		// where the slot always runs to env.till.
+		var (
+			quiet  *time.Timer
+			quietC <-chan time.Time
+		)
+		if params.BlockIdleSealTime > 0 && env.tcount > 0 {
+			quiet = time.NewTimer(time.Duration(params.BlockIdleSealTime) * time.Millisecond)
+			quietC = quiet.C
+		}
+
+		sealOnIdle := false
 		select {
 		case <-timer.C:
+		case <-quietC:
+			sealOnIdle = true
 		case <-txCh:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
+			stopTimer(timer)
+			stopTimer(quiet)
 			continue
 		case <-sub.Err():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
+			stopTimer(timer)
+			stopTimer(quiet)
 			return true
 		}
-		if !timer.Stop() {
-			select {
-			case <-timer.C:
-			default:
-			}
+		stopTimer(timer)
+		stopTimer(quiet)
+		if sealOnIdle {
+			log.Debug("Sealing early, transaction pool went quiet", "number", env.header.Number,
+				"txs", env.tcount, "idle-ms", params.BlockIdleSealTime,
+				"slot-left", common.PrettyDuration(time.Until(*env.till)))
+			break
 		}
 	}
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -259,11 +259,16 @@ var (
 	MaxTxsPerBlock int    = 5000 // Max # of transactions in a block
 	Hub            string = ""   // Hub's id
 
-	BlockInterval        int64  = 1       // Block generation interval in seconds
-	BlockTimeAdjBlocks   int64  = 120     // Block interval to adjust timestamp
-	BlockTimeAdjMultiple int64  = 4       // How many of block intervals to consider
-	BlockMinBuildTime    int64  = 300     // Minimum block generation time in ms
-	BlockMinBuildTxs     int64  = 2500    // Minimum txs in a block with pending txs
-	BlockTrailTime       int64  = 300     // Time to leave for block data transfer transfer in ms
-	BlobRetentionBlocks  uint64 = 1572480 // Number of blocks to keep blob sidecars (~36.4 days at Metadium's 2s block interval; 0 = forever)
+	BlockInterval        int64 = 1    // Block generation interval in seconds
+	BlockTimeAdjBlocks   int64 = 120  // Block interval to adjust timestamp
+	BlockTimeAdjMultiple int64 = 4    // How many of block intervals to consider
+	BlockMinBuildTime    int64 = 300  // Minimum block generation time in ms
+	BlockMinBuildTxs     int64 = 2500 // Minimum txs in a block with pending txs
+	BlockTrailTime       int64 = 300  // Time to leave for block data transfer transfer in ms
+	// Private-PoA (enterprise) block timing. 0 = off, which is the behavior of
+	// the public networks: a block is sealed when its slot elapses. Deployments
+	// that need lower confirmation latency than the on-chain block interval
+	// turn this on; see docs/enterprise-block-timing.md.
+	BlockIdleSealTime   int64  = 0       // Seal once the pool stays quiet this long (ms) and the block has txs
+	BlobRetentionBlocks uint64 = 1572480 // Number of blocks to keep blob sidecars (~36.4 days at Metadium's 2s block interval; 0 = forever)
 )

--- a/tests/private-net-poa/deploy.sh
+++ b/tests/private-net-poa/deploy.sh
@@ -7,6 +7,7 @@
 #
 # Usage: ./deploy.sh
 # Options: GMET_BIN=/path/to/gmet ./deploy.sh
+#          BLOCK_CREATION_TIME=5000 (ms, on-chain block interval; default 2000)
 
 set -euo pipefail
 
@@ -82,7 +83,7 @@ cat > config.json <<EOF
     "stakingMin":             1000000000000000000,
     "stakingMax":             100000000000000000000000000,
     "MaxIdleBlockInterval":   5,
-    "blockCreationTime":      2000,
+    "blockCreationTime":      ${BLOCK_CREATION_TIME:-2000},
     "blockRewardAmount":      1000000000000000000,
     "maxPriorityFeePerGas":   80000000000,
     "rewardDistributionMethod": [4000, 1000, 2500, 2500],


### PR DESCRIPTION
## What this changes

A private PoA deployment is idle most of the time and then wants a transaction
*confirmed* quickly. Our sealer takes its cadence from governance and closes a
block when the slot elapses, so a transaction waits out the rest of its slot --
with a 5s interval that is 2.5s on average, and it is the whole latency. Early
Metadium did not work this way: `11be6ec99` (2018-06-29, "immediate block
generation / empty blocks only after maxidleblockinterval") sealed as soon as
the pool drained. The fixed cadence replaced that deliberately.

This restores the confirmation half of that behaviour **behind one flag that
defaults to off**, so a private network can have the old bargain without
changing anything the public networks do:

| Flag | Unit | Default | Effect |
|---|---|---|---|
| `--metadium.block.idleseal` | ms | `0` (off) | Once the block being built holds at least one transaction, seal it after this much quiet instead of holding the slot to its deadline. |

The insertion point is the wait `select` at the end of `commitTransactionsEx`,
which already resets when a transaction arrives. It gains one case, guarded by
`params.BlockIdleSealTime > 0 && env.tcount > 0`. **The `tcount` condition is
the load-bearing one**: an empty block still runs to its deadline exactly as
before, so the on-chain interval remains the chain's heartbeat and only blocks
carrying transactions close early.

`eth.New` refuses to start when the flag is set on a chain whose genesis is the
Metadium mainnet or testnet genesis, so a stray flag cannot alter block
production there. The check is keyed on the genesis hash rather than the chain
id, because a private chain may legitimately reuse a chain id but never the
public genesis.

The second commit removes `throttleMining`/`ancestorTimes` (`7ed4d8b27`,
2019-03): a hard rate cap -- 1000 blocks per 2000s, 500/500s, 100/50s, 50/10s,
sleeping for the shortfall **in whole seconds**. Its call site disappeared in
the `f113fe913` go-wemix import (2023-07), which is the same import that brought
`timeIt`; it has been uncalled in every release from `m0.10.0` to `m1.1.3`,
including `0cd7607a` which both public chains run today. It is removed rather
than left inert because this flag turns it from clutter into a trap: at the
692ms/block measured here, the 1000-block rule alone sleeps `2000-692 = 1308s`,
stopping block production for **~22 minutes**. `timeIt` stays -- correcting a
chain that runs *late* was never the removed function's job.

Setup recipe, measurements and the trade-offs are in
`docs/enterprise-block-timing.md`. Note for anyone configuring this: the block
interval is on-chain (`EnvStorage.getBlockCreationTime`, ms), and
`--metadium.block.interval` is a dead flag -- it is stored in
`params.BlockInterval` and never read.

### Scope note (branch rewritten 2026-09-08)

An earlier version of this branch carried a second flag,
`--metadium.block.emptyinterval`, which skipped the round entirely while the
pool was empty. **It has been dropped from this PR.** It is not needed for the
latency this PR is about, it reached further into `commitWork` and the mining
token, and it is the part whose interactions turned up surprises. The work is
preserved on `jsong1230:bak/enterprise-emptyinterval-20260908` (tip
`53d91c570`, measurements and rejected-design notes intact) and will be
proposed separately if it is wanted. The branch was also rebased onto the
current `dev` tip in the process.

## Compatibility tier

- [x] **C7 — internal only.** Producer-side behaviour that does not change block
      validity.

**Why this tier:** no validation rule is touched. Block spacing is not checked by
`verifyHeader` (the `header.Time <= parent.Time` rejection is guarded by
`metaminer.IsPoW()`), producer rotation is height-based
(`admin.go`: `ix := int(height/blocksPer) % len(nodes)`), and rewards are per
block. A node running this flag produces blocks that a node on the current
release accepts unchanged, and the flag changes nothing about validation, so a
mixed fleet stays in agreement. On mainnet and testnet the flag cannot be set at
all (the node exits), and with it unset the sealer runs the same code as before:
the quiet timer is never created and the `select` waits on a nil channel, which
never fires.

## Rollout

- [x] **Testnet BPs first, then verify the rest of the testnet on the old build.**
      Not because the change alters block production -- it cannot, with the flag
      off -- but because the new code sits in the sealer loop that mainnet BPs run
      every block. Treat it as a normal release gate rather than ticking the C7
      "nothing deploys" box.
- [ ] Remaining testnet nodes upgraded and soaked
- [ ] Mainnet BPs rolled one at a time (PoA: never stop two at once, never `kill -9`)
- [ ] C1 only — not applicable
- [ ] C0 only — not applicable

## Verification

3-node PoA private network (`tests/private-net-poa`, LevelDB, all three sealing),
governance `blockCreationTime = 5000`. "Confirm" is wall clock from
`eth_sendTransaction` returning to the receipt being available.

| Configuration | Idle cadence | Confirm (single tx) | 40-tx burst |
|---|---|---|---|
| flag off | empty block every 4.3-5.8s | avg **3357ms** (min 2631, max 5637) | 1 block, 5662ms |
| `idleseal=100` | empty block every 4.31s | **avg 121ms** (min 117, max 128) | 1 block, **179ms** |

10-minute soak, `idleseal=100`, one transaction every 3s: **193 transactions,
193 blocks**, min 107 / p50 117 / p90 127 / p99 129 / **max 130ms**, nothing
above 500ms. With traffic that steady every slot closes on a transaction, so no
empty blocks appear at all.

Three nodes stayed in lockstep at the same head throughout, 61 consecutive
blocks had no parent-hash break, and the three sealers logged no `BAD BLOCK`,
no panic and no seal failure.

**Every number above was measured on this head**, not carried over from the
pre-rewrite branch: the image was rebuilt from `335bd892` (md5
`033d09b0f0114ad58db4925a7f6a2792`, `gmet version` reports the commit) and the
three sealers were rolled onto it one at a time, `docker stop -t 120` before
each. The flag-off row is the same binary with the flag omitted, and the flag
was put back afterwards -- confirmation returned to avg 107ms.

One honest note on that flag-off row: an earlier run of it gave avg 2544ms
where this one gives 3357ms. Both are the same thing -- a transaction waiting
out the remainder of its slot -- and where in the slot the sample lands depends
on the phase between the 6s send interval and the 4.3/5.8s deadline. Read the
row as a distribution (2.6-5.6s here), not as a constant.

**The end-to-end suites were run with the flag on**, which had not been done
before -- the earlier runs all predate the flag:

| Suite | Result |
|---|---|
| `blob-tx-e2e` | ALL PASS — type `0x3` mined, sidecar retrievable after mining |
| `mixed-tx-e2e` | ALL PASS — plain + fee-delegation + blob in one run |
| `scripts/rpc-test-full.sh` | 63 PASS / **0 FAIL** / 1 WARN / 3 SKIP (67 total) |
| `camellia-test.sh` | 13 PASS / 1 FAIL / 3 SKIP |

The blob suites matter here specifically: blob transactions are filled after
the plain ones, so an early seal firing between the two phases would show up as
a missing or partial blob block. It does not.

**The one FAIL is a harness defect, and it is not this change.** `camellia-test.sh`
I-05 (EIP-3651 warm `COINBASE`) hardcodes `from = 0x7099...` on the assumption
that node1 is the only sealer, then compares gas at block 99 against block 100.
On this 3-sealer chain block 99 happens to have been sealed by `0x7099...`, so
`from == coinbase` and EIP-2929 pre-warms the account regardless of the fork.
Re-probing with a `from` that is not that block's miner:

```
from = 0x3C44...    block 98 -> 106   (warm: 0x3C44 sealed that block)
                    block 99 -> 2606  (cold, pre-fork, correct)
                    block 100 -> 106  (warm, post-fork, correct)
```

So EIP-3651 activates exactly at `camelliaBlock = 100`; the test is unreliable
on any chain with rotating sealers, depending on parity. Same family as #100,
and worth its own issue. The 3 SKIPs are `eth-account` not installed (I-08/I-09,
I-14) and governance contracts not present in the private-net genesis (I-10).

**A stock `m1.1.3` node imports the chain this flag produces.** Until now the C7
claim -- a mixed fleet stays in agreement -- rested on reading the code. The
official release binary (`0cd7607a7`, `metadium-1.1.3-linux-leveldb.tar.gz`,
md5 `76e6cfe29321a4361b96bbc19cfd7c0a`), which is the build both public networks
run today, was pointed at this network with a fresh datadir and the same
genesis: **9,887 blocks imported by full sync, 0 `BAD BLOCK`, 0 panics, no
rejected headers**. It was then left running through the soak and tracked the
chain live, sitting at 10087 against the sealers' 10088 -- one block behind,
which is just the newest block.

**The genesis guard was exercised on this head, not just written.** Mutation test:
with `publicMetadiumNetwork`'s default branch changed to report every genesis as
public, a private chain plus `--metadium.block.idleseal 100` exits `1` with
`Fatal: Failed to register the Ethereum service: --metadium.block.idleseal is for
private networks only, but this node is on the Metadium mainnet`, while the same
mutant with the flag unset starts normally -- so both halves of the condition are
load-bearing. Unmutated, the private chain starts with the flag set.
`TestPublicMetadiumNetwork` pins the hash-to-name mapping so the constants cannot
drift.

- [x] Affected packages pass (`./miner/...`, `./eth`, `./params`, `./cmd/utils`), `gofmt` and `go vet` clean
- [x] Both engines build (`CGO_ENABLED=0`, and `-tags rocksdb` with the RocksDB link flags)
- [x] SPoA private network run on this exact binary — mining is touched; the tables above are that run
- [x] A node on the current release (`m1.1.3`) syncs and follows the resulting chain
- [ ] Clean sync over the affected range — not applicable, the change applies to
      production only and adds no rule that history must satisfy

### Gaps, stated rather than left implicit

What this testing does not cover, in case it matters to a deployment decision
later: the sealers share one host, so there is no propagation delay between
them; the chain is LevelDB (the RocksDB build compiles and is verified, but no
chain was run on it with the flag); and the longest run is the 10-minute soak,
so there is no figure for disk growth or state growth at a sustained high block
rate.

### Also here

`tests/private-net-poa/deploy.sh` now takes `BLOCK_CREATION_TIME`, so the harness
can raise a 5s-interval chain without editing the script.

### Open questions for review

1. **The guard is a hard refusal.** A stray flag on mainnet stops the node from
   starting. The alternative is a warning plus ignoring the flag. Refusing seemed
   right for something that changes block production, but it is a judgement call.
2. A private chain that clones the public genesis outright cannot use this flag.
   Documented; assumed to be a configuration nobody wants.
3. **No floor on block rate.** Traffic arriving just slower than `idleseal` gives
   every transaction its own block. Nothing pathological appeared in testing, but
   if a deployment needs a floor the shape to add is a bounded minimum spacing
   since the parent -- say `--metadium.block.minspacing <ms>`. Left out for now.
