### PR TITLE
docs: state how many approvals a pull request needs

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -19,6 +19,44 @@ every rule below:
 
 Pull requests target `dev`. `master` is the release line.
 
+## Approvals required
+
+**Every pull request is sent to both reviewers.** What differs is how many
+approvals it waits for before merging.
+
+| Change | Approvals to merge |
+|---|---|
+| **C0–C3** — consensus (either direction), P2P wire, or database format | **2** |
+| Everything else | **1** |
+
+The dividing line is the class of failure, not the diff size and not whether
+code changed. C0–C3 are the tiers whose failure mode is a chain that splits, a
+peer set that cannot talk, or a rollback path that no longer exists — none of
+which a single reviewer should be the only one to have looked at, and none of
+which a revert fixes once a node has acted on it. Everything else fails in ways
+that are visible and recoverable: a wrong latency, a broken build, a bad doc.
+
+Two consequences worth stating, because they are the point of the split rather
+than an oversight:
+
+- **Producer-side timing and behaviour merge on one approval.** A change in the
+  sealer loop that does not alter block validity — the private-PoA idle seal is
+  the example — is a one-approval change. It runs on every block a producer
+  makes, so the single review carries weight; that is a deliberate trade for
+  not blocking on a second reader.
+- **A release cut is a one-approval change.** The version bump itself is
+  trivial; what protects a release is the runbook and its gates, not the count
+  of approvals on the PR.
+
+Two things the relaxed rule does not relax:
+
+- **Read the reviewers individually.** `reviewDecision: APPROVED` is an
+  aggregate — it can be reported for a stale commit, and it says nothing about
+  a blocking comment left outside a formal review. Check each reviewer's latest
+  state, and check that the approval names the current head.
+- **An approval belongs to the commit it was given on.** If commits land after
+  it, the approval no longer covers the branch and the count restarts.
+
 ## 1. Verify the declared compatibility tier
 
 This is the highest-value thing a review can do here. The author picks one of


### PR DESCRIPTION
## What this changes

`REVIEW.md` (#115) says what a reviewer should check but never says when a
branch is ready to merge, so the answer has lived in habit: two approvals,
always. That is the right bar for a change that can split the chain and too
slow for everything else — #115 itself waited days on it.

This adds an **Approvals required** section that splits on the class of
failure:

| Change | Approvals to merge |
|---|---|
| **C0–C3** — consensus (either direction), P2P wire, database format | **2** |
| Everything else | **1** |

Both reviewers are still asked to review either way; only the wait changes.

**Why the class of failure and not the diff.** C0–C3 fail as a chain that
splits, a peer set that cannot negotiate, or a rollback path that no longer
exists, and a revert does not undo any of them once a node has acted on the
change. Everything else fails visibly and recoverably: a wrong latency, a
broken build, a bad document. Diff size is a poor proxy in either direction —
the smallest diffs in this repository have been the consensus ones.

Two consequences are deliberate, so the section states them rather than
leaving them to be discovered:

- **Producer-side sealer behaviour is a one-approval change** when it does not
  touch block validity — #116 is the current example. It runs on every block a
  producer makes, so the single review carries weight. That is the trade being
  made, not an oversight.
- **A release cut is a one-approval change.** What protects a release is the
  runbook and its gates, not the number of approvals on a version bump.

The section also carries over two failure modes this repository has actually
hit, because they survive the relaxation and get easier to trip when one
approval is enough:

- `reviewDecision: APPROVED` is an aggregate. It can be reported for a stale
  commit, and it says nothing about a blocking comment left outside a formal
  review. On 2026-08-31, three pull requests were merged on that field alone,
  one of which had an unaddressed conditional comment.
- An approval belongs to the commit it was given on. #116 showed `APPROVED`
  for a commit that a force-push had removed from the branch, and needed a
  re-review at the new head.

## Compatibility tier

- [x] **C7 — internal only.** Documentation; no code, no build input.

**Why this tier:** the only file touched is `REVIEW.md`. Nothing is compiled,
linked, or shipped, and no node behaviour changes.

## Rollout

- [x] Not applicable — nothing deploys (C7)

## Verification

Documentation only. Each factual claim in the new section is checkable in this
repository's history:

- `REVIEW.md` on `dev` (merge `304c4c98`) contains no statement about approval
  count — the gap this fills.
- The 2026-08-31 aggregate-field merges: #99, #101, #98, with the follow-up
  apology and post-hoc review requests on each.
- #116's stale approval: `trident90` APPROVED at `1c98a792` while the branch
  head was `335bd892`, re-approved at the head afterwards.

## Note on precedent

#115 was merged on a single approval before this rule was written down, as its
first application. Flagging that explicitly rather than leaving it to be found
in the history.

Under the rule as written, this pull request is itself a one-approval change.
