### PR TITLE
params, README: bump the version to 1.1.4-stable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fo
 - Backend: Go 1.21+
 - DB: LevelDB (default) / RocksDB (`-tags rocksdb`)
 - Consensus: Metadium PoA (ethash placeholder, custom sealing)
-- Version: 1.1.2-stable
+- Version: 1.1.4-stable
 
 ## Directory Structure
 - `cmd/geth/` -- main binary entrypoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 Metadium blockchain node implementation (go-ethereum v1.13.14 fork). Camellia fork integrates Shanghai + Cancun EIPs on Metadium PoA.
 
 ## Tech Stack
-- Backend: Go 1.21+
+- Backend: Go 1.22+ (floor set by the embedded etcd)
 - DB: LevelDB (default) / RocksDB (`-tags rocksdb`)
 - Consensus: Metadium PoA (ethash placeholder, custom sealing)
 - Version: 1.1.4-stable

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Camellia is Metadium's hard fork that activates Ethereum's Shanghai and Cancun E
 
 Nodes must run this release before the mainnet activation block; older binaries will follow a diverging chain.
 
+**For contract authors:** the EVM is **Cancun** from the activation blocks above.
+Compile with `--evm-version cancun` (or a toolchain default targeting Cancun or
+older); a contract compiled for a newer EVM version will not run.
+
 | EIP | Feature | Status |
 |-----|---------|--------|
 | EIP-3855 | PUSH0 opcode | Verified |
@@ -44,7 +48,9 @@ See [docs/camellia-test-report.md](docs/camellia-test-report.md) for full test r
 
 ## Building
 
-Prerequisites: Go 1.21+, C compiler (for RocksDB builds).
+Prerequisites: Go 1.22+, C compiler (for RocksDB builds). The floor is set by
+the embedded etcd, whose own `go.mod` declares 1.22; a module cannot declare
+less than its dependencies.
 
 These are the Makefile targets CI validates. They build against whatever the
 host provides, which is what you want for development — but **not** for

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Metadium blockchain node implementation, forked from [go-ethereum](https://githu
 
 Metadium is a Proof-of-Authority (PoA) blockchain with on-chain governance. It uses a custom consensus layer built on top of go-ethereum's ethash engine, with block signing via node keys and reward distribution through governance smart contracts.
 
-**Current version:** 1.1.3-stable (Camellia fork)
+**Current version:** 1.1.4-stable (Camellia fork)
 
 ## Camellia Fork
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 1        // Minor version component of the current release
-	VersionPatch = 3        // Patch version component of the current release
+	VersionPatch = 4        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## What this changes

The version cut for **m1.1.4**: `VersionPatch` 3 → 4, plus the two places that
carry the version in prose. `gmet version` and the release asset names both read
from `params.VersionPatch`, so it moves before the tag, not after.

`CLAUDE.md` still said `1.1.2` — it was not updated for m1.1.3 — so it is
corrected here rather than left two releases behind.

**Merge last, immediately before promoting `dev` to `master`.** Everything else
intended for this release should already be in `dev` when this lands.

## Why patch and not minor

Nothing in this release changes what a node on m1.1.3 accepts:

- **The two private-PoA flags** (`--metadium.block.idleseal`,
  `--metadium.block.emptyinterval`) default to off, and a node refuses to start
  with either set on a chain whose genesis is the mainnet or testnet genesis.
- **The Camellia header rule** is a tightening, and the chain already satisfies
  it — all 607,202 blocks from 117,764,000 to head check out, zero violations.
- **The etcd upgrade** is a dependency bump behind the same sealer-only path.

The one externally visible change is not in the node at all: building from
source now needs Go 1.22 (etcd 3.5.16 declares it). That belongs in the release
notes, which is where it is going.

## Compatibility tier

- [x] **C7 — internal only.** A version constant and two documentation lines.

## Rollout

- [x] Not applicable — nothing deploys on merge. The release this version names
      rolls out under its own runbook: testnet BPs first, then the rest of the
      testnet on the old build, then mainnet one BP at a time.

## Verification

- `go build ./cmd/geth` OK
- The three occurrences are the complete set: `grep -rn "1\.1\.3"` over
  tracked Go, Markdown, Makefile and workflow files returns only README (bumped)
  and historical references in `docs/` that name the *previous* release
  deliberately (`enterprise-block-timing.md` describes the range m0.10.0 →
  m1.1.3, and README's testnet-operator note is about the m1.1.2 asset).
  Those are history, not the current version, and are left alone.
