### PR TITLE
miner: start a round when a transaction arrives, not on the next tick

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -572,6 +572,22 @@ func (w *worker) newWorkLoopEx(recommit time.Duration) {
 	timer := time.NewTimer(10 * time.Millisecond)
 	defer timer.Stop()
 
+	// Metadium private PoA: when a round is in flight, a transaction arriving
+	// mid-round is picked up by the wait select in commitTransactionsEx. When
+	// no round is in flight, the 1s timer below is the only thing that notices,
+	// so a transaction can sit for most of a second before a round even starts
+	// to build it -- which is the whole latency BlockIdleSealTime is there to
+	// remove. Wake on arrival instead. commitSimple's busyMining CAS makes this
+	// a no-op while a round is already running. Left unsubscribed (a nil
+	// channel never selects) when idle sealing is off, so the public networks
+	// keep starting rounds exactly as before.
+	var txCh chan core.NewTxsEvent
+	if params.BlockIdleSealTime > 0 {
+		txCh = make(chan core.NewTxsEvent, 64)
+		sub := w.pool.SubscribeTransactions(txCh, true)
+		defer sub.Unsubscribe()
+	}
+
 	// commitSimple just starts a new commitNewWork
 	commitSimple := func() {
 		if atomic.CompareAndSwapInt32(&w.busyMining, 0, 1) {
@@ -600,6 +616,17 @@ func (w *worker) newWorkLoopEx(recommit time.Duration) {
 
 		case head := <-w.chainHeadCh:
 			clearPending(head.Block.NumberU64())
+			commitSimple()
+
+		case <-txCh:
+			// Collapse a burst into the one round that will pick all of it up.
+			for drained := false; !drained; {
+				select {
+				case <-txCh:
+				default:
+					drained = true
+				}
+			}
 			commitSimple()
 
 		case <-timer.C:


### PR DESCRIPTION
## What this changes

`newWorkLoopEx` starts a round on `startCh`, on `chainHeadCh`, or on a
**1-second timer**. A transaction that arrives while a round is already in
flight is picked up by the wait `select` in `commitTransactionsEx`, so that case
is covered. The uncovered one is the other: **no round in flight, where the
1-second tick is the only thing that notices the arrival.** The transaction then
waits up to most of a second before a round even begins to build it — which is
exactly the latency `--metadium.block.idleseal` exists to remove.

This subscribes to the pool and starts a round on arrival:

```go
case <-txCh:
    // Collapse a burst into the one round that will pick all of it up.
    for drained := false; !drained; { ... }
    commitSimple()
```

`commitSimple`'s `busyMining` CAS makes it a **no-op while a round is already
running**, so the only behaviour added is the round that would otherwise have
waited for the tick.

**Gated on `params.BlockIdleSealTime > 0`.** With idle sealing off the channel
stays nil and never selects, so the public networks start rounds exactly as
before. That preserves the invariant #116 rests on — flags off means the sealer
runs the same code — rather than changing when mainnet begins building blocks.

### Where this came from

The delay sweep done for #119 turned up outliers (1.9s, 1.5s) that did not fit
the propagation-cost model, and the code explains them: with `emptyinterval`
dropped from #116, the tx-arrival wake-up went with it, since at the time it
existed only to serve the round-skipping path. It turns out to matter on its
own.

## Compatibility tier

- [x] **C7 — internal only.** Producer-side behaviour, reachable only with
      `--metadium.block.idleseal` set, which the public networks refuse.

**Why this tier:** no validation rule is touched; this changes *when a producer
starts building*, not what is accepted. With the flag unset the subscription is
not opened and the `select` case cannot fire, so a node on the public networks
is byte-for-byte the same behaviour as `dev` today.

Per `REVIEW.md`'s new approvals section this is a one-approval change — and it
is precisely the case that section calls out as a deliberate trade: producer-side
sealer code, running on every block a producer makes. Flagging that rather than
letting the count pass unnoticed.

## Rollout

- [x] Not applicable — nothing deploys. The flag is private-network only and
      defaults off; this reaches a public node only when a release carrying it is
      deployed, under that release's own runbook.

## Verification

3-node harness (`blockCreationTime 5000`, `idleseal 100`), `tc netem` injecting
one-way delay toward two of the three sealers, **40 transactions per cell**,
A/B against the merged `dev` build.

**Read per sealing node, not pooled.** At high delay the pooled distribution is
a mixture of a fast mode (the undelayed node sealed it) and a slow one (a
delayed node did), and the sample split between them moves between runs — 13/27
in one cell against 16/24 in its pair. That makes the pooled median unstable:
it reads 922 ms for this build against 552 ms for the baseline at 200 ms delay
purely because the baseline run happened to draw more fast-mode samples. Per
subset the direction is consistent:

| | this build | `dev` |
|---|---|---|
| **120 ms delay, sealed locally** — p50 / max | 293 / **303** | 355 / **793** |
| **200 ms delay, sealed locally** — p50 / max | 521 / **523** | 521 / **1150** |
| 120 ms delay, sealed remotely — p50 / max | 603 / 1153 | 656 / 1277 |
| 200 ms delay, sealed remotely — p50 / max | **925** / 1947 | 1130 / 2640 |

**The locally-sealed rows are the evidence.** No propagation delay is involved
in them — the transaction is submitted to the node that seals it — and yet the
baseline still produced 793 ms and 1150 ms confirmations while this build's
worst cases were 303 ms and 523 ms. Those were transactions waiting for the
tick, and they are gone.

Confirmations over a threshold, out of 40:

| | over 1 s | over 1.5 s |
|---|---|---|
| 120 ms delay — this build / `dev` | 2 / 3 | 0 / 0 |
| 200 ms delay — this build / `dev` | **7 / 18** | **2 / 8** |

With no delay injected nothing changes: p50 117 ms on both, max 133 ms here
against 438 ms on `dev` (a single outlier of the same tick-wait shape).

- [x] `gofmt`, `go vet ./miner` clean; `./miner/...` passes
- [x] `CGO_ENABLED=0` build OK
- [x] Harness run on this exact code — the binary measured was built from the
      same `miner/worker.go`; `git diff` between the measured base
      (`6be7b0ead`) and the rebase target (`d976969e2`) touches **no `.go`
      file**, only CI, build and documentation
- [x] Zero `BAD BLOCK` and head spread ≤ 1 block across all six cells
- [ ] Clean sync — not applicable, production-side only, adds no rule history
      must satisfy

### Correction to an earlier claim of mine

On #119 I described these outliers as consistent with the 1-second tick and then,
on a 10-sample A/B, reported that the tail improvement had disappeared at 200 ms.
Both readings were drawn from too few samples: 10 per cell cannot resolve a tail.
At 40 the tail improvement is clear, and the pooled-median inversion that made me
doubt it is a mixture artifact, not a regression.
