### PR TITLE
miner, eth, cmd: withhold empty blocks on an idle private chain

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -221,6 +221,7 @@ var (
 		utils.BlockMinBuildTxs,
 		utils.BlockTrailTime,
 		utils.BlockIdleSealTime,
+		utils.BlockEmptyInterval,
 		utils.BlobRetentionBlocks,
 	}
 )

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1028,6 +1028,11 @@ var (
 		Usage: "Private networks only: seal a non-empty block once no new transaction arrives for this many ms (0 = off, hold the full block interval)",
 		Value: params.BlockIdleSealTime,
 	}
+	BlockEmptyInterval = &cli.Int64Flag{
+		Name:  "metadium.block.emptyinterval",
+		Usage: "Private networks only: with an empty transaction pool, produce no block until this many seconds have passed since the parent (0 = off, produce empty blocks every interval)",
+		Value: params.BlockEmptyInterval,
+	}
 	BlobRetentionBlocks = &cli.Uint64Flag{
 		Name:  "blob.retention",
 		Usage: "Number of blocks to retain blob sidecars (0 = keep forever)",
@@ -2064,6 +2069,12 @@ func SetMetadiumConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		params.BlockIdleSealTime = ctx.Int64(BlockIdleSealTime.Name)
 		if params.BlockIdleSealTime < 0 {
 			Fatalf("Invalid %s: %d, must not be negative", BlockIdleSealTime.Name, params.BlockIdleSealTime)
+		}
+	}
+	if ctx.IsSet(BlockEmptyInterval.Name) {
+		params.BlockEmptyInterval = ctx.Int64(BlockEmptyInterval.Name)
+		if params.BlockEmptyInterval < 0 {
+			Fatalf("Invalid %s: %d, must not be negative", BlockEmptyInterval.Name, params.BlockEmptyInterval)
 		}
 	}
 

--- a/docs/enterprise-block-timing.md
+++ b/docs/enterprise-block-timing.md
@@ -6,17 +6,16 @@ seal on that clock whether or not anyone sent a transaction. An enterprise chain
 is typically idle most of the time and then needs a transaction *confirmed*
 quickly -- waiting out the rest of a 5 second slot is the whole latency.
 
-One node flag restores the confirmation behavior early Metadium had
-(`11be6ec99`, 2018-06-29, "immediate block generation / empty blocks only after
-maxidleblockinterval"), without changing what the public networks do.
+Two node flags restore the behavior early Metadium had (`11be6ec99`, 2018-06-29,
+"immediate block generation / empty blocks only after maxidleblockinterval"),
+without changing what the public networks do.
 
 | Flag | Unit | Default | Effect |
 |---|---|---|---|
 | `--metadium.block.idleseal` | ms | `0` (off) | Once the block being built holds at least one transaction, seal it as soon as no new transaction has arrived for this long, instead of holding the slot open to its deadline. |
+| `--metadium.block.emptyinterval` | s | `0` (off) | While the pool is empty, produce no block at all until this many seconds have passed since the parent. |
 
-It defaults to off, which is exactly the behavior of a build without it. Empty
-blocks are untouched: with an empty pool the sealer still runs the slot to its
-deadline, so the on-chain interval remains the chain's heartbeat.
+Both default to off, which is exactly the behavior of a build without them.
 
 ## Configuring a private PoA network
 
@@ -34,11 +33,11 @@ deadline, so the on-chain interval remains the chain's heartbeat.
    `--metadium.block.interval` looks like the knob for this but is dead: the
    value is stored in `params.BlockInterval` and never read.
 
-2. **Set the flag identically on every sealer.** It only takes effect on the
-   node that is building a block, so a fleet with mixed values simply gets
+2. **Set the two flags identically on every sealer.** They only take effect on
+   the node that is building a block, so a fleet with mixed values simply gets
    different latency depending on whose turn it is. Non-sealing RPC and full
-   nodes ignore it (`commitWork` returns before this code on a non-miner), so
-   passing it there is harmless but pointless.
+   nodes ignore them (`commitWork` returns before this code on a non-miner), so
+   passing them there is harmless but pointless.
 
 3. **Typical enterprise profile** -- 5 second heartbeat, ~100ms confirmation:
 
@@ -50,6 +49,10 @@ deadline, so the on-chain interval remains the chain's heartbeat.
    --metadium.block.idleseal 100
    ```
 
+   Add `--metadium.block.emptyinterval <s>` only if the empty-block stream
+   itself is a problem (disk growth on a chain that is idle for long stretches).
+   It is not needed for latency.
+
 ## Measured behavior
 
 3-node PoA private net (`tests/private-net-poa`, LevelDB, one host), governance
@@ -58,20 +61,38 @@ from `eth_sendTransaction` returning to the receipt being available.
 
 | Configuration | Idle cadence | Confirm (single tx) | 40-tx burst |
 |---|---|---|---|
-| flag off (public-network behavior) | empty block every 4.3-5.8s | avg 2544ms (min 1962, max 2634) | 1 block, 5657ms |
+| flags off (public-network behavior) | empty block every 4.3-5.8s | avg 2544ms (min 1962, max 2634) | 1 block, 5657ms |
 | `idleseal=100` | empty block every 4.3s | **avg 117ms** (min 117, max 118) | 1 block, **174ms** |
+| `idleseal=100` + `emptyinterval=30` | **1 block / ~30s** | **avg 123ms** (min 116, max 127) | 1 block, 179ms |
 
 A 10-minute soak with `idleseal=100` and one transaction every 3 seconds, to see
 whether latency ever spikes: 193 transactions, **min 107ms, p50 118ms, p90 128ms,
 p99 130ms, max 130ms**, nothing above 500ms. The gap between p50 and the maximum
-is 12ms -- there is no tail. That run also produced 193 blocks for 193
+is 12ms — there is no tail. That run also produced 193 blocks for 193
 transactions: with traffic this steady every slot closes on a transaction, so no
-empty blocks appear at all.
+empty blocks appear at all even with `emptyinterval` off.
 
 Across the runs: three nodes stayed in lockstep at the same head, 40 sampled
 blocks had no parent-hash break, and the logs carried no `BAD BLOCK`, no panic
 and no seal failure. The only ERROR lines were the harness's pre-existing
 `static-nodes.json is deprecated` warnings.
+
+**Set `emptyinterval` above the on-chain interval, or it does almost nothing.**
+The withhold is measured from the parent's timestamp, so a value at or below the
+interval expires before the slot the sealer would have used anyway. Measured on
+the same chain (`blockCreationTime = 5000`), 8 single transactions and a 40-60s
+idle window per row:
+
+| Configuration | Idle cadence (median) | Confirm (median) |
+|---|---|---|
+| flags off | 4.34s (3.9-5.9) | 2825ms |
+| `idleseal=100` | 5.81s (1.3-5.9) | 121ms |
+| `idleseal=100` + `emptyinterval=5` | **4.97s (4.3-5.2)** — barely moved | 125ms |
+| `idleseal=100` + `emptyinterval=30` | **29.8s (17.0-30.1)** | 126ms |
+
+Pick the gap you actually want between empty blocks. A `5` on a 5-second chain
+reads like "one empty block every five seconds", which is what it was already
+doing.
 
 ## Interactions worth knowing
 
@@ -80,10 +101,9 @@ and no seal failure. The only ERROR lines were the harness's pre-existing
 `2000`). `getMaxIdleBlockInterval` is the idle heartbeat -- mainnet has it set
 to `5` -- and **nothing reads it for block production**: it is loaded into a
 struct and never consulted, the same fate as `throttleMining`'s call site. That
-is why an idle chain still mints an empty block every slot. Re-wiring it is not
-the small fix it looks like: mainnet has the value set to `5`, so honoring it
-would move mainnet's idle cadence from 2s to 5s. This flag deliberately leaves
-empty blocks alone and touches only the block that carries a transaction.
+is why an idle chain still mints an empty block every slot, and why
+`emptyinterval` is a node flag here rather than a revival of the on-chain
+value: re-wiring it would silently change mainnet's idle cadence from 2s to 5s.
 
 **The drift correction still owns the empty-block cadence, and only that.**
 `timeIt` compares recent block density against the nominal interval and either
@@ -142,7 +162,7 @@ timestamps are whole seconds. On mainnet's 2s interval the window is
 matches its measured spacing (1s 26.0%, 2s 55.8%, 3s 10.5%, 4s 7.7%).
 
 Only the empty heartbeat is affected. A block carrying a transaction is sealed
-by the idle rule long before either deadline -- the 10-minute soak above saw a
+by the idle rule long before either deadline -- the 10-minute soak below saw a
 maximum of 130ms.
 
 **`BlockMinBuildTime` is not a floor for idle sealing.** It only shapes the
@@ -176,40 +196,51 @@ the faster the chain, the longer the stall. Nothing is lost by removing it:
 catching up when the chain runs *late* was never its job, and that half is
 `timeIt`'s, which stays.
 
-**What disappears is the slot deadline acting as a ceiling on block rate.**
-Traffic arriving just slower than `idleseal` gives every transaction its own
-block. Nothing pathological appeared in testing -- steady traffic produced one
-block per transaction and dense traffic coalesced (40 transactions into one
-block) -- but if a deployment needs a floor under the block rate, the shape to
-add is a bounded minimum spacing since the parent.
+What genuinely disappears with idle sealing is the slot deadline acting as a
+natural ceiling on block *rate*: traffic arriving just slower than
+`idleseal` gives every transaction its own block. If a deployment needs a floor
+under that, the shape to add is a bounded minimum spacing, not this.
+
+**With `emptyinterval` on, a transaction block may be trailed by one empty
+block.** The withhold decision is taken in `commitWork` from the pool's own
+view, before the mining-token gate. A node that has not yet reset its pool after
+someone else sealed the transaction still sees it as pending, does not skip, and
+builds a round that comes out empty. Deciding after the fill instead -- where
+emptiness is known exactly -- was measured and rejected: a round discarded at
+that point has already taken the mining token and leaves it to expire (TTL 10s),
+which pushed confirmation from 117ms to **4.4s average**. One trailing empty
+block is the cheaper trade, and the comment in `commitTransactionsEx` records it
+so the next reader does not redo the experiment.
 
 **Timestamps are seconds, and several blocks can share one.** PoA permits it --
 the `header.Time <= parent.Time` rejection in `consensus/ethash/consensus.go` is
 guarded by `metaminer.IsPoW()` -- so this is consensus-legal. Explorers and
 indexers that compute block time by subtracting timestamps will show 0s gaps.
 
-**Finality depth is measured in blocks, not seconds.**
-`GetFinalizedBlockNumber` returns `head - (govNodeCount/2 + 1)`. Empty blocks
-keep arriving on the on-chain interval, so that depth fills at the same rate as
-before; sealing early only brings it forward, never delays it.
+**Finality depth is measured in blocks, not seconds.** `GetFinalizedBlockNumber`
+returns `head - (govNodeCount/2 + 1)`. Withholding empty blocks means those
+confirmations arrive only as fast as real traffic produces blocks, so on a very
+quiet chain a transaction is included in ~100ms but finalized later than the
+fixed-cadence chain would have finalized it. Use `emptyinterval` deliberately.
 
 ## Why mainnet and testnet are unaffected
 
-- **Off by default.** `params.BlockIdleSealTime` is 0, and every new path is
-  behind a `> 0` test. With the flag unset the sealer runs the same code it ran
-  before: the quiet timer is never created and the wait selects on a nil
-  channel, which never fires. Measured on the same binary with the flag
-  omitted: idle cadence and confirmation latency matched the pre-change
-  baseline.
+- **Off by default.** `params.BlockIdleSealTime` and `params.BlockEmptyInterval`
+  are 0, and every new path is behind a `> 0` test. With the flags unset the
+  sealer runs the same code it ran before: the idle timer is never created, no
+  extra transaction subscription is opened, and `commitWork` gains one integer
+  comparison. Measured on the same binary with the flags omitted: idle cadence
+  and confirmation latency matched the pre-change baseline.
 - **Refused outright on the public chains.** `eth.New` looks up the genesis hash
-  and returns an error -- the node exits rather than starting -- if the flag is
-  set on a chain whose genesis is `MetadiumMainnetGenesisHash` or
+  and returns an error -- the node exits rather than starting -- if either flag
+  is set on a chain whose genesis is `MetadiumMainnetGenesisHash` or
   `MetadiumTestnetGenesisHash`. Keyed on genesis rather than chain id, because a
   private chain may reuse a chain id but never the public genesis.
 - **No consensus rule is touched.** Block spacing is not validated by
   `verifyHeader`; producer rotation is height-based
   (`admin.go: ix := int(height/blocksPer) % len(nodes)`); rewards are per block.
-  A node running this flag produces blocks that any stock node accepts, and the
-  flag changes nothing about validation, so a mixed fleet stays in agreement --
-  the sealer just closes blocks sooner.
-- **Sealer-side only.** Nothing in the import, sync or RPC path reads the value.
+  A node running these flags produces blocks that any stock node accepts, and
+  the flags change nothing about validation, so a mixed fleet stays in
+  agreement -- the sealers just close blocks sooner.
+- **Sealer-side only.** Nothing in the import, sync or RPC path reads either
+  value.

--- a/docs/enterprise-private-poa.md
+++ b/docs/enterprise-private-poa.md
@@ -28,9 +28,18 @@ second interval:
 | 40 transactions submitted at once | 1 block, 5.7 s | 1 block, **0.18 s** |
 | Empty-block cadence when idle | every 4.3–5.8 s | unchanged, every 4.3–5.8 s |
 
-The last row is the important one: **empty blocks are untouched.** The
+The last row is the important one: **`idleseal` leaves empty blocks alone.** The
 heartbeat of the chain stays the on-chain interval, and only blocks that carry
 transactions close early.
+
+If that heartbeat is itself the problem — a chain idle for long stretches, where
+the empty blocks are just disk growth — there is a second flag for it,
+`--metadium.block.emptyinterval <s>`: with an empty pool, no block is produced
+until that many seconds have passed since the parent. It is **not needed for
+confirmation latency** and this guide does not use it; measured behaviour, the
+one empty block that can trail a transaction block, and the effect on finality
+depth are in [enterprise-block-timing.md](enterprise-block-timing.md). The rest
+of this guide is about `idleseal`.
 
 ## Prerequisites
 
@@ -234,7 +243,7 @@ flag at all) against such a chain: 9,887 blocks imported, no rejected headers.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Node exits: `--metadium.block.idleseal is for private networks only` | The chain's genesis is the Metadium mainnet or testnet genesis | Not usable there. Confirm the chain has its own genesis |
+| Node exits: `--metadium.block.idleseal is for private networks only` (or the same for `--metadium.block.emptyinterval`, or both named at once) | The chain's genesis is the Metadium mainnet or testnet genesis | Not usable there. Confirm the chain has its own genesis |
 | Node exits: `flag provided but not defined` | Binary predates the flag (`m1.1.3` or older) | Upgrade the sealer |
 | Node exits: `Invalid metadium.block.idleseal: -1, must not be negative` | Negative value | Use `0` (off) or a positive millisecond count |
 | Confirmation is fast for some transactions and slow for others | The flag is set on some sealers but not all; latency then depends on whose turn it is | Set the same value on every sealer |

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -232,15 +233,25 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The private-PoA idle seal changes when a sealer closes a block. Metadium
-	// mainnet and testnet take their cadence from governance and must keep the
-	// one behavior every node agrees on, so refuse to start rather than let a
-	// stray flag alter block production there. Keyed on the genesis hash, not
-	// the chain id, because a private chain may legitimately reuse a chain id
-	// but never the public genesis.
-	if params.BlockIdleSealTime > 0 {
+	// The private-PoA block timing flags change when a sealer closes a block.
+	// Metadium mainnet and testnet take their cadence from governance and must
+	// keep the one behavior every node agrees on, so refuse to start rather than
+	// let a stray flag alter block production there. Keyed on the genesis hash,
+	// not the chain id, because a private chain may legitimately reuse a chain
+	// id but never the public genesis.
+	if params.BlockIdleSealTime > 0 || params.BlockEmptyInterval > 0 {
 		if network := publicMetadiumNetwork(eth.blockchain.Genesis().Hash()); network != "" {
-			return nil, fmt.Errorf("--metadium.block.idleseal is for private networks only, but this node is on the Metadium %s", network)
+			// Name the flags actually set, so the operator is told which one to
+			// drop rather than being handed both to check.
+			var set []string
+			if params.BlockIdleSealTime > 0 {
+				set = append(set, "--metadium.block.idleseal")
+			}
+			if params.BlockEmptyInterval > 0 {
+				set = append(set, "--metadium.block.emptyinterval")
+			}
+			return nil, fmt.Errorf("%s is for private networks only, but this node is on the Metadium %s",
+				strings.Join(set, " and "), network)
 		}
 	}
 	eth.bloomIndexer.Start(eth.blockchain)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -579,10 +579,14 @@ func (w *worker) newWorkLoopEx(recommit time.Duration) {
 	// to build it -- which is the whole latency BlockIdleSealTime is there to
 	// remove. Wake on arrival instead. commitSimple's busyMining CAS makes this
 	// a no-op while a round is already running. Left unsubscribed (a nil
-	// channel never selects) when idle sealing is off, so the public networks
-	// keep starting rounds exactly as before.
+	// channel never selects) when both timing flags are off, so the public
+	// networks keep starting rounds exactly as before.
+	//
+	// BlockEmptyInterval needs the same wake-up for a different reason: a round
+	// it withholds builds nothing, so an idle chain has no round in flight at
+	// all and the arrival would otherwise wait for the tick.
 	var txCh chan core.NewTxsEvent
-	if params.BlockIdleSealTime > 0 {
+	if params.BlockIdleSealTime > 0 || params.BlockEmptyInterval > 0 {
 		txCh = make(chan core.NewTxsEvent, 64)
 		sub := w.pool.SubscribeTransactions(txCh, true)
 		defer sub.Unsubscribe()
@@ -1234,6 +1238,17 @@ func (w *worker) commitTransactionsEx(env *environment, interrupt *atomic.Int32,
 
 	log.Debug("Block", "number", env.header.Number.Int64(), "elapsed", common.PrettyDuration(time.Since(tstart)), "txs", env.tcount)
 
+	// Note on BlockEmptyInterval: the withhold decision deliberately stays in
+	// commitWork, ahead of the mining-token gate, and is not re-taken here.
+	// Deciding it after the fill would be more precise -- a round can come out
+	// empty because another sealer got the transaction first, which the pool
+	// pre-check cannot see until its own reset lands -- but a round discarded
+	// at this point has already taken the mining token and would leave it to
+	// expire (TTL 10s). Measured on the 3-node private net: doing it here cut
+	// the trailing empty blocks but pushed idle-seal confirmation from 117ms to
+	// 4.4s average, because every withheld round burned a token. One empty
+	// block trailing a transaction block is the cheaper trade.
+
 	return false
 }
 
@@ -1634,6 +1649,18 @@ func (w *worker) commitWork(interrupt *atomic.Int32, timestamp int64) {
 	}
 	if !metaminer.IsPoW() {
 		parent := w.chain.CurrentBlock()
+		// Metadium private PoA: with an empty pool, skip the round entirely
+		// until BlockEmptyInterval has passed since the parent, so an idle
+		// chain does not accumulate empty blocks. Checked before the miner and
+		// mining-token gates below so a skipped round never holds the token.
+		// Off (0) on the public networks, which seal every slot.
+		if params.BlockEmptyInterval > 0 {
+			if pending, _ := w.eth.TxPool().Stats(); pending == 0 &&
+				time.Now().Unix()-int64(parent.Time) < params.BlockEmptyInterval {
+				w.refreshPending(true)
+				return
+			}
+		}
 		height := new(big.Int).Add(parent.Number, common.Big1)
 		if !w.chain.Config().IsBokbunja(height) {
 			if !metaminer.IsMiner() {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -265,10 +265,13 @@ var (
 	BlockMinBuildTime    int64 = 300  // Minimum block generation time in ms
 	BlockMinBuildTxs     int64 = 2500 // Minimum txs in a block with pending txs
 	BlockTrailTime       int64 = 300  // Time to leave for block data transfer transfer in ms
-	// Private-PoA (enterprise) block timing. 0 = off, which is the behavior of
-	// the public networks: a block is sealed when its slot elapses. Deployments
-	// that need lower confirmation latency than the on-chain block interval
-	// turn this on; see docs/enterprise-block-timing.md.
+	// Private-PoA (enterprise) block timing. Both are 0 = off, which is the
+	// behavior of the public networks: a block is sealed when its slot elapses,
+	// and empty blocks are produced on every slot. Deployments that need lower
+	// confirmation latency than the on-chain block interval, or that do not want
+	// an empty-block stream while idle, turn these on; see
+	// docs/enterprise-block-timing.md.
 	BlockIdleSealTime   int64  = 0       // Seal once the pool stays quiet this long (ms) and the block has txs
+	BlockEmptyInterval  int64  = 0       // Withhold empty blocks until this many seconds since the parent
 	BlobRetentionBlocks uint64 = 1572480 // Number of blocks to keep blob sidecars (~36.4 days at Metadium's 2s block interval; 0 = forever)
 )

--- a/tests/private-net-poa/deploy.sh
+++ b/tests/private-net-poa/deploy.sh
@@ -8,6 +8,7 @@
 # Usage: ./deploy.sh
 # Options: GMET_BIN=/path/to/gmet ./deploy.sh
 #          BLOCK_CREATION_TIME=5000 (ms, on-chain block interval; default 2000)
+#          MAX_IDLE_BLOCK_INTERVAL=5 (s, on-chain idle interval; default 5)
 
 set -euo pipefail
 
@@ -82,7 +83,7 @@ cat > config.json <<EOF
     "ballotDurationMax":      604800,
     "stakingMin":             1000000000000000000,
     "stakingMax":             100000000000000000000000000,
-    "MaxIdleBlockInterval":   5,
+    "MaxIdleBlockInterval":   ${MAX_IDLE_BLOCK_INTERVAL:-5},
     "blockCreationTime":      ${BLOCK_CREATION_TIME:-2000},
     "blockRewardAmount":      1000000000000000000,
     "maxPriorityFeePerGas":   80000000000,


### PR DESCRIPTION
## What this changes

`--metadium.block.emptyinterval <s>` — the second half of the private-PoA timing
pair. With an empty transaction pool, `commitWork` skips the round entirely until
that many seconds have passed since the parent, so a private chain that is idle
for long stretches stops minting an empty block every slot.

This is the part held back when #116 was narrowed to `idleseal` alone; the code
has been carried onto current `dev` and re-verified there rather than merged from
the branch it was written on, since `dev` has moved (#116, #123).

**Why now:** the 2026-09-09 business review asked for private-network block
production to become optional — a block as soon as a transaction settles, and no
blocks while idle — as a switch in the same codebase rather than a separate
branch or binary. `idleseal` (#116) is the first half and is already merged; this
is the second. Nothing about the request needs new work beyond this PR.

## Compatibility tier

- [x] **C7 — internal only.** Producer-side behaviour behind a flag the public
      networks refuse; no validation rule is touched.

**Why this tier:** with the flag unset nothing changes — `params.BlockEmptyInterval`
is 0, `commitWork` gains one integer comparison against it, and no subscription
is opened. With it set, the node refuses to start on a chain whose genesis is the
Metadium mainnet or testnet genesis (`eth.New`, keyed on genesis hash rather than
chain id). Block spacing is not validated by `verifyHeader`, producer rotation is
height-based and rewards are per block, so a sealer running this produces blocks
any stock node accepts.

## Rollout

- [x] Not applicable — nothing deploys (C7). Private-network flag, default off.

## Verification

3-node harness (`tests/private-net-poa`, LevelDB), governance
`blockCreationTime = 5000`, all three nodes sealing, built from this branch.
Eight single transactions and a 40–90 s idle window per row; "confirm" is wall
clock from `eth_sendTransaction` returning to the receipt being available.

| Configuration | Idle cadence (median) | Confirm (median) |
|---|---|---|
| flags off | 4.34 s (3.9–5.9) | 2825 ms |
| `idleseal=100` | 5.81 s | 121 ms |
| `idleseal=100` + `emptyinterval=5` | **4.97 s — barely moved** | 125 ms |
| `idleseal=100` + `emptyinterval=30` | **29.8 s (17.0–30.1)** | 126 ms |

- Zero `BAD BLOCK`, zero panics, zero seal failures across all three nodes for
  the whole session; no parent-hash break over the last 31 blocks; the three
  heads were equal at every sample (spread 0).
- Flags-off row was taken on the same binary and reproduces the pre-change
  baseline (the recorded figures are 4.3–5.8 s and avg 2544 ms).
- `gofmt` clean, `go vet ./miner/... ./eth/... ./params/... ./cmd/utils/...`
  clean, `go test ./miner/... ./eth/` pass, `CGO_ENABLED=0` build OK.

**One trap the measurement turned up, now documented:** `emptyinterval` at or
below the on-chain interval does almost nothing — the withhold is measured from
the parent's timestamp, so it expires before the slot the sealer would have used
anyway. On a 5-second chain, `emptyinterval=5` reads like "one empty block every
five seconds", which is what it was already doing. That is exactly the value a
reader would pick first, so it is called out in `docs/enterprise-block-timing.md`
with the numbers above.

## Notes for review

- **The `#123` wake-up gate is widened**, from `BlockIdleSealTime > 0` to either
  flag. A round this flag withholds builds nothing, so with no round in flight an
  arriving transaction would wait for the 1 s tick and the confirmation would be
  that tick's phase rather than the idle window. With both flags off the channel
  is still nil and the case cannot fire.
- **The withhold decision deliberately stays in `commitWork`**, ahead of the
  mining-token gate, and is not re-taken after the fill. Deciding it after the
  fill is more precise — a round can come out empty because another sealer got
  the transaction first, which the pool pre-check cannot see until its own reset
  lands — but a round discarded there has already taken the mining token and
  leaves it to expire (TTL 10 s). That variant was measured: confirmation went
  from 117 ms to 4.4 s. The cost of the cheaper trade is that a transaction block
  may be trailed by one empty block. Both the reasoning and the number are in a
  comment at the point where the next reader will look for them.
- **Finality depth is in blocks, not seconds**, so withholding empty blocks means
  confirmations arrive only as fast as real traffic produces blocks. On a very
  quiet chain a transaction is included in ~100 ms but finalised later than a
  fixed-cadence chain would have finalised it. Documented; it is the reason to
  use this flag deliberately rather than by default.
- `docs/enterprise-private-poa.md` (the operator guide) gains a short pointer
  only — it stays an `idleseal` guide, and the full treatment is in the design
  record. That file is also touched by #126; the two edits are in different
  sections and do not overlap.
