### PR TITLE
ci: check the PR body for the two fields the template requires

### DIFF
--- a/.github/scripts/check-pr-template.sh
+++ b/.github/scripts/check-pr-template.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Check a pull request body against the required fields in
+# .github/PULL_REQUEST_TEMPLATE.md (issue #113).
+#
+# The template makes the compatibility tier and the rollout gate required, and
+# nothing enforced that: CI never read the PR body, so a PR that omitted either
+# merged on reviewer diligence alone.
+#
+# What this checks is only whether the fields are *there*. Whether the ticked
+# tier is the right one, and whether the rollout plan is the right plan, stays a
+# reviewer's judgement -- no script can do that part.
+#
+#   usage: check-pr-template.sh <file containing the PR body>
+#
+# Run it on a body you are about to submit:
+#
+#   gh pr view <n> --json body --jq .body > /tmp/body.md
+#   .github/scripts/check-pr-template.sh /tmp/body.md
+
+set -uo pipefail
+
+if [[ $# -ne 1 ]]; then
+	echo "usage: $0 <pr-body-file>" >&2
+	exit 2
+fi
+
+body_file=$1
+if [[ ! -r $body_file ]]; then
+	echo "$0: cannot read $body_file" >&2
+	exit 2
+fi
+
+# Strip HTML comments before anything else: the template's own prompts live in
+# them, and a body that only kept those prompts has said nothing.
+body=$(perl -0777 -pe 's/<!--.*?-->//gs' "$body_file")
+
+fail=0
+problem() {
+	fail=1
+	echo "FAIL: $1"
+}
+
+# --- compatibility tier -----------------------------------------------------
+#
+# Exactly one "- [x] **C<n>" must be ticked. Zero means the field was skipped;
+# more than one means the PR has not decided what a node on the current release
+# sees, which is the whole point of picking a tier.
+
+ticked_tiers=$(printf '%s\n' "$body" |
+	grep -oiE '^[[:space:]]*-[[:space:]]*\[x\][[:space:]]*\*\*C[0-7]' |
+	grep -oE 'C[0-7]')
+tier_count=$(printf '%s' "$ticked_tiers" | grep -c . || true)
+
+tier=""
+case $tier_count in
+0)
+	problem "no compatibility tier is ticked. Tick exactly one '- [x] **C<n>' box under '## Compatibility tier'."
+	;;
+1)
+	tier=$ticked_tiers
+	echo "ok: compatibility tier $tier"
+	;;
+*)
+	problem "more than one compatibility tier is ticked ($(printf '%s' "$ticked_tiers" | tr '\n' ' ')). Pick exactly one."
+	;;
+esac
+
+# --- rollout ----------------------------------------------------------------
+#
+# The section is extracted up to the next level-2 heading. Lines that markdown
+# folds into the item above them (the template wraps every checkbox over several
+# indented lines) are joined back onto it, so "prose" below means a real
+# paragraph rather than the tail of an untouched template checkbox.
+
+rollout=$(printf '%s\n' "$body" | awk '
+	/^##[[:space:]]+Rollout([[:space:]]|$)/ { inside = 1; next }
+	/^##[[:space:]]/                        { inside = 0 }
+	inside                                  { print }
+')
+
+if ! printf '%s\n' "$body" | grep -qiE '^##[[:space:]]+Rollout([[:space:]]|$)'; then
+	problem "no '## Rollout' section. Say how this reaches the fleet, or that nothing deploys."
+else
+	unwrapped=$(printf '%s\n' "$rollout" | awk '
+		/^[[:space:]]+[^[:space:]]/ && NR > 1 && buf != "" { sub(/^[[:space:]]+/, " "); buf = buf $0; next }
+		{ if (buf != "") print buf; buf = $0 }
+		END { if (buf != "") print buf }
+	')
+
+	has_ticked=$(printf '%s\n' "$unwrapped" | grep -ciE '^[[:space:]]*-[[:space:]]*\[x\]' || true)
+	has_prose=$(printf '%s\n' "$unwrapped" |
+		grep -vE '^[[:space:]]*-[[:space:]]*\[[[:space:]xX]\]' |
+		grep -c '[^[:space:]]' || true)
+
+	if [[ $has_ticked -eq 0 && $has_prose -eq 0 ]]; then
+		problem "'## Rollout' is empty -- it carries only the template's unticked boxes. Tick what applies or write what happens."
+	else
+		echo "ok: rollout stated"
+
+		# C0-C3 are the tiers a node on the current release can feel, so the
+		# template requires the mixed-fleet gate for them: testnet BPs first,
+		# rest of the testnet left on the old build. Prose satisfies this --
+		# #136 said it in a sentence rather than a checkbox -- so the test is
+		# that the gate is named at all, not how.
+		case $tier in
+		C0 | C1 | C2 | C3)
+			if printf '%s' "$unwrapped" | grep -qi 'testnet' &&
+				printf '%s' "$unwrapped" | grep -qiE '\bBPs?\b|block producers?'; then
+				echo "ok: $tier rollout names the testnet-BP-first gate"
+			else
+				problem "tier $tier requires the testnet-BP-first gate in '## Rollout' (testnet block producers upgrade first, the rest of the testnet stays on the old build). It is not mentioned."
+			fi
+			;;
+		esac
+	fi
+fi
+
+if [[ $fail -ne 0 ]]; then
+	echo
+	echo "See .github/PULL_REQUEST_TEMPLATE.md. This check reads the PR body only;"
+	echo "edit the description and it runs again."
+	exit 1
+fi
+
+echo
+echo "PR template fields present."

--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -1,0 +1,36 @@
+name: pr-template
+
+# Enforces the two fields the PR template calls required -- the compatibility
+# tier and the rollout gate -- which until now nothing but reviewer diligence
+# checked (issue #113).
+#
+# This reads the pull request body out of the event payload. It builds nothing
+# and needs no checkout of the head code, so it finishes in seconds and cannot
+# be affected by what the PR changes. The body is passed to the script through
+# the environment, never interpolated into a shell line: a PR description is
+# attacker-controlled text.
+#
+# Advisory to begin with. Make it a required check on dev only after it has been
+# seen passing on a few PRs, so a false positive does not block a merge before
+# anyone has watched it run.
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  fields:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - name: Check the required template fields
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+          bash .github/scripts/check-pr-template.sh "$RUNNER_TEMP/pr-body.md"


### PR DESCRIPTION
## What this changes

The PR template (#97) marks the **Compatibility tier** and the **Rollout** gate
required, and nothing enforced either. CI never looked at the PR body, so a PR
that omitted the tier or the rollout gate merged on reviewer diligence alone.
That has held because two reviewers read every PR against the template, but the
point of writing the rule down was to stop depending on that — this is cp-khs's
non-blocking follow-up on #97, filed as issue #113.

A `pull_request` workflow (`opened`, `edited`, `synchronize`) reads the body out
of the event payload and fails when

- no `- [x] **C<n>` tier box is ticked, or more than one is;
- `## Rollout` is missing, or carries only the template's untouched boxes;
- a C0–C3 tier is ticked and the Rollout section does not name the
  testnet-BP-first gate those tiers require.

The logic is a standalone shell script so it can be run on a body before it is
submitted, which is also how it was tested:

```
gh pr view <n> --json body --jq .body > /tmp/body.md
.github/scripts/check-pr-template.sh /tmp/body.md
```

**Prose satisfies a field as well as a ticked box does.** That is not a
concession — it is how the template is actually used. #136 stated the mixed-fleet
gate in a sentence rather than ticking it, and #133 wrote "None. Documentation-only,
so the testnet-BP-first gate does not apply." A check that demanded the checkbox
would have failed both, and both were right. What the check catches is a field
that is *absent*; whether the ticked tier is the *correct* tier is a judgement no
script makes, and reviewers still make it.

## Sequencing

Issue #113 asked for this to land after the release-pipeline split, so the two
would not race on `.github/workflows/`. That split's workflow half is already on
`dev` (`bd335c253` collapsed the three amd64 pipelines, `c7be6b06d` pinned the
toolchain), and this adds one new file next to them rather than editing any.
The diff touches no file that any other open branch touches.

## Compatibility tier

- [x] **C7 — internal only.** A GitHub Actions workflow and a shell script under
      `.github/`. No Go file, no build input, no release artifact. `make release-check`
      output is byte-identical with or without it.

**Why this tier:** nothing here is compiled into `gmet` or packaged into a
release. A node on the current release cannot observe this change; it is visible
only to someone opening a pull request.

## Rollout

None — nothing deploys. The check affects pull requests, not nodes, so the
testnet-BP-first gate does not apply.

It is **advisory to begin with**: it is not listed as a required status check on
`dev`. Making it required is a branch-protection setting rather than anything in
this diff, and it should wait until the check has been seen passing on a few real
PRs, so a false positive cannot block a merge before anyone has watched it run.

## Verification

Ran against **9 merged PR bodies** — the ones written under the template — and
all 9 pass, including the two that use prose where the template has boxes:

| PR | tier | rollout form | result |
|---|---|---|---|
| #136 | C1 | prose naming the gate | pass |
| #132 | C6 | ticked box | pass |
| #133 | C7 | prose, "None." | pass |
| #131 #130 #129 #128 #127 #126 | C7/C6 | ticked box | pass |

And against cases that must fail, each one isolating a single rule:

| case | expected | result |
|---|---|---|
| template submitted unchanged | fail: no tier, empty rollout | ✅ both |
| C1 ticked, rollout left as the untouched boxes | fail: empty rollout | ✅ |
| C1 ticked, rollout prose without the gate (boxes deleted) | fail: gate not named | ✅ |
| C1 ticked, **template boxes intact** + unrelated prose | fail: gate not named | ✅ |
| C1 ticked, **template boxes intact**, only "Not applicable — nothing deploys" ticked | fail: gate not named | ✅ |
| C1 ticked, gate in prose | pass | ✅ |
| C1 ticked, gate via the template checkbox | pass | ✅ |
| two tiers ticked | fail: pick one | ✅ |
| tier ticked inside an HTML comment | fail: no tier | ✅ |
| empty body | fail: no tier, no rollout | ✅ |

The two rows in bold are trident90's, found in review and fixed in `4b5b3ed8f`. The gate check grepped the whole Rollout section, and the template's own first box spells out both words it looks for ("Testnet BPs first ... Upgrade only the testnet block producers"), so an untouched template satisfied the gate on wording its author never wrote. The row above them passed only because building that case deleted the boxes — which also deleted what was carrying the check. Unticked boxes are now dropped before the gate grep, the way the emptiness test already dropped them; a ticked gate box still passes, so prose and checkbox remain equally valid.

The HTML-comment case matters because the template's own prompts live in
comments; a body that kept only those has said nothing. CRLF bodies were tested
separately — the event payload uses `\r\n` where `gh --jq` hands back `\n` — and
both the passing and the failing cases behave identically.

- [x] Affected packages pass — no Go package is affected; `make lint` and the
      unit tests run unchanged in CI on this PR.
- [ ] Both engines build — not applicable, no Go change.
- [ ] SPoA private network run — not applicable, consensus untouched.
- [ ] Clean sync — not applicable.

**This PR is the check's own first live case.** For `pull_request` events the
workflow runs from the merge ref, so the `pr-template` check on this PR is
running the script this PR adds, against this body.

## Note on the body being untrusted

A PR description is attacker-controlled text, so it is passed to the script
through the environment and written to a file, never interpolated into a shell
line. The job declares `contents: read`, needs no secrets, and checks out only
`.github`.

