### PR TITLE
docs: record what the release build's shape commits us to

### DIFF
--- a/Dockerfile.metadium
+++ b/Dockerfile.metadium
@@ -19,9 +19,11 @@ FROM ubuntu:focal@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2faf
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update -q -y && apt-get upgrade -q -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata software-properties-common
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update -q -y
+RUN apt-get update -q -y && apt-get upgrade -q -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -q -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 # The compiler is pinned too. It comes from a community PPA that keeps only its
 # newest build, so an unpinned install means release binaries can come from a
 # compiler revision nobody tested, with nothing to detect it. The tradeoff is
@@ -30,9 +32,17 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update -q -y
 # here and rebuild.
 ARG GCC_VERSION=11.5.0-10ubuntu1~20~ppa3
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential gcc-11=${GCC_VERSION} g++-11=${GCC_VERSION} \
-        ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git
+# Deliberately not build-essential: it pulls in focal's gcc 9 next to the gcc 11
+# this image is for -- 150-200MB of dead weight, and it leaves the compiler that
+# *cannot* build the vendored RocksDB (no C++20 `using enum`) as the default cc
+# for anything that ignores $CC. make and libc6-dev are what the build actually
+# needs from it; g++-11 brings libstdc++-11-dev, which carries the static
+# archive STATIC_STDCPP links against.
+RUN apt-get update -q -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make libc6-dev gcc-11=${GCC_VERSION} g++-11=${GCC_VERSION} \
+        ca-certificates curl libjemalloc-dev liblz4-dev libsnappy-dev libzstd-dev libudev-dev git && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV CC=gcc-11
 ENV CXX=g++-11
@@ -57,7 +67,10 @@ RUN curl -sL -o /tmp/go.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-am
     ln -sf /usr/local/go/bin/* /usr/local/bin/ && \
     rm /tmp/go.tar.gz
 
-RUN apt autoremove && apt autoclean
+# No autoremove/autoclean layer here: it cannot shrink the image (earlier layers
+# are immutable) and, without -y, it would abort the build the first time it
+# found something to remove. The apt lists are dropped in the layers that
+# populate them instead.
 
 ENTRYPOINT ["/bin/bash", "-c"]
 

--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,13 @@ gmet-linux:
 		     "update both, with the matching GO_SHA256" >&2;	\
 		exit 1;							\
 	fi
-	docker build -t meta/builder:local -f Dockerfile.metadium		\
-		--build-arg GO_VERSION=$(GO_VERSION) .
+	@# Built from stdin, with no build context at all. The Dockerfile has no
+	@# COPY, so every build used to stream the whole working tree -- .git alone
+	@# is ~260MB, and rocksdb after a submodule checkout is larger. Doing it
+	@# here rather than in .dockerignore keeps the context rules for the other
+	@# images (which do COPY the tree) untouched.
+	docker build -t meta/builder:local					\
+		--build-arg GO_VERSION=$(GO_VERSION) - < Dockerfile.metadium
 	docker run -e HOME=/tmp --rm -v $(shell pwd):/data		\
 		-u $(shell id -u):$(shell id -g)			\
 		-w /data meta/builder:local				\
@@ -250,9 +255,16 @@ release-check:
 ifneq ($(USE_ROCKSDB), YES)
 rocksdb:
 else
+# -j comes from the host rather than a fixed 8: a fixed 8 under-uses a large
+# build host and oversubscribes a small one. getconf rather than nproc so this
+# still works on a developer's macOS box.
+#
+# Keep this comment out of the recipe: the first recipe line ends in a
+# continuation, so a `@#` line placed after it lands inside that same shell
+# command and the shell tries to execute `@#` (exit 127).
 rocksdb:
 	@[ ! -e rocksdb/.git ] && git submodule update --init rocksdb;	\
-	cd $(ROCKSDB_DIR) && PORTABLE=1 make -j8 static_lib;
+	cd $(ROCKSDB_DIR) && PORTABLE=1 make -j$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8) static_lib;
 endif
 
 AWK_CODE='								     \

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ libraries (snappy, lz4, zstd, jemalloc) must exist on the target host; the
 symbol-version checks passing does not by itself make an artifact runnable on a
 freshly installed machine.
 
+Two consequences of building this way are standing rules rather than build steps,
+and they live in
+[docs/release-build-toolchain.md](docs/release-build-toolchain.md): a toolchain
+CVE means a rebuild and a re-release, because the statically linked libstdc++ is
+no longer reachable by a distro update, and the move off the 20.04 base is gated
+on the fleet, with `MAX_GLIBC` as the last step rather than the first.
+
 Direct `go build` works for development — **these produce non-portable binaries
 and must not be published** (`./cmd/gmet` and `./cmd/geth` are the same
 entrypoint; the Makefile uses `./cmd/gmet`):

--- a/docs/release-build-toolchain.md
+++ b/docs/release-build-toolchain.md
@@ -1,0 +1,98 @@
+# Release Build Toolchain — Standing Rules and Known Limits
+
+Status: reference, 2026-08-13; versions and in-tree anchors re-checked
+2026-09-09. Companion to the README's "Release artifacts" section, which covers
+how to build them. This covers what follows from how they are built. Every
+version below was read out of the image or the archive rather than taken from
+memory; the commands are included so the next reader can re-check instead of
+trusting the date on this file.
+
+## 1. Static libstdc++ means security fixes arrive by rebuild, not by upgrade
+
+Release artifacts are linked with `STATIC_STDCPP=YES`, which resolves to
+`-l:libstdc++.a -static-libgcc` (`Makefile`, `STDCPP_LDFLAGS`). That is what lets
+a binary built on Ubuntu 20.04 run on every newer release: it carries no
+`GLIBCXX` or `CXXABI` version requirement at all, which `make release-check`
+enforces.
+
+The consequence is that the distribution's update channel no longer reaches that
+code. A libstdc++ or libgcc fix on a node does nothing for `gmet`, because the
+copy `gmet` uses is inside the binary.
+
+**The rule: a toolchain CVE is a rebuild and a re-release, not a distro
+package update.** Nothing in the fleet will report the old code as present, and
+no node-side upgrade will remove it.
+
+What is *not* static, and therefore is still the distribution's job on each
+node: glibc, and for RocksDB artifacts snappy, lz4, zstd, jemalloc and libudev.
+`make release-check` prints each artifact's `NEEDED` list for exactly this
+reason — those libraries must exist on the target host and their updates do
+apply normally.
+
+## 2. The image is one dependency bump away from a confusing failure
+
+The builder image is Ubuntu 20.04 (focal), whose zstd is **1.4.4**:
+
+```console
+$ docker run --rm ubuntu:focal bash -c 'apt-get update -qq; apt-cache policy libzstd-dev'
+  Candidate: 1.4.4+dfsg-3ubuntu0.1
+```
+
+The vendored RocksDB (submodule `5fbc1cd5bcf63782675168b98e114151490de6d9`) gates
+part of its dictionary-compression support on a newer zstd —
+`util/compression.h`:
+
+```c
+// ZDICT_finalizeDictionary API is exported and stable since v1.4.5
+#if ZSTD_VERSION_NUMBER >= 10405
+```
+
+So on focal that code compiles out. Today that costs nothing, because this node
+never selects a RocksDB compression type: the options it builds set only
+`create_if_missing` and `max_open_files` (`ethdb/rocksdb/rocksdb.go`), leaving
+RocksDB's own default, and dictionary compression is not in play.
+
+What to expect if that changes: **a RocksDB bump that raises the zstd floor to
+1.4.5 breaks the release image, and the error will look like a compiler
+problem** — a missing symbol or a failed feature test, in C++ output, several
+hundred lines into a RocksDB build. It is a base-image problem. Check the
+distribution's zstd before reading the compiler output.
+
+## 3. The base is past standard support, and jammy is the exit
+
+focal left standard support on **31 May 2025**; Expanded Security Maintenance
+began 29 May 2025 and runs to May 2030. ESM requires an attached Ubuntu Pro
+subscription, and the public `ubuntu:focal` image this build pulls does not have
+one — so the `apt-get update && apt-get upgrade` in the first layer no longer
+picks up new security fixes for most packages. It is still the right base today
+for one reason only: it is the oldest distribution in the fleet, and the
+artifacts have to run there.
+
+Ubuntu 22.04 (jammy) removes two of the three awkward things about the current
+image at once:
+
+```console
+$ docker run --rm ubuntu:jammy bash -c 'apt-get update -qq; apt-cache policy gcc libc6 libzstd-dev'
+gcc         4:11.2.0-1ubuntu1
+libc6       2.35-0ubuntu3.15
+libzstd-dev 1.4.8+dfsg-3build1
+```
+
+(The `libc6` revision moves with the archive — it read `3.14` in August and
+`3.15` in September. What matters is the `2.35` in front of it.)
+
+- gcc 11 is in the archive, so `ppa:ubuntu-toolchain-r/test` — a community PPA
+  that keeps only its newest build, and a single point of failure for the release
+  build — is no longer needed.
+- zstd is 1.4.8, above the floor in §2.
+
+The blocker is the fleet, not the build: moving the base raises the glibc floor
+from 2.31 to 2.35, and any node still on 20.04 could no longer run the
+artifacts. That is why this waits on the remaining 20.04 nodes being upgraded or
+replaced.
+
+When it happens, the number to change is `MAX_GLIBC` in the `Makefile`. It is the
+one place the ceiling is written down, and `release-check` fails a build that
+exceeds it — so the sequence is: fleet off 20.04, then base image, then
+`MAX_GLIBC`, in that order. Raising `MAX_GLIBC` first would remove the check that
+protects the nodes still running.


### PR DESCRIPTION
## What this changes

Closes #87, the last of the release-pipeline split (#84 → #86 → this).

The README says how to build release artifacts. Two consequences of building
them *that way* are standing rules rather than build steps, and they were not
written down anywhere:

1. **A toolchain CVE is a rebuild and a re-release, not a distro package
   update.** Release artifacts link libstdc++ from its archive
   (`STATIC_STDCPP=YES` → `-l:libstdc++.a -static-libgcc`), which is what lets a
   binary built on 20.04 run on everything newer with no `GLIBCXX`/`CXXABI`
   requirement. The cost is that the distribution's update channel no longer
   reaches that code: a libstdc++ fix on a node does nothing for `gmet`, and
   nothing in the fleet will report the old code as present. The document also
   records what is *not* static and therefore still each node's job — glibc,
   and for RocksDB artifacts snappy, lz4, zstd, jemalloc, libudev.

2. **The move off the 20.04 base is gated on the fleet, and `MAX_GLIBC` is the
   last step, not the first.** Moving to jammy would drop the community gcc PPA
   (a single point of failure that keeps only its newest build) and clear the
   zstd floor in §2 — but it raises the glibc floor from 2.31 to 2.35, so any
   node still on 20.04 could no longer run the artifacts. Sequence: fleet off
   20.04, then the base image, then `MAX_GLIBC`. Raising `MAX_GLIBC` first would
   remove the check that protects the nodes still running.

Plus §2, which exists to save the next person an afternoon: focal's zstd is
1.4.4, the vendored RocksDB gates dictionary compression on ≥ 1.4.5, and it
compiles out silently today because this node selects no RocksDB compression
type at all. If a RocksDB bump raises that floor, **the failure will look like a
compiler problem** — a failed feature test several hundred lines into C++ output
— when it is a base-image problem.

## Stacked on #122

Base is `dev`, so GitHub shows two commits; the new one is the last
(`95672086b`). The first is #122's commit, present because #86 has not merged
yet. Review the two-file delta — `README.md` and
`docs/release-build-toolchain.md` — or `git diff jsong1230/build/builder-image-hygiene-86...HEAD`.
Merge after #122.

## Compatibility tier

- [x] **C7 — internal only.** Documentation; no code, no build input.

**Why this tier:** the files touched are `docs/release-build-toolchain.md` (new)
and seven lines of `README.md`. Nothing is compiled, linked, or shipped.

## Rollout

- [x] Not applicable — nothing deploys (C7)

## Verification

The document's own claim is that its numbers were read out of the image and the
archive rather than remembered, so re-checking them is the verification.
Everything below was re-run on 2026-09-09, on the current `dev` (which now
carries #84's pins) with the RocksDB submodule checked out:

| Claim | Checked | Result |
|---|---|---|
| `STATIC_STDCPP=YES` → `-l:libstdc++.a -static-libgcc` | `Makefile:36` | holds |
| glibc ceiling is one written-down value | `Makefile:62` `MAX_GLIBC ?= 2.31` | holds |
| Vendored RocksDB at `5fbc1cd5b` | `git submodule status` | holds |
| RocksDB gates dictionary compression on zstd ≥ 1.4.5 | `rocksdb/util/compression.h:76` `#if ZSTD_VERSION_NUMBER >= 10405` | holds, comment quoted verbatim |
| This node sets no RocksDB compression type | `ethdb/rocksdb/rocksdb.go:76-77` — exactly `create_if_missing` and `max_open_files` | holds |
| focal `libzstd-dev` is 1.4.4 | `apt-cache policy` in `ubuntu:focal` | `1.4.4+dfsg-3ubuntu0.1` |
| jammy has gcc 11 and zstd 1.4.8 in-archive | `apt-cache policy` in `ubuntu:jammy` | `4:11.2.0-1ubuntu1`, `1.4.8+dfsg-3build1` |

**Three corrections came out of that pass**, which is the reason to re-check a
reference document rather than re-open it as written:

- **focal left standard support on 31 May 2025, not April**, and ESM began
  29 May 2025. The material part is not the date: ESM needs an attached Ubuntu
  Pro subscription, and the public `ubuntu:focal` image this build pulls does
  not have one — so the `apt-get update && apt-get upgrade` in the first layer
  no longer brings new security fixes for most packages. §3 now says that.
- jammy's `libc6` candidate moved `2.35-0ubuntu3.14` → `3.15`; the document now
  notes that the revision moves and the `2.35` is the part that matters.
- The status line carries the re-check date, so the next reader knows which
  numbers were confirmed when.

- [ ] Unit tests / builds — not applicable, no code or build input is touched
