### PR TITLE
build: package the bundle by name, and clear stale artifacts before a release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,14 @@ ROCKSDB_CGO_CFLAGS = -I$(ROCKSDB_DIR)/include
 ROCKSDB_CGO_LDFLAGS = -L$(ROCKSDB_DIR) -lrocksdb -lm $(STDCPP_LDFLAGS) $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print} /JEMALLOC=1/ {print "-ljemalloc"}' < $(ROCKSDB_DIR)/make_config.mk)
 endif
 
+# What the deploy bundle ships. Named explicitly rather than tarring bin/
+# wholesale: $(GOBIN) is shared with `make all`, `make geth` and anything else
+# that installs there, and a leftover from one of those used to be packaged
+# with no complaint. release-check guards the glibc floor, not the provenance
+# of what sits in the directory, so an older artifact that happens to satisfy
+# the ceiling would ship silently. See issue #125.
+METADIUM_BUNDLE_BIN = gmet logrot gmet.sh solc.sh
+
 metadium: gmet logrot
 	@[ -d build/conf ] || mkdir -p build/conf
 	@cp -p metadium/scripts/gmet.sh metadium/scripts/solc.sh build/bin/
@@ -78,8 +86,18 @@ metadium: gmet logrot
 		metadium/contracts/MetadiumGovernance.js	\
 		metadium/scripts/deploy-governance.js		\
 		build/conf/
-	@(cd build; tar cfz metadium.tar.gz bin conf)
+	@missing=;							\
+	for f in $(METADIUM_BUNDLE_BIN); do				\
+		[ -f build/bin/$$f ] || missing="$$missing $$f";	\
+	done;								\
+	if [ -n "$$missing" ]; then					\
+		echo "metadium: missing from build/bin:$$missing" >&2;	\
+		exit 1;							\
+	fi
+	@(cd build; tar cfz metadium.tar.gz				\
+		$(patsubst %,bin/%,$(METADIUM_BUNDLE_BIN)) conf)
 	@echo "Done building build/metadium.tar.gz"
+	@echo "Bundled: $(patsubst %,bin/%,$(METADIUM_BUNDLE_BIN)) conf/"
 
 gmet: rocksdb metadium/governance_abi.go metadium/governance_legacy_abi.go
 ifeq ($(USE_ROCKSDB), NO)
@@ -180,6 +198,23 @@ gmet-linux:
 		     "Dockerfile.metadium ARG GO_VERSION ($$dv) disagree;" \
 		     "update both, with the matching GO_SHA256" >&2;	\
 		exit 1;							\
+	fi
+	@# Clear ELFs a previous build left in $(GOBIN). release-check covers every
+	@# ELF in that directory, so a host-built leftover makes the gate fail while
+	@# naming the release artifacts as the culprit -- the message says a binary
+	@# needs a too-new glibc and never mentions that the file is from another
+	@# build. Only ELFs go: gmet.sh and solc.sh are copied in by `make metadium`
+	@# and are not build outputs. See issue #125.
+	@if [ -d $(GOBIN) ]; then					\
+		removed=;						\
+		for f in $(GOBIN)/*; do					\
+			[ -f "$$f" ] || continue;			\
+			head -c 4 "$$f" | grep -q 'ELF' || continue;	\
+			rm -f "$$f";					\
+			removed="$$removed `basename $$f`";		\
+		done;							\
+		[ -z "$$removed" ] ||					\
+			echo "release-build: cleared stale artifacts:$$removed"; \
 	fi
 	@# Built from stdin, with no build context at all. The Dockerfile has no
 	@# COPY, so every build used to stream the whole working tree -- .git alone


### PR DESCRIPTION
## What this changes

Two ways a file that nobody built in this release reached a release artifact.
Closes #125.

**`make metadium` tarred `build/bin` wholesale.** `$(GOBIN)` is shared with
`make all`, `make geth` and every other install target, so whatever was left
there came along. `release-check` guards the glibc floor, not the provenance of
the directory — a leftover built *in the container* from an older commit
satisfies the ceiling and ships with no complaint. The bundle now names what it
contains (`gmet`, `logrot`, `gmet.sh`, `solc.sh`) and **fails if one of them is
missing** rather than quietly shipping a short bundle.

**`make gmet-linux` did not clear `$(GOBIN)` first.** A host build had left
eleven binaries there, and `release-check` reported them as release artifacts
needing `GLIBC_2.34` and `2.38`. The message names the wrong culprit: it reads
as though the change under test raised the floor, and nothing in it says the
files are from a different build a week earlier. That cost a round of
investigation on #122 — a change to the builder image, which is exactly where
that message would be believed. The release path now removes ELFs from
`$(GOBIN)` before building and prints which ones. Only ELFs: `gmet.sh` and
`solc.sh` are copied in by `make metadium` and are not build outputs.

## Compatibility tier

- [x] **C6 — build or OS baseline.** Release packaging and the release build
      path. No node behaviour, no Go file touched.

**Why this tier:** what a release bundle contains changes — it stops carrying
binaries that were never part of the build. `MAX_GLIBC`, `release-check`'s own
logic, and the toolchain pins are untouched. Nothing an operator runs behaves
differently; what changes is what they receive.

One consequence worth naming: **the bundle is now smaller for anyone who was
relying on the extras.** `metadium.tar.gz` previously carried whatever
`make all` had installed — `evm`, `abigen`, `clef`, `devp2p`, `ethkey`,
`rlpdump` and friends — as an accident of tarring the directory. The README has
always documented the bundle as `bin/` + `conf/` for deployment, and `gmet.sh`
is the only entry point it describes, but if anyone was picking `evm` out of a
release tarball, it will not be there. I believe that is the right call — those
were never built by the release path and were not verified against the glibc
ceiling as *release* artifacts — but it is a visible change, so say so if you
disagree.

## Rollout

- [x] Not applicable — nothing deploys. This changes how the next release
      bundle is assembled; that release rolls out under its own runbook.

## Verification

End to end with a deliberately contaminated `$(GOBIN)`: a host binary copied in
as `geth`, an unrelated ELF (`stale-leftover`), a **non-ELF** script
(`keepme.sh`), and `gmet`/`logrot` left from a previous build. Then
`make gmet-linux USE_ROCKSDB=NO` on this branch:

```
release-build: cleared stale artifacts: geth gmet logrot stale-leftover
Done building build/metadium.tar.gz
Bundled: bin/gmet bin/logrot bin/gmet.sh bin/solc.sh conf/
release-check: OK (2 binaries, ceiling GLIBC_2.31)
```

- **The non-ELF script survived the clear** — `keepme.sh` was still in
  `build/bin` afterwards, so the filter is doing what the comment says.
- **`release-check` saw two binaries, not six.** Before this change the same
  directory state produced `release-check: FAILED` naming `GLIBC_2.34`/`2.38`,
  which is the confusing failure the issue describes.
- **The tarball holds exactly the four bin entries plus `conf/`**:

```
bin/gmet  bin/logrot  bin/gmet.sh  bin/solc.sh
conf/{MetadiumGovernance.js,config.json.example,deploy-governance.js,genesis-template.json}
```

- [ ] Unit tests — not applicable, no Go file is touched.

## Not covered here

Option 3 in the issue (have `release-check` report artifacts older than this
build) is not implemented. With the clear in place it has nothing left to
report on the release path, and it would still be guesswork on a developer's
`make release-check`.
