### PR TITLE
consensus/ethash: pin the three Camellia header fields left unverified

### DIFF
--- a/consensus/ethash/camellia_header_metadium_test.go
+++ b/consensus/ethash/camellia_header_metadium_test.go
@@ -80,6 +80,48 @@ func TestVerifyCamelliaHeaderFields(t *testing.T) {
 			header(func(h *types.Header) { h.ExcessBlobGas = new(big.Int) }),
 			"invalid excessBlobGas",
 		},
+		// Issue #134. Three fields in the same class as excessBlobGas: signed by
+		// the seal, acted on by the node, and previously unverified.
+		{
+			// core.ProcessBeaconBlockRoot runs the EIP-4788 system call whenever
+			// this is set, so leaving it free let a sealer write contract storage
+			// that no rule authorised.
+			"parent beacon root set",
+			header(func(h *types.Header) { h.ParentBeaconRoot = &other }),
+			"invalid parentBeaconRoot",
+		},
+		{
+			// The builder capped this; nothing on the verify path did. Header and
+			// body agreeing with each other was enough.
+			"blob gas used over the block maximum",
+			header(func(h *types.Header) {
+				h.BlobGasUsed = new(big.Int).SetUint64(params.MaxBlobGasPerBlock + params.BlobTxBlobGasPerBlob)
+			}),
+			"over the per-block maximum",
+		},
+		{
+			"blob gas used at the block maximum",
+			header(func(h *types.Header) {
+				h.BlobGasUsed = new(big.Int).SetUint64(params.MaxBlobGasPerBlock)
+			}),
+			"",
+		},
+		{
+			// core.ValidateBody divides, so this passes there; the child's
+			// excessBlobGas derives from it undivided.
+			"blob gas used with sub-blob slack",
+			header(func(h *types.Header) {
+				h.BlobGasUsed = new(big.Int).SetUint64(params.BlobTxBlobGasPerBlob + params.BlobTxBlobGasPerBlob - 1)
+			}),
+			"not a multiple of",
+		},
+		{
+			"blob gas used one whole blob",
+			header(func(h *types.Header) {
+				h.BlobGasUsed = new(big.Int).SetUint64(params.BlobTxBlobGasPerBlob)
+			}),
+			"",
+		},
 	} {
 		err := verifyCamelliaHeaderFields(tt.header, parent)
 		switch {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -546,6 +546,18 @@ func (ethash *Ethash) Prepare(chain consensus.ChainHeaderReader, header *types.H
 // deployed. The failure message carries the block, the parent and both values so
 // that a violation found that way is diagnosable rather than just a stall.
 func verifyCamelliaHeaderFields(header, parent *types.Header) error {
+	// EIP-4788's parentBeaconRoot means nothing here -- Metadium has no beacon
+	// chain, and the PoA sealing path never sets the field; only the engine-API
+	// payload path does. The pre-Camellia branch pins it to nil, and this branch
+	// has to as well: core.ProcessBeaconBlockRoot acts on it whenever it is set,
+	// running the EIP-4788 system call and writing the ring-buffer contract's
+	// storage. That is deterministic, so every node would agree on a state
+	// change no rule had authorised. The field is covered by the seal hash, so
+	// it is a signed field with no rule attached.
+	if header.ParentBeaconRoot != nil {
+		return fmt.Errorf("invalid parentBeaconRoot in camellia block %v (parent %x): have %#x, expected nil",
+			header.Number, parent.Hash(), *header.ParentBeaconRoot)
+	}
 	// Metadium PoA has no withdrawals; FinalizeAndAssemble pins the hash to the
 	// empty root, so anything else is a header that was not built by this code.
 	if header.WithdrawalsHash == nil {
@@ -563,6 +575,26 @@ func verifyCamelliaHeaderFields(header, parent *types.Header) error {
 	}
 	if header.BlobGasUsed == nil {
 		return fmt.Errorf("missing blobGasUsed in camellia block %v (parent %x)", header.Number, parent.Hash())
+	}
+	// The per-block blob ceiling existed only in the builder. eip4844's
+	// VerifyEIP4844Header is not called on the ethash path, and
+	// core.ValidateBody only reconciles the header against the body's blob
+	// count, so nothing capped it: a block carrying ten blobs verified, because
+	// header and body agreed with each other.
+	if !header.BlobGasUsed.IsUint64() || header.BlobGasUsed.Uint64() > params.MaxBlobGasPerBlock {
+		return fmt.Errorf("blobGasUsed over the per-block maximum in block %v (parent %x): have %v, max %d",
+			header.Number, parent.Hash(), header.BlobGasUsed, uint64(params.MaxBlobGasPerBlock))
+	}
+	// core.ValidateBody compares the body's blob count to blobGasUsed by
+	// dividing, so every value in [blobs*perBlob, (blobs+1)*perBlob) passes
+	// there. The parent's blobGasUsed then feeds the child's excessBlobGas
+	// undivided, just below -- so that slack moves the blob fee market by up to
+	// perBlob-1 per block, compounding, and the excessBlobGas check cannot see
+	// it because it is computing from the inflated value. Require a whole
+	// multiple so the two readings of the field agree.
+	if rem := new(big.Int).Mod(header.BlobGasUsed, big.NewInt(params.BlobTxBlobGasPerBlob)); rem.Sign() != 0 {
+		return fmt.Errorf("blobGasUsed not a multiple of %d in block %v (parent %x): have %v",
+			uint64(params.BlobTxBlobGasPerBlob), header.Number, parent.Hash(), header.BlobGasUsed)
 	}
 	var parentBlobGasUsed uint64
 	if parent.BlobGasUsed != nil {

--- a/scripts/check-camellia-headers.py
+++ b/scripts/check-camellia-headers.py
@@ -2,6 +2,11 @@
 # check-camellia-headers.py - verify a chain's post-Camellia headers against the
 # rule consensus/ethash/consensus.go enforces (verifyCamelliaHeaderFields).
 #
+# Covers all five checks that rule makes: withdrawalsHash pinned to the empty
+# root, excessBlobGas derived from the parent, parentBeaconRoot absent,
+# blobGasUsed within the per-block cap, and blobGasUsed a whole multiple of a
+# blob's gas. The last three were added for issue #134.
+#
 # Usage:
 #   python3 scripts/check-camellia-headers.py [RPC_URL] [START] [END]
 #   python3 scripts/check-camellia-headers.py http://localhost:8545 117764000
@@ -44,6 +49,13 @@ BATCH = 100
 # was invisible because a chain that has never carried a blob gives the same
 # answer for any target.
 TARGET_BLOB_GAS = 131072  # 1 * params.BlobTxBlobGasPerBlob
+# params.BlobTxBlobGasPerBlob and params.MaxBlobGasPerBlock (2 blobs). The cap
+# and the multiple are the two blobGasUsed rules added for issue #134: nothing
+# on the verify path capped the field, and core.ValidateBody compares it to the
+# body's blob count by dividing, which leaves up to PER_BLOB-1 of slack that
+# feeds the next block's excessBlobGas undivided.
+PER_BLOB = 131072
+MAX_BLOB_GAS = 2 * PER_BLOB
 # types.EmptyWithdrawalsHash. Metadium PoA has no withdrawals and
 # FinalizeAndAssemble pins the header to this value.
 EMPTY_WITHDRAWALS = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
@@ -108,10 +120,18 @@ def main():
                 continue
 
             withdrawals = block.get("withdrawalsRoot")
+            beacon_root = block.get("parentBeaconBlockRoot")
             excess = field(block, "excessBlobGas")
             used = field(block, "blobGasUsed")
             parent_excess = field(parent, "excessBlobGas") or 0
             parent_used = field(parent, "blobGasUsed") or 0
+
+            # Metadium has no beacon chain and the sealing path never sets this;
+            # core.ProcessBeaconBlockRoot acts on it whenever it is present.
+            if beacon_root is not None:
+                print(f"  {num}: parentBeaconBlockRoot {beacon_root}, want absent",
+                      flush=True)
+                violations += 1
 
             if withdrawals is None:
                 print(f"  {num}: missing withdrawalsRoot", flush=True)
@@ -128,6 +148,14 @@ def main():
                 print(f"  {num}: missing blobGasUsed", flush=True)
                 violations += 1
             else:
+                if used > MAX_BLOB_GAS:
+                    print(f"  {num}: blobGasUsed {used} over the per-block max {MAX_BLOB_GAS}",
+                          flush=True)
+                    violations += 1
+                if used % PER_BLOB:
+                    print(f"  {num}: blobGasUsed {used} is not a multiple of {PER_BLOB}",
+                          flush=True)
+                    violations += 1
                 want = calc_excess_blob_gas(parent_excess, parent_used)
                 if excess != want:
                     print(f"  {num}: excessBlobGas {excess}, want {want} "


### PR DESCRIPTION
## What this changes

Closes #134. `verifyCamelliaHeaderFields` pinned `withdrawalsHash` and
`excessBlobGas`; three fields in the same class were still unread. All three are
covered by the seal hash, so each was a signed header field with no rule
attached.

**`parentBeaconRoot` must be nil.** The pre-Camellia branch already pins it,
this branch did not. `core.ProcessBeaconBlockRoot` acts on the field whenever it
is set — the EIP-4788 system call, writing the ring-buffer contract's storage.
That is deterministic, so a producer setting it would have every node apply the
state change and agree on the result.

**`blobGasUsed` is capped at `MaxBlobGasPerBlock`.** The two-blob limit lived
only in the builder: `eip4844.VerifyEIP4844Header` is not called on the ethash
path, and `core.ValidateBody` only reconciles the header against the body's blob
count. Ten blobs verified, because header and body agreed with each other.

**`blobGasUsed` must be a whole multiple of `BlobTxBlobGasPerBlob`.** That body
check *divides*, so anything in `[blobs*perBlob, (blobs+1)*perBlob)` passes it,
while the parent's `blobGasUsed` feeds the child's `excessBlobGas` undivided.
The slack moves the blob fee market by up to `perBlob-1` per block and compounds,
and the `excessBlobGas` rule cannot catch it because it derives its expectation
*from* the inflated value.

`scripts/check-camellia-headers.py` (#131) learns the same three rules, so it now
mirrors all five checks the engine makes rather than two.

## Compatibility tier

- [x] **C1 — consensus, tightening.** Rejects headers the current release
      accepts.

**Why this tier:** external nodes are unaffected — they accept our blocks either
way — but a node running the rule stalls on a block that violates it, and the
only producers are our own BPs. **The blocks being produced today already
satisfy all three rules**, so verifiers roll one at a time like any other
release; the producers do not have to move first.

Evidence, in the order the tier definition asks for it:

- **The rule also applies to history, so the whole post-Camellia range was
  checked.** `scripts/check-camellia-headers.py` against mainnet,
  **117,764,000 → 118,447,863 (683,864 blocks): zero violations.**

  ```
  DONE checked=683864 violations=0 elapsed=733s
  ```

  The scan also printed **no `note:` lines**, which is the stronger half of the
  result: the script logs every block whose `blobGasUsed` is non-zero, and there
  were none in 683,864 blocks. So the two blob rules are not "violated nowhere"
  — the field is zero on the entire post-Camellia chain, and the paths they
  guard have never been exercised.
- **Why a header scan rather than a clean sync.** The rule is a pure function of
  `(header, parent)`, so reading every header in the range checks exactly what a
  sync would check *for this change*, in minutes instead of days. A clean sync
  additionally re-verifies execution, which is the right gate for a change to
  execution and not for this one. This is the same gate #131 was written for and
  the same argument accepted there.
- **Unreachable in practice, not merely unviolated.** No Metadium block has ever
  carried a blob, so both blob paths are untested by the chain rather than
  exercised-and-clean. `parentBeaconRoot` is nil on every block because the PoA
  sealing path never sets it — only the engine-API payload path does
  (`miner/worker.go`, via `genParams.beaconRoot`), which Metadium does not use.

## Rollout

Rides m1.1.4, whose rollout already carries the testnet-BP-first mixed-fleet
gate this tier requires: testnet block producers upgrade first with the rest of
the testnet left on m1.1.3, soak, then mainnet. Cutting this as a separate
release would run the same gate a second time for no additional coverage.

## Verification

- `go test ./consensus/ethash/ -run Camellia` — the existing table plus four new
  cases: `parentBeaconRoot` set is rejected; `blobGasUsed` at exactly
  `MaxBlobGasPerBlock` is accepted and one blob more is rejected; `2*perBlob-1`
  is rejected and one whole blob is accepted.
- **Mutation check.** Disabling all three new conditions fails exactly the three
  new negative cases and nothing else; restoring them returns the file to its
  committed hash. So the tests fail for the reason they claim to.
- **The script was shown to catch each rule before it was trusted**, against a
  mock RPC serving a three-block chain with one defect injected into the middle
  block:

  | injected | result |
  |---|---|
  | clean chain | `0 violations`, exit 0 |
  | `parentBeaconBlockRoot` set | caught, 1 violation |
  | `blobGasUsed` = 10 blobs | caught, plus the child's `excessBlobGas` mismatch it causes |
  | `blobGasUsed` = `2*perBlob-1` | caught, plus the child's expectation inflated to 131071 — the compounding described above, reproduced |

- `gofmt` clean, `go vet ./consensus/ethash/` clean, `CGO_ENABLED=0 go build`
  over `./consensus/... ./core/...`.
- Unit regression over `./consensus/... ./core/`: all green, including
  `core 141.577s` and `consensus/ethash`, `consensus/clique`,
  `consensus/misc/eip1559`, `consensus/misc/eip4844`.

## Note on the release notes

m1.1.4's notes currently say this release "pins two of those fields, not all
three" and point at #134 for the rest. If this merges, that paragraph goes back
to describing the header as verified.
