### PR TITLE
build: builder image hygiene (gcc 9, apt layers, build context, -j)

### DIFF
--- a/Dockerfile.metadium
+++ b/Dockerfile.metadium
@@ -19,9 +19,11 @@ FROM ubuntu:focal@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2faf
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update -q -y && apt-get upgrade -q -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata software-properties-common
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update -q -y
+RUN apt-get update -q -y && apt-get upgrade -q -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -q -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 # The compiler is pinned too. It comes from a community PPA that keeps only its
 # newest build, so an unpinned install means release binaries can come from a
 # compiler revision nobody tested, with nothing to detect it. The tradeoff is
@@ -30,9 +32,17 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update -q -y
 # here and rebuild.
 ARG GCC_VERSION=11.5.0-10ubuntu1~20~ppa3
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential gcc-11=${GCC_VERSION} g++-11=${GCC_VERSION} \
-        ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git
+# Deliberately not build-essential: it pulls in focal's gcc 9 next to the gcc 11
+# this image is for -- 150-200MB of dead weight, and it leaves the compiler that
+# *cannot* build the vendored RocksDB (no C++20 `using enum`) as the default cc
+# for anything that ignores $CC. make and libc6-dev are what the build actually
+# needs from it; g++-11 brings libstdc++-11-dev, which carries the static
+# archive STATIC_STDCPP links against.
+RUN apt-get update -q -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make libc6-dev gcc-11=${GCC_VERSION} g++-11=${GCC_VERSION} \
+        ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV CC=gcc-11
 ENV CXX=g++-11
@@ -57,7 +67,10 @@ RUN curl -sL -o /tmp/go.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-am
     ln -sf /usr/local/go/bin/* /usr/local/bin/ && \
     rm /tmp/go.tar.gz
 
-RUN apt autoremove && apt autoclean
+# No autoremove/autoclean layer here: it cannot shrink the image (earlier layers
+# are immutable) and, without -y, it would abort the build the first time it
+# found something to remove. The apt lists are dropped in the layers that
+# populate them instead.
 
 ENTRYPOINT ["/bin/bash", "-c"]
 

--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,13 @@ gmet-linux:
 		     "update both, with the matching GO_SHA256" >&2;	\
 		exit 1;							\
 	fi
-	docker build -t meta/builder:local -f Dockerfile.metadium		\
-		--build-arg GO_VERSION=$(GO_VERSION) .
+	@# Built from stdin, with no build context at all. The Dockerfile has no
+	@# COPY, so every build used to stream the whole working tree -- .git alone
+	@# is ~260MB, and rocksdb after a submodule checkout is larger. Doing it
+	@# here rather than in .dockerignore keeps the context rules for the other
+	@# images (which do COPY the tree) untouched.
+	docker build -t meta/builder:local					\
+		--build-arg GO_VERSION=$(GO_VERSION) - < Dockerfile.metadium
 	docker run -e HOME=/tmp --rm -v $(shell pwd):/data		\
 		-u $(shell id -u):$(shell id -g)			\
 		-w /data meta/builder:local				\
@@ -250,9 +255,16 @@ release-check:
 ifneq ($(USE_ROCKSDB), YES)
 rocksdb:
 else
+# -j comes from the host rather than a fixed 8: a fixed 8 under-uses a large
+# build host and oversubscribes a small one. getconf rather than nproc so this
+# still works on a developer's macOS box.
+#
+# Keep this comment out of the recipe: the first recipe line ends in a
+# continuation, so a `@#` line placed after it lands inside that same shell
+# command and the shell tries to execute `@#` (exit 127).
 rocksdb:
 	@[ ! -e rocksdb/.git ] && git submodule update --init rocksdb;	\
-	cd $(ROCKSDB_DIR) && PORTABLE=1 make -j8 static_lib;
+	cd $(ROCKSDB_DIR) && PORTABLE=1 make -j$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8) static_lib;
 endif
 
 AWK_CODE='								     \


### PR DESCRIPTION
## What this changes

Five items from the #83 review of the release builder image, all in
`Dockerfile.metadium` and the `gmet-linux` path. Closes #86.

- **`build-essential` is gone.** It pulled in focal's gcc 9 next to the gcc 11
  this image exists for: 150-200MB of packages the build does not use, and — the
  part that matters — it left the compiler that **cannot** build the vendored
  RocksDB (focal's gcc 9 has no C++20 `using enum`) installed as the default
  `cc` for anything that ignores `$CC`. Replaced with `make` and `libc6-dev`,
  which is what the build actually needed from it; `g++-11` already brings
  `libstdc++-11-dev` and the static archive `STATIC_STDCPP` links against.
- **The `apt autoremove && apt autoclean` layer is dropped.** It could not shrink
  anything — earlier layers are immutable — and it had no `-y`, so the first time
  it found something to remove it would have aborted the release build. The apt
  lists are now removed in the layers that populate them, which does shrink the
  image.
- **The build no longer streams the working tree as context.**
  `Dockerfile.metadium` has no `COPY` at all, so the context was pure waste:
  `.git` alone is ~260MB and `rocksdb` after a submodule checkout is larger.
  `make gmet-linux` now builds from stdin with no context. Doing it there rather
  than in `.dockerignore` leaves the context rules alone for the other images,
  which do `COPY` the tree.
- **RocksDB's `-j` comes from the host** instead of a hardcoded `-j8`, which
  under-used a large build host and oversubscribed a small one. `getconf` rather
  than `nproc` so a developer's macOS box still works.

The image goes from 1.39GB to 1.21GB.

**One defect in this change was found and fixed during re-verification** — worth
reading before the rest, because it is the reason this PR was re-verified rather
than carried over. The `-j` comment had been placed after a recipe line ending
in a continuation, so the shell received
`[ ! -e rocksdb/.git ] && ... ; @# -j from the host ...` and tried to execute
`@#`: `make rocksdb` died with exit 127 and took the RocksDB path of
`make gmet-linux` with it. The comment now sits above the target with a note
saying why it cannot live inside the recipe.

Why it survived the first pass: the earlier verification checked the image's
*contents* (packages, compiler, glibc) and never ran a RocksDB build, and CI does
not build RocksDB either. In a diff it reads as an added comment.

## Compatibility tier

- [x] **C6 — build or OS baseline.** The release build environment changes.

**Why this tier:** no toolchain version moves here — Go stays 1.22.5, the base
stays the pinned focal digest, gcc stays the pinned 11.5.0, and the glibc floor
and `release-check` are untouched — so by the reasoning applied to #117 this
could be argued down to C7. Graded C6 anyway because the *package set* of the
release image changes, which is a wider surface than a pin, and the artifact is
produced by that image. Please re-derive; the approval count is the same either
way under `REVIEW.md`'s new section (C0–C3 need two).

Nothing in the node changes: no Go file is touched, and the resulting `gmet` has
the same `NEEDED` list and a lower glibc requirement than the ceiling.

## Rollout

- [x] Not applicable — nothing deploys. This changes how release artifacts are
      built, not what runs on a node. The next release cut is built by this
      image; that release rolls out under its own runbook.

## Verification

Re-run from scratch on the current `dev`, because #117 (toolchain pins) landed in
the same Dockerfile and the combination is new. The full release path was
exercised this time, not just the image:

**In the rebuilt image**

| Check | Result |
|---|---|
| Image size | **1.21GB** (was 1.39GB) |
| gcc-9 packages | **0**; no `cc`/`gcc`/`g++` on `PATH`; only `gcc-11`/`g++-11` |
| C++20 `using enum` under `g++-11 -std=c++20` | compiles and runs |
| `libstdc++.a` | present (6.2MB, `/usr/lib/gcc/x86_64-linux-gnu/11/`) |
| `-static-libstdc++` link | **0 GLIBCXX symbols** in the result |
| glibc | **2.31** |

**Through the real build** — this is the part the earlier pass did not do, and
the part that matters for dropping `build-essential`:

- `librocksdb.a` builds inside the trimmed image: `g++-11`, `-std=c++20`,
  `-j12` (the `getconf` expansion picking up this host's core count, replacing
  the hardcoded 8).
- `gmet` links against it, and `make release-check` reports:

  ```
  ./build/bin/gmet: GLIBC=2.30 GLIBCXX=none CXXABI=none
    NEEDED libm.so.6 libpthread.so.0 libdl.so.2 libsnappy.so.1 liblz4.so.1
           libjemalloc.so.2 libresolv.so.2 libc.so.6 ld-linux-x86-64.so.2
  ./build/bin/logrot: no dynamic symbol table (statically linked)
  release-check: OK (2 binaries, ceiling GLIBC_2.31)
  ```

  GLIBC 2.30 against a 2.31 ceiling, no GLIBCXX requirement, and the same
  `NEEDED` set as before — so the trimmed package set changes neither the
  build's ability to produce the artifact nor what the artifact needs at runtime.

- [x] Both engines: this is the RocksDB path end to end; `USE_ROCKSDB=NO` is
      unaffected (the `rocksdb` target is empty there)
- [x] `make release-check` OK
- [ ] Unit tests / clean sync — not applicable, no Go code is touched

### One thing worth knowing, not fixed here

`make gmet-linux` does not clean `build/bin` first. On this machine the
directory still held host-built binaries from a previous session (2026-09-04),
and `release-check` — which covers every ELF in `build/bin` — failed on those
with `needs GLIBC_2.34 > 2.31` and `GLIBC_2.38` while the freshly built `gmet`
was clean. That is the check doing its job, but the failure names the wrong
culprit, and a stale artifact sitting in `build/bin` is also a candidate for
being packaged. Left out of this PR to keep it to the #86 items; happy to fix it
here instead if you would rather it not wait.
