### PR TITLE
README: mainnet Camellia is activated, not scheduled

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Camellia is Metadium's hard fork that activates Ethereum's Shanghai and Cancun E
 | Network | Activation block | Activation time |
 |---------|------------------|-----------------|
 | Testnet | 86,449,000 | 2026-05-20 12:00 KST (activated) |
-| Mainnet | 117,764,000 | 2026-08-27 12:00 KST (scheduled) |
+| Mainnet | 117,764,000 | 2026-08-27 12:00 KST (activated) |
 
-Nodes must run this release before the mainnet activation block; older binaries will follow a diverging chain.
+Both networks are past their activation block, so a Camellia-capable release is required to follow the chain at all. A pre-Camellia binary does not diverge onto its own chain — block production is permissioned and every producer has upgraded — it stops importing at the activation block. See [Upgrading from 0.10.x](#upgrading-from-010x) for which release to take.
 
 **For contract authors:** the EVM is **Cancun** from the activation blocks above.
 Compile with `--evm-version cancun` (or a toolchain default targeting Cancun or

--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ before — but review the following **before** restarting on the new binary.
 
 ### Upgrade checklist
 
-1. **Upgrade before the activation block** — mainnet 117,764,000. The block
-   height is authoritative; wall-clock estimates are approximate. Nodes on
-   older binaries follow a diverging chain from that block on.
+1. **Both networks are already past activation** — mainnet 117,764,000,
+   testnet 86,449,000. The block height is authoritative; wall-clock
+   estimates are approximate. A pre-Camellia binary stops importing at the
+   activation block; it does not diverge onto its own chain.
 2. **Use the engine-matched tarball.** The DB engine is decided at build time.
    Check the node's chaindata before extracting: `.sst` files → rocksdb
    tarball, `.ldb` files → leveldb tarball. A mismatched binary cannot open


### PR DESCRIPTION
## What this changes

Two lines in the Camellia Fork section of `README.md`.

The fork table still reads `(scheduled)` for mainnet, and the sentence under it
still tells operators to upgrade *before* an activation block that passed on
2026-08-27. The testnet row was already marked `(activated)`; only mainnet was
left behind.

```
-| Mainnet | 117,764,000 | 2026-08-27 12:00 KST (scheduled) |
+| Mainnet | 117,764,000 | 2026-08-27 12:00 KST (activated) |
```

The sentence is also factually wrong now, not just stale. "Older binaries will
follow a diverging chain" was the right warning while producers could still be
split across versions — they cannot be: block production is permissioned and
every producer is on Camellia, so a pre-Camellia binary has no chain to diverge
onto. It stops importing at the activation block. The replacement says that,
and links to `Upgrading from 0.10.x` rather than naming a version, because the
earliest Camellia release is m1.1.1 and that section exists partly to explain
why its assets should not be used (glibc 2.38).

## Why now, before the release

The m1.1.4 release notes link into this file **at the tag** —
`blob/m1.1.4/README.md#upgrading-from-010x` and
`#node-configuration-reference-gmetsh--rc`. Cutting the tag with these two
lines freezes "mainnet hard fork upcoming" into a permanent URL that operators
reach from the release page. After the tag it cannot be corrected in place.

## Compatibility tier

- [x] **C7 — internal only.** Documentation. No code, no build input, no
      behaviour.

**Why this tier:** the only file touched is `README.md`, and the change is to
prose describing an event that already happened. Nothing a node does changes,
and the release artifacts are byte-identical with or without it.

## Rollout

None. Documentation-only, so the testnet-BP-first gate does not apply.

## Verification

- The anchor added, `#upgrading-from-010x`, resolves to `## Upgrading from
  0.10.x` (README.md:168).
- Activation values in the table match `params/config.go`: mainnet
  `CamelliaBlock: 117_764_000`, testnet `86_449_000`.
- The claim that mainnet is past activation is on-chain: head is well beyond
  117,764,000, and the post-Camellia range was scanned block by block for the
  m1.1.4 header work (607,202 blocks, zero violations).
- No pre-activation wording survives in tracked `*.md`:
  `grep -rnE 'diverging chain|upgrade before the activation|older binaries'`
  returns nothing.

  **Corrected after review.** The original pattern here searched for `will
  follow a diverging`, and the surviving sentence in the upgrade checklist has
  no `will` — so this line claimed a clean sweep that had not happened. The
  second commit fixes item 1 of `Upgrading from 0.10.x`, which carried both of
  the same errors and which the new sentence links straight at.

  `docs/camellia-mainnet-hf-plan.md:45` ("Not yet activated on mainnet") is
  deliberately left alone: it records the plan as written at the time, not
  operator guidance.
