### PR TITLE
docs: cite the measured inter-region latency the delay sweep stands on

### DIFF
--- a/docs/enterprise-private-poa.md
+++ b/docs/enterprise-private-poa.md
@@ -148,8 +148,25 @@ So:
   `idleseal` plus about 20 ms.
 
 **Agreement was unaffected throughout that sweep**: 15 configurations, up to
-200 ms one-way (a 400 ms round trip, worse than any pair of AWS regions), zero
-`BAD BLOCK`, and the three nodes were never more than one block apart.
+200 ms one-way, zero `BAD BLOCK`, and the three nodes were never more than one
+block apart.
+
+For scale, 200 ms one-way is a 400 ms round trip — more than twice the worst
+link in Metadium mainnet's own three-region sealer set. Measured between the
+production nodes on 2026-09-09, 100 TCP handshakes per pair (median round trip):
+
+| Pair | Round trip | One-way |
+|---|---|---|
+| us-west-1 ↔ ap-southeast-1 | 176 ms | ~88 ms |
+| us-west-1 ↔ ap-northeast-1 | 108 ms | ~54 ms |
+| ap-northeast-1 ↔ ap-southeast-1 | 69 ms | ~34 ms |
+| within one region | 0.2 ms | ~0.1 ms |
+
+So sealers spread as far apart as that fleet sit inside the range the sweep
+covers, with the 80 ms row as the closest reference: median 741 ms at
+`idleseal 100`, worst case 1175 ms. Treat that worst case as the ceiling rather
+than interpolating between rows — ten samples per cell cannot resolve the
+difference between the 80, 120 and 200 ms rows, which came out flat.
 
 A negative value is rejected at startup. `0` means off.
 
@@ -225,7 +242,12 @@ flag at all) against such a chain: 9,887 blocks imported, no rejected headers.
 - **Untested combinations**, stated so a rollout does not assume them: sealers
   on genuinely separate hosts (delay between sealers has been measured, but by
   injecting it with `tc netem` on one host — real links also bring jitter, loss
-  and reordering, none of which was injected), the RocksDB build with this flag
+  and reordering, none of which was injected; of those three, jitter has since
+  been measured on the production links in the table above and is small, 0.7–3.4
+  ms standard deviation per pair with p99 within 6 ms of the median, so its
+  absence is unlikely to have flattered these numbers, while loss and reordering
+  remain unmeasured — a handshake timing cannot see a retransmitted SYN, and
+  ICMP is blocked across that fleet), the RocksDB build with this flag
   (it compiles and is verified, but no chain has been run on it), and sustained
   high block rates over hours (the longest run is the 10-minute soak, so there
   is no disk or state growth figure).


### PR DESCRIPTION
## What this changes

`docs/enterprise-private-poa.md` told a reader that the `tc netem` delay sweep
ran "up to 200 ms one-way (a 400 ms round trip, worse than any pair of AWS
regions)". The parenthesis was an assertion — nobody had measured the fleet it
compares against, so a reader sizing a real deployment had no way to tell whether
the sweep covered their links or fell short of them.

It is now measured. Mainnet's own three-region sealer set was probed on
2026-09-09 and the numbers replace the claim, along with the guidance that
follows from them: which row of the sweep table to read for a cross-region
deployment, and why not to interpolate between rows.

| Pair | Round trip | One-way |
|---|---|---|
| us-west-1 ↔ ap-southeast-1 | 176 ms | ~88 ms |
| us-west-1 ↔ ap-northeast-1 | 108 ms | ~54 ms |
| ap-northeast-1 ↔ ap-southeast-1 | 69 ms | ~34 ms |
| within one region | 0.2 ms | ~0.1 ms |

The worst real link is ~88 ms one-way, so the sweep covers it with room to
spare — but the honest reading of the sweep is not an interpolation to 88 ms.
The 80, 120 and 200 ms rows came out flat (741 / 623 / 635 ms at
`idleseal 100`), which ten samples per cell cannot resolve, so the document now
says to use the 80 ms row and treat its 1175 ms worst case as a ceiling.

The same measurement narrows one of the **untested combinations** the document
lists. It warned that `netem` injected delay without jitter, loss or reordering.
Jitter is no longer unknown: 0.7–3.4 ms standard deviation per pair, p99 within
6 ms of the median, so its absence is unlikely to have flattered the sweep. Loss
and reordering stay unmeasured and the reason is now written down — the timing
came from TCP handshakes, which cannot see a retransmitted SYN, and ICMP is
blocked across that fleet, so a loss figure would have needed a security-group
change on production sealers.

## Compatibility tier

- [x] **C7 — internal only.** Documentation. One file, no code, no build input.

**Why this tier:** the only file touched is
`docs/enterprise-private-poa.md`. Nothing is compiled, linked, or shipped, and
no flag default or measured behaviour changes — the numbers being cited were
already the behaviour, they simply had not been written down.

## Rollout

- [x] Not applicable — nothing deploys (C7)

## Verification

The measurement is the verification, and it was checked rather than accepted:

- **Probed by the operator of the production fleet** (read-only: `admin.peers`
  and `admin.nodeInfo` reads plus TCP connect timing; no restarts, no config or
  security-group changes), 100 samples per pair at 0.2 s intervals, then re-run
  independently.
- **Recomputed from the raw 400-row sample here**, not taken from the summary
  table: medians 107.9 / 68.5 / 175.9 / 0.2 ms and standard deviations 0.73 /
  0.69 / 3.34 / 0.02 ms, matching the reported figures to 0.3 ms. The two
  independent runs agreed to ≤ 0.3 ms per pair.
- **Path symmetry checked** before halving round trips for the one-way column:
  108.2 ms one direction against 108.4 ms the other.
- **The measurement is of the path the nodes actually use.** Every
  `admin.peers[].network.remoteAddress` is a public address — no `10.x`/`172.x`
  — so these are not VPC-peering figures being passed off as the real links.
- **The p2p port is 8589, not 30303**, which is why an ICMP-blocked fleet needed
  the handshake method at all; the first probe at 30303 failed 30/30.

Sweep numbers quoted in the document (741 / 623 / 635 ms, 1175 ms) are from the
15-cell run already recorded there and in #119; this PR does not re-measure them.

- [ ] Unit tests / builds — not applicable, no code or build input is touched
